### PR TITLE
Updating ingresses with the proper backend svc name generation

### DIFF
--- a/graylog/templates/service/ingress/graylog-forwarder.yaml
+++ b/graylog/templates/service/ingress/graylog-forwarder.yaml
@@ -35,7 +35,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: graylog-svc
+                name: {{ include "graylog.serviceName" $ }}
                 port:
                   name: input-forwarder
           {{- end }}

--- a/graylog/templates/service/ingress/graylog.yaml
+++ b/graylog/templates/service/ingress/graylog.yaml
@@ -35,7 +35,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: graylog-svc
+                name: {{ include "graylog.serviceName" $ }}
                 port:
                   number: {{ $.Values.graylog.custom.service.ports.app }}
           {{- end }}


### PR DESCRIPTION
Updating ingresses with the proper backend svc name generation.

This can be tested with a values value like.
```yaml
ingress:
  web:
    enabled: true
    hosts:
      - host: graylog-helm.example.com
        paths:
          - path: /
            pathType: Prefix
```
Then run the following.
```bash
helm template graylog/. -f graylog/some-values.yaml
```
The resulting backend service name should be `release-name-graylog-svc`.
