### PR TITLE
Brining in basic chart linting

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,0 +1,15 @@
+name: Tests
+
+on: 
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: d3adb5/helm-unittest-action@v2
+      - run: helm lint graylog

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Graylog Helm
+![Tests](https://github.com/graylog2/graylog-helm/actions/workflows/lint-and-test.yaml/badge.svg)
+
 Official helm chart for Graylog.
 
 ## Not For External Use


### PR DESCRIPTION
This brings in some basic chart linting for pull requests on `main`, and runs on `main` when it has been pushed to. Eventually we can expand this out to build a small kind cluster to validate changes, but this is a start to that.