### PR TITLE
docs: simplify ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,9 @@ This chart is still under development and does not have locked in api contracts 
 ## Table of Contents
 * [Requirements](#requirements)
 * [Installation](#installation)
-  * [Clone this repo](#clone-this-repo)
-  * [Install local chart](#install-local-chart)
 * [Post-installation](#post-installation)
   * [Set root Graylog password](#set-root-graylog-password)
   * [Set external access](#set-external-access)
-    * [LoadBalancer Service](#alternative-loadbalancer-service)
-    * [Port Forwarding](#temporary-access-port-forwarding)
 * [Usage](#usage)
   * [Scale Graylog](#scale-graylog)
   * [Scale DataNode](#scale-datanode)
@@ -26,17 +22,11 @@ This chart is still under development and does not have locked in api contracts 
   * [Customize deployed Kubernetes resources](#customize-deployed-kubernetes-resources)
   * [Add inputs](#add-inputs)
   * [Enable TLS](#enable-tls)
-    * [Bring Your Own Certificate](#bring-your-own-certificate)
 * [Uninstall](#uninstall)
   * [Removing everything](#removing-everything)
 * [Debugging](#debugging)
 * [Logging](#logging)
 * [Graylog Helm Chart Values Reference](#graylog-helm-chart-values-reference)
-  * [Global](#global)
-  * [Graylog application](#graylog-application)
-  * [DataNode](#datanode)
-  * [Service Account](#service-account)
-  * [Ingress](#ingress)
 
 ## Requirements
 - Kubernetes v1.32


### PR DESCRIPTION
By only allowing one nested level in the content index, except for the values reference section for which no nesting is allowed, we can simplify the ToC in `README.md`. This will reduce clutter, and besides GitHub users can always take a look at the [auto-generated ToC button](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/) for deeper levels.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

