### PR TITLE
refactor values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ helm install graylog . --dry-run --debug --create-namespace -n graylog
 ### Installing chart
 
 ```bash
-helm install graylog . -n graylog --create-namespace -n graylog --set size="xs" --set graylog.custom.service.type="LoadBalancer"
+helm install graylog . -n graylog --create-namespace -n graylog --set size="xs" --set graylog.service.type="LoadBalancer"
 ```
 
 ### Upgrading chart

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Alternatively, external access can be configured directly through the provided s
 pre-existing dependencies.
 
 ```sh
-helm upgrade graylog ./graylog -n graylog --set graylog.custom.service.type="LoadBalancer" --reuse-values
+helm upgrade graylog ./graylog -n graylog --set graylog.service.type="LoadBalancer" --reuse-values
 ```
 
 ### Temporary access: Port Forwarding
@@ -204,10 +204,10 @@ helm upgrade graylog ./graylog -n graylog --set graylog.config.email.enabled=tru
 # A few examples: 
 
 # expose the Graylog application with a LoadBalancer service
-helm upgrade graylog ./graylog -n graylog --set graylog.custom.service.type="LoadBalancer" --reuse-values
+helm upgrade graylog ./graylog -n graylog --set graylog.service.type="LoadBalancer" --reuse-values
 
 # modify readiness probe initial delay
-helm upgrade graylog ./graylog -n graylog --set graylog.custom.readinessProbe.initialDelaySeconds=5 --reuse-values
+helm upgrade graylog ./graylog -n graylog --set graylog.readinessProbe.initialDelaySeconds=5 --reuse-values
 
 # use a custom Storage Class for all resources (e.g. for AWS EKS)
 helm upgrade graylog ./graylog -n graylog --set global.defaultStorageClass="gp2" --reuse-values
@@ -417,10 +417,13 @@ stern statefulset/graylog-datanode -n graylog-helm-dev-1
 ---
 
 # Graylog Helm Chart Values Reference
-| Key Path           | Description                                           | Default   |
-| ------------------ |-------------------------------------------------------| --------- |
-| `nameOverride`     | Override the `app.kubernetes.io/name` label value.    | `""`      |
-| `fullnameOverride` | Override the fully qualified name of the application. | `""`      |
+| Key Path           | Description                                                      | Default   |
+|--------------------|------------------------------------------------------------------| --------- |
+| `size`             | Preset cluster size (optional).                                  | `""`      |
+| `provider`         | Kubernetes provider (optional).                                  | `""`      |
+| `version`          | Override Graylog and Graylog Data Node version (optional).       | `""`      |
+| `nameOverride`     | Override the `app.kubernetes.io/name` label value (optional).    | `""`      |
+| `fullnameOverride` | Override the fully qualified name of the application (optional). | `""`      |
 
 ## Global
 These values affect Graylog, DataNode, and MongoDB
@@ -438,8 +441,14 @@ These values affect Graylog, DataNode, and MongoDB
 | `graylog.enabled`                                                     | Enable the Graylog server.                                 | `true`                          |
 | `graylog.enterprise`                                                  | Enable enterprise features.                                | `true`                          |
 | `graylog.replicas`                                                    | Number of Graylog server replicas.                         | `2`                             |
+| `graylog.service.nameOverride`                                        | Override for service name.                                 | `""`                            |
+| `graylog.service.type`                                                | Kubernetes service type.                                   | `ClusterIP`                     |
+| `graylog.service.ports.app`                                           | Graylog web UI port.                                       | `9000`                          |
+| `graylog.service.ports.metrics`                                       | Metrics endpoint port.                                     | `9833`                          |
+| `graylog.service.metrics.enabled`                                     | Enable metrics collection.                                 | `true`                          |
 | `graylog.inputs`                                                      | List of inputs to configure.                               | See below                       |
 | `graylog.plugins`                                                     | List of plugins to configure.                              | See below                       |
+| `graylog.env`                                                         | Custom environment variables                               | `[]`                            |
 | `graylog.config.rootUsername`                                         | Root admin username.                                       | `"admin"`                       |
 | `graylog.config.rootPassword`                                         | Root admin password.                                       | `""`                            |
 | `graylog.config.timezone`                                             | Timezone for the Graylog server.                           | `"UTC"`                         |
@@ -503,23 +512,50 @@ These values affect Graylog, DataNode, and MongoDB
 | `graylog.config.init.assetFetch.plugins.baseUrl`                      | Base URL for plugin assets.                                | `""`                            |
 | `graylog.config.init.geolocation.enabled`                             | Enable geolocation asset fetch.                            | `"false"`                       |
 | `graylog.config.init.geolocation.baseUrl`                             | Base URL for geolocation assets.                           | `""`                            |
-| `graylog.custom.podAnnotations`                                       | Additional pod annotations.                                | `{}`                            |
-| `graylog.custom.nodeSelector`                                         | Node selector for scheduling.                              | `{}`                            |
-| `graylog.custom.env`                                                  | Custom environment variables                               | `[]`                            |
-| `graylog.custom.extraEnv`                                             | Custom EnvVar environment variables                        | `[]`                            |
-| `graylog.custom.inputs.enabled`                                       | Enable Graylog inputs.                                     | `true`                          |
-| `graylog.custom.metrics.enabled`                                      | Enable metrics collection.                                 | `true`                          |
-| `graylog.custom.image.repository`                                     | Image repository for Graylog.                              | `""`                            |
-| `graylog.custom.image.tag`                                            | Image tag for Graylog.                                     | `""`                            |
-| `graylog.custom.image.imagePullPolicy`                                | Pull policy for Graylog image.                             | `IfNotPresent`                  |
-| `graylog.custom.image.imagePullSecrets`                               | Pull secrets for image.                                    | `[]`                            |
-| `graylog.custom.updateStrategy.type`                                  | Pod update strategy for StatefulSet.                       | `"RollingUpdate"`               |
-| `graylog.custom.updateStrategy.rollingUpdate.maxUnavailable`          | Max unavailable pods during an update.                     | `1`                             |
-| `graylog.custom.updateStrategy.rollingUpdate.partition`               | Pods that will remain unaffected by the update.            | `""`                            |
-| `graylog.custom.service.nameOverride`                                 | Override for service name.                                 | `""`                            |
-| `graylog.custom.service.type`                                         | Kubernetes service type.                                   | `ClusterIP`                     |
-| `graylog.custom.service.ports.app`                                    | Graylog web UI port.                                       | `9000`                          |
-| `graylog.custom.service.ports.metrics`                                | Metrics endpoint port.                                     | `9833`                          |
+| `graylog.image.repository`                                            | Image repository for Graylog.                              | `""`                            |
+| `graylog.image.tag`                                                   | Image tag for Graylog.                                     | `""`                            |
+| `graylog.image.imagePullPolicy`                                       | Pull policy for Graylog image.                             | `IfNotPresent`                  |
+| `graylog.image.imagePullSecrets`                                      | Pull secrets for image.                                    | `[]`                            |
+| `graylog.updateStrategy.type`                                         | Pod update strategy for StatefulSet.                       | `"RollingUpdate"`               |
+| `graylog.updateStrategy.rollingUpdate.maxUnavailable`                 | Max unavailable pods during an update.                     | `1`                             |
+| `graylog.updateStrategy.rollingUpdate.partition`                      | Pods that will remain unaffected by the update.            | `""`                            |
+| `graylog.resources.limits.cpu`                                        | CPU limit for the Graylog pod.                             | `"2"`                           |
+| `graylog.resources.limits.memory`                                     | Memory limit for the Graylog pod.                          | `"2Gi"`                         |
+| `graylog.resources.requests.cpu`                                      | CPU request for the Graylog pod.                           | `"1"`                           |
+| `graylog.resources.requests.memory`                                   | Memory request for the Graylog pod.                        | `"1Gi"`                         |
+| `graylog.persistence.enabled`                                         | Enable persistent storage.                                 | `true`                          |
+| `graylog.persistence.storageClass`                                    | Storage class for the persistent volume.                   | `""`                            |
+| `graylog.persistence.volumeNameOverride`                              | Override name of the persistent volume.                    | `""`                            |
+| `graylog.persistence.existingClaim`                                   | Use an existing PVC.                                       | `""`                            |
+| `graylog.persistence.mountPath`                                       | Path where volume will be mounted.                         | `""`                            |
+| `graylog.persistence.accessModes`                                     | Access modes for the persistent volume.                    | `[]`                            |
+| `graylog.persistence.size`                                            | Size of the persistent volume.                             | `""`                            |
+| `graylog.persistence.annotations`                                     | Annotations for the persistent volume claim.               | `{}`                            |
+| `graylog.persistence.labels`                                          | Labels for the persistent volume claim.                    | `{}`                            |
+| `graylog.persistence.selector`                                        | Selector for the persistent volume.                        | `{}`                            |
+| `graylog.livenessProbe.enabled`                                       | Enable liveness probe.                                     | `true`                          |
+| `graylog.livenessProbe.initialDelaySeconds`                           | Initial delay for liveness probe.                          | `60`                            |
+| `graylog.livenessProbe.periodSeconds`                                 | Period between liveness probe checks.                      | `10`                            |
+| `graylog.livenessProbe.timeoutSeconds`                                | Timeout for the liveness probe.                            | `5`                             |
+| `graylog.livenessProbe.failureThreshold`                              | Failure threshold for the liveness probe.                  | `6`                             |
+| `graylog.livenessProbe.successThreshold`                              | Success threshold for the liveness probe.                  | `1`                             |
+| `graylog.readinessProbe.enabled`                                      | Enable readiness probe.                                    | `true`                          |
+| `graylog.readinessProbe.initialDelaySeconds`                          | Initial delay for readiness probe.                         | `30`                            |
+| `graylog.readinessProbe.periodSeconds`                                | Period between readiness probe checks.                     | `10`                            |
+| `graylog.readinessProbe.timeoutSeconds`                               | Timeout for the readiness probe.                           | `5`                             |
+| `graylog.readinessProbe.failureThreshold`                             | Failure threshold for the readiness probe.                 | `6`                             |
+| `graylog.readinessProbe.successThreshold`                             | Success threshold for the readiness probe.                 | `1`                             |
+| `graylog.podDisruptionBudget.enabled`                                 | Enable PodDisruptionBudget.                                | `false`                         |
+| `graylog.podDisruptionBudget.minAvailable`                            | Minimum available pods during disruption.                  | `1`                             |
+| `graylog.podAnnotations`                                              | Additional pod annotations.                                | `{}`                            |
+| `graylog.nodeSelector`                                                | Node selector for scheduling.                              | `{}`                            |
+| `graylog.tolerations`                                                 | Tolerations for scheduling.                                | `{}`                            |
+| `graylog.affinity`                                                    | Affinity rules for scheduling.                             | `{}`                            |
+| `graylog.extraEnv`                                                    | Custom EnvVar environment variables.                       | `[]`                            |
+| `graylog.podAnnotations`                                              | Additional pod annotations.                                | `{}`                            |
+| `graylog.nodeSelector`                                                | Node selector for scheduling.                              | `{}`                            |
+| `graylog.extraEnv`                                                    | Custom EnvVar environment variables                        | `[]`                            |
+
 
 ### Graylog inputs
 | Key Path                       | Description                       | Example            |
@@ -539,33 +575,81 @@ These values affect Graylog, DataNode, and MongoDB
 | `graylog.plugins[i].checksum`      | Checksum of JAR file.                  | `13550350a8681c84c861aac2e5b440161c2b33a3e4f302ac680ca5b686de48de` |
 
 ### Graylog environment variables
-| Key Path                | Descriptions                                                                                                                                                                                   | Example                                                                                                                                                          |
-|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `graylog.custom.env`    | Simple key/value environment variables                                                                                                                                                         | `["FOO=BAR", "HELLO=123"]`                                                                                                                                       |
-| `graylog.custom.EnvVar` | [EnvVar spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)-compliant environment variables<br/>(valueFrom, configMaps, secrets, etc.) | <pre><code>extraEnv:<br/>  - name: MADE_UP_PASSWORD<br/>    valueFrom:<br/>      secretKeyRef:<br/>        name: mysecret<br/>        key: password</code></pre> |
+| Key Path           | Descriptions                                                                                                                                                                                   | Example                                                                                                                                                          |
+|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `graylog.env`      | Simple key/value environment variables                                                                                                                                                         | `["FOO=BAR", "HELLO=123"]`                                                                                                                                       |
+| `graylog.extraEnv` | [EnvVar spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)-compliant environment variables<br/>(valueFrom, configMaps, secrets, etc.) | <pre><code>extraEnv:<br/>  - name: MADE_UP_PASSWORD<br/>    valueFrom:<br/>      secretKeyRef:<br/>        name: mysecret<br/>        key: password</code></pre> |
 
 ## Datanode
-| Key Path                                                      | Description                                     | Default           |
-|---------------------------------------------------------------|-------------------------------------------------|-------------------|
-| `datanode.enabled`                                            | Enable Graylog datanode.                        | `true`            |
-| `datanode.replicas`                                           | Number of datanode replicas.                    | `3`               |
-| `datanode.config.nodeIdFile`                                  | Path to datanode ID file.                       | `""`              |
-| `datanode.config.opensearchHeap`                              | OpenSearch heap size.                           | `"2g"`            |
-| `datanode.config.javaOpts`                                    | Java options for datanode.                      | `"-Xms1g -Xmx1g"` |
-| `datanode.config.skipPreflightChecks`                         | Skip startup checks.                            | `"false"`         |
-| `datanode.config.nodeSearchCacheSize`                         | Size of search cache.                           | `"10gb"`          |
-| `datanode.custom.podAnnotations`                              | Additional pod annotations.                     | `{}`              |
-| `datanode.custom.nodeSelector`                                | Node selector for datanode.                     | `{}`              |
-| `datanode.custom.image.repository`                            | Datanode image repository.                      | `""`              |
-| `datanode.custom.image.tag`                                   | Datanode image tag.                             | `""`              |
-| `datanode.custom.image.imagePullPolicy`                       | Image pull policy.                              | `IfNotPresent`    |
-| `datanode.custom.image.imagePullSecrets`                      | Image pull secrets.                             | `[]`              |
-| `datanode.custom.updateStrategy.type`                         | Pod update strategy for StatefulSet.            | `"RollingUpdate"` |
-| `datanode.custom.updateStrategy.rollingUpdate.maxUnavailable` | Max unavailable pods during an update.          | `1`               |
-| `datanode.custom.updateStrategy.rollingUpdate.partition`      | Pods that will remain unaffected by the update. | `""`              |
-| `datanode.custom.service.ports.api`                           | API communication port.                         | `8999`            |
-| `datanode.custom.service.ports.data`                          | Data communication port.                        | `9200`            |
-| `datanode.custom.service.ports.config`                        | Configuration communication port.               | `9300`            |
+| Key Path                                               | Description                                     | Default           |
+|--------------------------------------------------------|-------------------------------------------------|-------------------|
+| `datanode.enabled`                                     | Enable Graylog datanode.                        | `true`            |
+| `datanode.replicas`                                    | Number of datanode replicas.                    | `3`               |
+| `datanode.service.ports.api`                           | API communication port.                         | `8999`            |
+| `datanode.service.ports.data`                          | Data communication port.                        | `9200`            |
+| `datanode.service.ports.config`                        | Configuration communication port.               | `9300`            |
+| `datanode.env`                                         | Custom environment variables                    | `[]`              |
+| `datanode.config.nodeIdFile`                           | Path to datanode ID file.                       | `""`              |
+| `datanode.config.opensearchHeap`                       | OpenSearch heap size.                           | `"2g"`            |
+| `datanode.config.javaOpts`                             | Java options for datanode.                      | `"-Xms1g -Xmx1g"` |
+| `datanode.config.skipPreflightChecks`                  | Skip startup checks.                            | `"false"`         |
+| `datanode.config.nodeSearchCacheSize`                  | Size of search cache.                           | `"10gb"`          |
+| `datanode.config.s3ClientDefaultSecretKey`             | Default S3 client secret key.                   | `""`              |
+| `datanode.config.s3ClientDefaultAccessKey`             | Default S3 client access key.                   | `""`              |
+| `datanode.config.s3ClientDefaultEndpoint`              | Default S3 client endpoint.                     | `""`              |
+| `datanode.config.s3ClientDefaultRegion`                | Default S3 client region.                       | `"us-east-2"`     |
+| `datanode.config.s3ClientDefaultProtocol`              | Default S3 client protocol.                     | `"http"`          |
+| `datanode.config.s3ClientDefaultPathStyleAccess`       | Enable path-style access for S3 client.         | `"true"`          |
+| `datanode.image.repository`                            | Datanode image repository.                      | `""`              |
+| `datanode.image.tag`                                   | Datanode image tag.                             | `""`              |
+| `datanode.image.imagePullPolicy`                       | Image pull policy.                              | `IfNotPresent`    |
+| `datanode.image.imagePullSecrets`                      | Image pull secrets.                             | `[]`              |
+| `datanode.updateStrategy.type`                         | Pod update strategy for StatefulSet.            | `"RollingUpdate"` |
+| `datanode.updateStrategy.rollingUpdate.maxUnavailable` | Max unavailable pods during an update.          | `1`               |
+| `datanode.updateStrategy.rollingUpdate.partition`      | Pods that will remain unaffected by the update. | `""`              |
+| `datanode.resources.limits.cpu`                        | CPU limit for the datanode pod.                 | `"1"`             |
+| `datanode.resources.limits.memory`                     | Memory limit for the datanode pod.              | `"5Gi"`           |
+| `datanode.resources.requests.cpu`                      | CPU request for the datanode pod.               | `"500m"`          |
+| `datanode.resources.requests.memory`                   | Memory request for the datanode pod.            | `"3.5Gi"`         |
+| `datanode.persistence.enabled`                         | Enable persistence.                             | `true`            |
+| `datanode.persistence.data.enabled`                    | Enable persistent volume for data.              | `true`            |
+| `datanode.persistence.data.storageClass`               | Storage class for data PVC.                     | `""`              |
+| `datanode.persistence.data.existingClaim`              | Use existing PVC for data.                      | `""`              |
+| `datanode.persistence.data.mountPath`                  | Mount path for data volume.                     | `""`              |
+| `datanode.persistence.data.accessModes`                | Access modes for data PVC.                      | `[]`              |
+| `datanode.persistence.data.size`                       | Size of the data volume.                        | `"8Gi"`           |
+| `datanode.persistence.data.annotations`                | Annotations for data PVC.                       | `{}`              |
+| `datanode.persistence.data.labels`                     | Labels for data PVC.                            | `{}`              |
+| `datanode.persistence.data.selector`                   | Selector for data PVC.                          | `{}`              |
+| `datanode.persistence.data.dataSource`                 | Data source for data PVC.                       | `{}`              |
+| `datanode.persistence.nativeLibs.enabled`              | Enable persistence for native libraries.        | `false`           |
+| `datanode.persistence.nativeLibs.storageClass`         | Storage class for native libs PVC.              | `""`              |
+| `datanode.persistence.nativeLibs.existingClaim`        | Use existing PVC for native libs.               | `""`              |
+| `datanode.persistence.nativeLibs.mountPath`            | Mount path for native libs volume.              | `""`              |
+| `datanode.persistence.nativeLibs.accessModes`          | Access modes for native libs PVC.               | `[]`              |
+| `datanode.persistence.nativeLibs.size`                 | Size of the native libs volume.                 | `"2Gi"`           |
+| `datanode.persistence.nativeLibs.annotations`          | Annotations for native libs PVC.                | `{}`              |
+| `datanode.persistence.nativeLibs.labels`               | Labels for native libs PVC.                     | `{}`              |
+| `datanode.persistence.nativeLibs.selector`             | Selector for native libs PVC.                   | `{}`              |
+| `datanode.livenessProbe.enabled`                       | Enable liveness probe.                          | `true`            |
+| `datanode.livenessProbe.initialDelaySeconds`           | Initial delay for liveness probe.               | `30`              |
+| `datanode.livenessProbe.periodSeconds`                 | Period between liveness probe checks.           | `10`              |
+| `datanode.livenessProbe.timeoutSeconds`                | Timeout for the liveness probe.                 | `5`               |
+| `datanode.livenessProbe.failureThreshold`              | Failure threshold for the liveness probe.       | `6`               |
+| `datanode.livenessProbe.successThreshold`              | Success threshold for the liveness probe.       | `1`               |
+| `datanode.readinessProbe.enabled`                      | Enable readiness probe.                         | `true`            |
+| `datanode.readinessProbe.initialDelaySeconds`          | Initial delay for readiness probe.              | `10`              |
+| `datanode.readinessProbe.periodSeconds`                | Period between readiness probe checks.          | `10`              |
+| `datanode.readinessProbe.timeoutSeconds`               | Timeout for the readiness probe.                | `5`               |
+| `datanode.readinessProbe.failureThreshold`             | Failure threshold for the readiness probe.      | `6`               |
+| `datanode.readinessProbe.successThreshold`             | Success threshold for the readiness probe.      | `1`               |
+| `datanode.podDisruptionBudget.enabled`                 | Enable PodDisruptionBudget.                     | `false`           |
+| `datanode.podDisruptionBudget.minAvailable`            | Minimum available pods during disruption.       | `2`               |
+| `datanode.podAnnotations`                              | Additional pod annotations.                     | `{}`              |
+| `datanode.nodeSelector`                                | Node selector for scheduling datanode pods.     | `{}`              |
+| `datanode.tolerations`                                 | Tolerations for scheduling.                     | `{}`              |
+| `datanode.affinity`                                    | Affinity rules for scheduling.                  | `{}`              |
+| `datanode.extraEnv`                                    | Custom EnvVar environment variables.            | `[]`              |
 
 
 ## Service Account

--- a/graylog/templates/NOTES.txt
+++ b/graylog/templates/NOTES.txt
@@ -2,7 +2,7 @@ Welcome to Graylog!
 
 · Your helm release is named: {{ .Release.Name | quote }}.
 
-· You are running Graylog version {{ include "graylog.imageTag" . | quote | trimAll "\"" }}
+· You are running Graylog version {{ include "graylog.tag" . | quote | trimAll "\"" }}
 
 · Your credentials are
   {{- if empty .Values.global.existingSecretName }}:
@@ -16,7 +16,7 @@ Welcome to Graylog!
 · The following workloads have been deployed to the cluster:
 
   - {{ include "graylog.replicas" . | int }} replicas of the Graylog application.
-  - {{ include "datanode.replicas" . | int }} replicas of the Graylog Datanode.
+  - {{ include "graylog.datanode.replicas" . | int }} replicas of the Graylog Datanode.
   {{- if .Values.mongodb.subchart.enabled }}
   - {{ if eq .Values.mongodb.architecture "replicaset" }}{{ .Values.mongodb.replicaCount }} replicas{{ if .Values.mongodb.arbiter.enabled }} (+ 1 arbiter){{ end }} for MongoDB, running as a replicaset in Primary-Secondary{{if .Values.mongodb.arbiter.enabled }}-Arbiter{{ end }} mode.
     {{- else }}1 replica for MongoDB running in standalone mode.
@@ -27,11 +27,11 @@ Welcome to Graylog!
 
     helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}
 
-{{- if eq .Values.graylog.custom.service.type "LoadBalancer" }}
+{{- if eq .Values.graylog.service.type "LoadBalancer" }}
 
 · Get the URL of the UI for your Graylog instance by running the following command:
 
-    echo {{ .Values.graylog.config.tls.enabled | ternary "https" "http" }}://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "graylog.serviceName" . }} --template "{{"{{ with (index .status.loadBalancer.ingress 0) }}{{ or .hostname .ip }}{{ end }}"}}"):{{ .Values.graylog.custom.service.ports.app | default 9000 | int }}/
+    echo {{ .Values.graylog.config.tls.enabled | ternary "https" "http" }}://$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "graylog.service.name" . }} --template "{{"{{ with (index .status.loadBalancer.ingress 0) }}{{ or .hostname .ip }}{{ end }}"}}"):{{ .Values.graylog.service.ports.app | default 9000 | int }}/
 
 {{- if .Release.IsInstall }}
 
@@ -40,10 +40,10 @@ Welcome to Graylog!
     2. All workloads are ready before opening the URL in your browser (~5 min).
 {{- end }}
 {{- end }}
-{{- if len .Values.graylog.inputs | lt 0 | and .Values.graylog.custom.inputs.enabled }}
+{{- with .Values.graylog.inputs }}
 
 · The following INPUTS are set with their corresponding service:
-{{ range .Values.graylog.inputs }}
+{{ range . }}
     - name: {{ .name }}
       port: {{ .port | int }}
       protocol: {{ .protocol }}

--- a/graylog/templates/config/datanode.yaml
+++ b/graylog/templates/config/datanode.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "graylog.datanode.configmapName" . }}
+  name: {{ include "graylog.datanode.configmap.name" . }}
 data:
   JAVA_OPTS: {{ .Values.datanode.config.javaOpts | quote }}
   GRAYLOG_DATANODE_NODE_ID_FILE: {{ .Values.datanode.config.nodeIdFile | default "/var/lib/graylog-datanode/node-id" | quote }}

--- a/graylog/templates/config/fallback.yaml
+++ b/graylog/templates/config/fallback.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "fallback.name" . | printf "%s-config" }}
+  name: {{ include "graylog.fallback.name" . | printf "%s-config" }}
 data:
   httpd.conf: |
     H:/var/www/html
@@ -12,7 +12,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "fallback.name" . | printf "%s-content" }}
+  name: {{ include "graylog.fallback.name" . | printf "%s-content" }}
 data:
   healthz: "ok"
   livez: "ok"

--- a/graylog/templates/config/graylog.yaml
+++ b/graylog/templates/config/graylog.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "graylog.configmapName" . }}
+  name: {{ include "graylog.configmap.name" . }}
 data:
-  GRAYLOG_PROMETHEUS_EXPORTER_ENABLED: {{ .Values.graylog.custom.metrics.enabled | ternary true false | quote }}
+  GRAYLOG_PROMETHEUS_EXPORTER_ENABLED: {{ .Values.graylog.service.metrics.enabled | ternary true false | quote }}
   GRAYLOG_SELFSIGNED_STARTUP: {{ .Values.graylog.config.selfSignedStartup | default true | quote }}
   GRAYLOG_IS_CLOUD: {{ .Values.graylog.config.isCloud | default false | quote }}
   GRAYLOG_SERVER_JAVA_OPTS: {{ include "graylog.javaOpts" . | quote }}

--- a/graylog/templates/config/init-graylog.yaml
+++ b/graylog/templates/config/init-graylog.yaml
@@ -15,7 +15,7 @@ data:
     fi
     {{ if and .Values.graylog.config.tls.enabled }}
     # check that the FDQN for all Graylog nodes is part of the certificate SANs
-    {{- $fqdn := printf "%s.%s.svc.cluster.local" (include "graylog.serviceName" .) .Release.Namespace }}
+    {{- $fqdn := printf "%s.%s.svc.cluster.local" (include "graylog.service.name" .) .Release.Namespace }}
     if ! openssl x509 -in "/mnt/tls/tls.crt" -noout -checkhost {{ printf "test.%s" $fqdn | squote }}; then
       echo "The provided certificate does not match the Graylog pod FQDN."
       echo "Please, make sure to include {{ printf "DNS:*.%s" $fqdn | quote }} as another SAN in your certificate request."

--- a/graylog/templates/custom/issuer.yaml
+++ b/graylog/templates/custom/issuer.yaml
@@ -1,8 +1,8 @@
-{{- if not .Values.graylog.config.tls.enabled | and (include "cert-manager.issuer.exists.any" . | eq "false") .Values.ingress.enabled .Values.ingress.config.tls.issuer.autoissue.enabled }}
+{{- if not .Values.graylog.config.tls.enabled | and (include "graylog.cert-manager.issuer.exists.any" . | eq "false") .Values.ingress.enabled .Values.ingress.config.tls.issuer.autoissue.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "cert-manager.issuer.name" . }}
+  name: {{ include "graylog.cert-manager.issuer.name" . }}
 spec:
   acme:
     server: {{ .Values.ingress.config.tls.issuer.autoissue.staging | ternary "-staging" "" | printf "https://acme%s-v02.api.letsencrypt.org/directory" }}
@@ -11,7 +11,7 @@ spec:
     solvers:
       - http01:
           ingress:
-            name: {{ include "ingress.web.name" . }}
+            name: {{ include "graylog.ingress.web.name" . }}
             {{- with .Values.tolerations }}
             podTemplate:
               spec:

--- a/graylog/templates/policy/pdb/datanode.yaml
+++ b/graylog/templates/policy/pdb/datanode.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.datanode.custom.podDisruptionBudget.enabled }}
-{{- if include "datanode.replicas" . | int | lt 1 }}
+{{- if .Values.datanode.podDisruptionBudget.enabled }}
+{{- if include "graylog.datanode.replicas" . | int | lt 1 }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -9,7 +9,7 @@ metadata:
     app: graylog-datanode
     {{- include "graylog.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.datanode.custom.podDisruptionBudget.minAvailable | default 3 | int }}
+  minAvailable: {{ .Values.datanode.podDisruptionBudget.minAvailable | default 3 | int }}
   selector:
     matchLabels:
       app: graylog-datanode

--- a/graylog/templates/policy/pdb/graylog.yaml
+++ b/graylog/templates/policy/pdb/graylog.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.graylog.enabled .Values.graylog.custom.podDisruptionBudget.enabled }}
+{{- if and .Values.graylog.enabled .Values.graylog.podDisruptionBudget.enabled }}
 {{- if include "graylog.replicas" . | int | lt 2 }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -9,7 +9,7 @@ metadata:
     app: graylog-app
     {{- include "graylog.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.graylog.custom.podDisruptionBudget.minAvailable | default 1 | int }}
+  minAvailable: {{ .Values.graylog.podDisruptionBudget.minAvailable | default 1 | int }}
   selector:
     matchLabels:
       app: graylog-app

--- a/graylog/templates/service/datanode.yaml
+++ b/graylog/templates/service/datanode.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "graylog.datanode.serviceName" . }}
+  name: {{ include "graylog.datanode.service.name" . }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
     app.kubernetes.io/app-name: graylog-datanode
@@ -10,11 +10,11 @@ spec:
   clusterIP: None
   ports:
     - name: api
-      port: {{ .Values.datanode.custom.service.ports.api | default 8999 | int }}
+      port: {{ .Values.datanode.service.ports.api | default 8999 | int }}
     - name: data
-      port: {{ .Values.datanode.custom.service.ports.data | default 9200 | int }}
+      port: {{ .Values.datanode.service.ports.data | default 9200 | int }}
     - name: config
-      port: {{ .Values.datanode.custom.service.ports.config | default 9300 |int }}
+      port: {{ .Values.datanode.service.ports.config | default 9300 |int }}
   selector:
     app: graylog-datanode
 {{end}}

--- a/graylog/templates/service/fallback.yaml
+++ b/graylog/templates/service/fallback.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "fallback.name" . }}
+  name: {{ include "graylog.fallback.name" . }}
 spec:
   selector:
-    graylog-app: {{ include "fallback.name" . }}
+    graylog-app: {{ include "graylog.fallback.name" . }}
   ports:
     - port: 80
       targetPort: 3000

--- a/graylog/templates/service/graylog.yaml
+++ b/graylog/templates/service/graylog.yaml
@@ -2,19 +2,19 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "graylog.serviceName" . }}
+  name: {{ include "graylog.service.name" . }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.graylog.custom.service.type | default "ClusterIP" }}
+  type: {{ .Values.graylog.service.type | default "ClusterIP" }}
   ports:
     - name: app
       port: {{ include "graylog.service.port.app" . }}
       targetPort: app
       protocol: TCP
-    {{- if .Values.graylog.custom.metrics.enabled }}
+    {{- if .Values.graylog.service.metrics.enabled }}
     - name: metrics
-      port: {{ .Values.graylog.custom.service.ports.metrics | default 9833 | int }}
+      port: {{ .Values.graylog.service.ports.metrics | default 9833 | int }}
       targetPort: metrics
       protocol: TCP
     {{- end }}

--- a/graylog/templates/service/ingress/graylog-forwarder.yaml
+++ b/graylog/templates/service/ingress/graylog-forwarder.yaml
@@ -35,7 +35,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "graylog.serviceName" $ }}
+                name: {{ include "graylog.service.name" $ }}
                 port:
                   name: input-forwarder
           {{- end }}

--- a/graylog/templates/service/ingress/graylog.yaml
+++ b/graylog/templates/service/ingress/graylog.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "ingress.web.name" . }}
+  name: {{ include "graylog.ingress.web.name" . }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:
@@ -11,11 +11,11 @@ metadata:
     {{- if $clusterissuer }}
     cert-manager.io/cluster-issuer: {{ $clusterissuer }}
     {{- else }}
-    cert-manager.io/issuer: {{ include "cert-manager.issuer.name" . | coalesce .Values.ingress.config.tls.issuer.existingName }}
+    cert-manager.io/issuer: {{ include "graylog.cert-manager.issuer.name" . | coalesce .Values.ingress.config.tls.issuer.existingName }}
     {{- end }}
   {{- end }}
   {{- if eq .Values.ingress.web.className "nginx" | and .Values.ingress.config.defaultBackend.enabled }}
-    nginx.ingress.kubernetes.io/default-backend: {{ include "fallback.name" . }}
+    nginx.ingress.kubernetes.io/default-backend: {{ include "graylog.fallback.name" . }}
   {{- end }}
   {{- with .Values.ingress.web.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -24,7 +24,7 @@ spec:
   {{- if .Values.ingress.config.defaultBackend.enabled }}
   defaultBackend:
     service:
-      name: {{ include "fallback.name" . }}
+      name: {{ include "graylog.fallback.name" . }}
       port:
         number: 3000
   {{- end }}
@@ -51,9 +51,9 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ include "graylog.serviceName" $ }}
+                name: {{ include "graylog.service.name" $ }}
                 port:
-                  number: {{ $.Values.graylog.custom.service.ports.app }}
+                  number: {{ $.Values.graylog.service.ports.app }}
           {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
@@ -62,9 +62,9 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "graylog.serviceName" $ }}
+                name: {{ include "graylog.service.name" $ }}
                 port:
-                  number: {{ $.Values.graylog.custom.service.ports.app }}
+                  number: {{ $.Values.graylog.service.ports.app }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/graylog/templates/workload/cronjobs/geoip.yaml
+++ b/graylog/templates/workload/cronjobs/geoip.yaml
@@ -12,7 +12,7 @@ data:
   GEOIPUPDATE_ACCOUNT_ID: {{ .Values.graylog.config.geolocation.maxmindGeoIp.accountId | int | quote | trimAll "\"" | b64enc }}
   GEOIPUPDATE_LICENSE_KEY: {{ .Values.graylog.config.geolocation.maxmindGeoIp.licenseKey | quote | trimAll "\"" | b64enc }}
 {{- $cronJobName := include "graylog.fullname" . | printf "%s-geoip-update" }}
-{{- $claimName := printf "%s-%s" (include "graylog.volumeName" .) (include "graylog.fullname" .) }}
+{{- $claimName := printf "%s-%s" (include "graylog.volume.name" .) (include "graylog.fullname" .) }}
 {{- $cronSchedule := .Values.graylog.config.geolocation.maxmindGeoIp.cronSchedule | default "0 0 * * *" }}
 {{- $hookIsEnabled := .Values.graylog.config.geolocation.maxmindGeoIp.postInstallRun | default true }}
 {{- range $i := include "graylog.replicas" . | default 2 | int | until }}

--- a/graylog/templates/workload/fallback.yaml
+++ b/graylog/templates/workload/fallback.yaml
@@ -2,16 +2,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "fallback.name" . }}
+  name: {{ include "graylog.fallback.name" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      graylog-app: {{ include "fallback.name" . }}
+      graylog-app: {{ include "graylog.fallback.name" . }}
   template:
     metadata:
       labels:
-        graylog-app: {{ include "fallback.name" . }}
+        graylog-app: {{ include "graylog.fallback.name" . }}
     spec:
       containers:
         - name: busybox
@@ -38,8 +38,8 @@ spec:
       volumes:
         - name: content
           configMap:
-            name: {{ include "fallback.name" . | printf "%s-content" }}
+            name: {{ include "graylog.fallback.name" . | printf "%s-content" }}
         - name: config
           configMap:
-            name: {{ include "fallback.name" . | printf "%s-config" }}
+            name: {{ include "graylog.fallback.name" . | printf "%s-config" }}
 {{- end }}

--- a/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/graylog/templates/workload/statefulsets/datanode.yaml
@@ -9,18 +9,18 @@ metadata:
   annotations:
     {{- include "graylog.annotations" . | nindent 4 }}
 spec:
-  replicas: {{ include "datanode.replicas" . | int }}
-  serviceName: {{ include "graylog.datanode.serviceName" . }}
+  replicas: {{ include "graylog.datanode.replicas" . | int }}
+  serviceName: {{ include "graylog.datanode.service.name" . }}
   selector:
     matchLabels:
       app: graylog-datanode
       {{- include "graylog.selectorLabels" . | nindent 6 }}
   updateStrategy:
-    type: {{ .Values.datanode.custom.updateStrategy.type | default "RollingUpdate" | quote }}
-    {{- if .Values.datanode.custom.updateStrategy.type | default "RollingUpdate" | eq "RollingUpdate" }}
+    type: {{ .Values.datanode.updateStrategy.type | default "RollingUpdate" | quote }}
+    {{- if .Values.datanode.updateStrategy.type | default "RollingUpdate" | eq "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.datanode.custom.updateStrategy.rollingUpdate.maxUnavailable | default "1" | quote }}
-      {{- with .Values.datanode.custom.updateStrategy.rollingUpdate.partition }}
+      maxUnavailable: {{ .Values.datanode.updateStrategy.rollingUpdate.maxUnavailable | default "1" | quote }}
+      {{- with .Values.datanode.updateStrategy.rollingUpdate.partition }}
       partition: {{ int . }}
       {{- end }}
     {{- end }}
@@ -31,33 +31,33 @@ spec:
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
         {{- $dd := randAlphaNum 5 | dict "data" }}
-        {{- $config := include "graylog.datanode.configmapName" . | lookup "v1" "ConfigMap" .Release.Namespace | default $dd }}
+        {{- $config := include "graylog.datanode.configmap.name" . | lookup "v1" "ConfigMap" .Release.Namespace | default $dd }}
         {{- $_ := randAlphaNum 5 | set $dd "data" }}
         {{- $secret := include "graylog.secretsName" . | lookup "v1" "Secret" .Release.Namespace | default $dd }}
         checksum/config: {{ $config.data | quote | sha256sum }}
         checksum/secret: {{ $secret.data | quote | sha256sum }}
-      {{- with .Values.datanode.custom.podAnnotations }}
+      {{- with .Values.datanode.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       dnsPolicy: ClusterFirst
-      {{- with .Values.datanode.custom.image.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- with .Values.datanode.image.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.datanode.custom.nodeSelector }}
-      nodeSelector: {{ .Values.datanode.custom.nodeSelector }}
+      {{- if .Values.datanode.nodeSelector }}
+      nodeSelector: {{ .Values.datanode.nodeSelector }}
       {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}
       {{- end }}
       containers:
         - name: graylog-datanode
-          image: {{ include "datanode.image" . }}
-          imagePullPolicy: {{ .Values.datanode.custom.image.imagePullPolicy }}
+          image: {{ include "graylog.datanode.image" . }}
+          imagePullPolicy: {{ .Values.datanode.image.imagePullPolicy }}
           envFrom:
             - configMapRef:
-                name: {{ include "graylog.datanode.configmapName" . }}
+                name: {{ include "graylog.datanode.configmap.name" . }}
             - secretRef:
                 name: {{ include "graylog.datanode.secretsName" . }}
           env:
@@ -66,7 +66,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: GRAYLOG_DATANODE_NODE_NAME
-              value: $(POD_NAME).{{ include "graylog.datanode.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+              value: $(POD_NAME).{{ include "graylog.datanode.service.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
             - name: GRAYLOG_DATANODE_OPENSEARCH_DISCOVERY_SEED_HOSTS
               value: {{ include "graylog.datanode.hosts" . }}
             - name: GRAYLOG_DATANODE_PASSWORD_SECRET
@@ -79,104 +79,104 @@ spec:
                 secretKeyRef:
                   name: {{ include "graylog.secretsName" . }}
                   key: GRAYLOG_MONGODB_URI
-            {{- include "graylog.custom.env" .Values.datanode | indent 12 }}
+            {{- include "graylog.env" .Values.datanode | indent 12 }}
           ports:
             - name: api
-              containerPort: {{ .Values.datanode.custom.service.ports.api | default 8999 | int }}
+              containerPort: {{ .Values.datanode.service.ports.api | default 8999 | int }}
               protocol: TCP
             - name: data
-              containerPort: {{ .Values.datanode.custom.service.ports.data | default 9200 | int }}
+              containerPort: {{ .Values.datanode.service.ports.data | default 9200 | int }}
               protocol: TCP
             - name: config
-              containerPort: {{ .Values.datanode.custom.service.ports.config | default 9300 | int }}
+              containerPort: {{ .Values.datanode.service.ports.config | default 9300 | int }}
               protocol: TCP
           volumeMounts:
             - name: "data"
-              mountPath: {{ .Values.datanode.custom.persistence.data.mountPath | default "/var/lib/graylog-datanode" | quote }}
+              mountPath: {{ .Values.datanode.persistence.data.mountPath | default "/var/lib/graylog-datanode" | quote }}
             - name: native-libs
-              mountPath: {{ .Values.datanode.custom.persistence.nativeLibs.mountPath | default "/native_libs" | quote }}
-          {{- if .Values.datanode.custom.livenessProbe.enabled }}
+              mountPath: {{ .Values.datanode.persistence.nativeLibs.mountPath | default "/native_libs" | quote }}
+          {{- if .Values.datanode.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
-              port: {{ .Values.datanode.custom.service.ports.api | default 8999 | int }}
-            initialDelaySeconds: {{ .Values.datanode.custom.livenessProbe.initialDelaySeconds | int }}
-            periodSeconds: {{ .Values.datanode.custom.livenessProbe.periodSeconds | int }}
-            timeoutSeconds: {{ .Values.datanode.custom.livenessProbe.timeoutSeconds | int }}
-            failureThreshold: {{ .Values.datanode.custom.livenessProbe.failureThreshold | int }}
-            successThreshold: {{ .Values.datanode.custom.livenessProbe.successThreshold | int }}
+              port: {{ .Values.datanode.service.ports.api | default 8999 | int }}
+            initialDelaySeconds: {{ .Values.datanode.livenessProbe.initialDelaySeconds | int }}
+            periodSeconds: {{ .Values.datanode.livenessProbe.periodSeconds | int }}
+            timeoutSeconds: {{ .Values.datanode.livenessProbe.timeoutSeconds | int }}
+            failureThreshold: {{ .Values.datanode.livenessProbe.failureThreshold | int }}
+            successThreshold: {{ .Values.datanode.livenessProbe.successThreshold | int }}
           {{- end }}
-          {{- if .Values.datanode.custom.readinessProbe.enabled }}
+          {{- if .Values.datanode.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.datanode.custom.service.ports.api | default 8999 | int }}
-            initialDelaySeconds: {{ .Values.datanode.custom.readinessProbe.initialDelaySeconds | int }}
-            periodSeconds: {{ .Values.datanode.custom.readinessProbe.periodSeconds | int }}
-            timeoutSeconds: {{ .Values.datanode.custom.readinessProbe.timeoutSeconds | int }}
-            failureThreshold: {{ .Values.datanode.custom.readinessProbe.failureThreshold | int }}
-            successThreshold: {{ .Values.datanode.custom.readinessProbe.successThreshold | int }}
+              port: {{ .Values.datanode.service.ports.api | default 8999 | int }}
+            initialDelaySeconds: {{ .Values.datanode.readinessProbe.initialDelaySeconds | int }}
+            periodSeconds: {{ .Values.datanode.readinessProbe.periodSeconds | int }}
+            timeoutSeconds: {{ .Values.datanode.readinessProbe.timeoutSeconds | int }}
+            failureThreshold: {{ .Values.datanode.readinessProbe.failureThreshold | int }}
+            successThreshold: {{ .Values.datanode.readinessProbe.successThreshold | int }}
           {{- end }}
-          {{- with .Values.datanode.custom.resources }}
+          {{- with .Values.datanode.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       tolerations:
-      {{- with .Values.datanode.custom.tolerations }}
+      {{- with .Values.datanode.tolerations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       affinity:
-      {{- with .Values.datanode.custom.affinity }}
+      {{- with .Values.datanode.affinity }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.datanode.custom.persistence.data.enabled .Values.datanode.custom.persistence.nativeLibs.enabled | not }}
+      {{- if and .Values.datanode.persistence.data.enabled .Values.datanode.persistence.nativeLibs.enabled | not }}
       volumes:
-        {{- if not .Values.datanode.custom.persistence.nativeLibs.enabled }}
+        {{- if not .Values.datanode.persistence.nativeLibs.enabled }}
         - name: native-libs
           emptyDir: {}
         {{- end }}
-        {{- if not .Values.datanode.custom.persistence.data.enabled }}
+        {{- if not .Values.datanode.persistence.data.enabled }}
         - name: data
           emptyDir: {}
         {{- end }}
       {{- end }}
-  {{- if or .Values.datanode.custom.persistence.data.enabled .Values.datanode.custom.persistence.nativeLibs.enabled }}
+  {{- if or .Values.datanode.persistence.data.enabled .Values.datanode.persistence.nativeLibs.enabled }}
   volumeClaimTemplates:
-    {{- if .Values.datanode.custom.persistence.data.enabled }}
+    {{- if .Values.datanode.persistence.data.enabled }}
     - metadata:
         name: data
       spec:
         accessModes:
-        {{- if .Values.datanode.custom.persistence.data.accessModes }}
-        {{- range .Values.datanode.custom.persistence.data.accessModes }}
+        {{- if .Values.datanode.persistence.data.accessModes }}
+        {{- range .Values.datanode.persistence.data.accessModes }}
           - {{ . | quote }}
         {{- end }}
         {{- else }}
           - "ReadWriteOnce"
         {{- end }}
-        {{- if or .Values.datanode.custom.persistence.data.storageClass .Values.global.defaultStorageClass }}
-        storageClassName: {{ .Values.datanode.custom.persistence.data.storageClass | default .Values.global.defaultStorageClass }}
+        {{- if or .Values.datanode.persistence.data.storageClass .Values.global.defaultStorageClass }}
+        storageClassName: {{ .Values.datanode.persistence.data.storageClass | default .Values.global.defaultStorageClass }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.datanode.custom.persistence.data.size | default "8Gi" | quote }}
+            storage: {{ .Values.datanode.persistence.data.size | default "8Gi" | quote }}
     {{- end }}
-    {{- if .Values.datanode.custom.persistence.nativeLibs.enabled }}
+    {{- if .Values.datanode.persistence.nativeLibs.enabled }}
     - metadata:
         name: nativeLibs
       spec:
         accessModes:
-        {{- if .Values.datanode.custom.persistence.nativeLibs.accessModes }}
-        {{- range .Values.datanode.custom.persistence.nativeLibs.accessModes }}
+        {{- if .Values.datanode.persistence.nativeLibs.accessModes }}
+        {{- range .Values.datanode.persistence.nativeLibs.accessModes }}
           - {{ . | quote }}
         {{- end }}
         {{- else }}
           - "ReadWriteOnce"
         {{- end }}
-        {{- if or .Values.datanode.custom.persistence.nativeLibs.storageClass .Values.global.defaultStorageClass }}
-        storageClassName: {{ .Values.datanode.custom.persistence.nativeLibs.storageClass | default .Values.global.defaultStorageClass }}
+        {{- if or .Values.datanode.persistence.nativeLibs.storageClass .Values.global.defaultStorageClass }}
+        storageClassName: {{ .Values.datanode.persistence.nativeLibs.storageClass | default .Values.global.defaultStorageClass }}
               {{- end }}
         resources:
           requests:
-            storage: {{ .Values.datanode.custom.persistence.nativeLibs.size | default "8Gi" | quote }}
+            storage: {{ .Values.datanode.persistence.nativeLibs.size | default "8Gi" | quote }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/graylog/templates/workload/statefulsets/graylog.yaml
@@ -11,17 +11,17 @@ metadata:
     {{- include "graylog.annotations" . | nindent 4 }}
 spec:
   replicas: {{ include "graylog.replicas" . | default 2 | int }}
-  serviceName: {{ include "graylog.serviceName" . }}
+  serviceName: {{ include "graylog.service.name" . }}
   selector:
     matchLabels:
       app: graylog-app
       {{- include "graylog.selectorLabels" . | nindent 6 }}
   updateStrategy:
-    type: {{ .Values.graylog.custom.updateStrategy.type | default "RollingUpdate" | quote }}
-    {{- if .Values.graylog.custom.updateStrategy.type | default "RollingUpdate" | eq "RollingUpdate" }}
+    type: {{ .Values.graylog.updateStrategy.type | default "RollingUpdate" | quote }}
+    {{- if .Values.graylog.updateStrategy.type | default "RollingUpdate" | eq "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.graylog.custom.updateStrategy.rollingUpdate.maxUnavailable | default "1" | quote }}
-      {{- with .Values.graylog.custom.updateStrategy.rollingUpdate.partition }}
+      maxUnavailable: {{ .Values.graylog.updateStrategy.rollingUpdate.maxUnavailable | default "1" | quote }}
+      {{- with .Values.graylog.updateStrategy.rollingUpdate.partition }}
       partition: {{ int . }}
       {{- end }}
     {{- end }}
@@ -32,22 +32,22 @@ spec:
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
         {{- $dd := randAlphaNum 5 | dict "data" }}
-        {{- $config := include "graylog.configmapName" . | lookup "v1" "ConfigMap" .Release.Namespace | default $dd  }}
+        {{- $config := include "graylog.configmap.name" . | lookup "v1" "ConfigMap" .Release.Namespace | default $dd  }}
         {{- $_ := randAlphaNum 5 | set $dd "data" }}
         {{- $secret := include "graylog.secretsName" . | lookup "v1" "Secret" .Release.Namespace | default $dd  }}
         checksum/config: {{ $config.data | quote | sha256sum }}
         checksum/secret: {{ $secret.data | quote | sha256sum }}
-      {{- with .Values.graylog.custom.podAnnotations }}
+      {{- with .Values.graylog.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       dnsPolicy: ClusterFirst
-      {{- with .Values.graylog.custom.image.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- with .Values.graylog.image.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.graylog.custom.nodeSelector }}
-      nodeSelector: {{ .Values.graylog.custom.nodeSelector }}
+      {{- if .Values.graylog.nodeSelector }}
+      nodeSelector: {{ .Values.graylog.nodeSelector }}
       {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}
@@ -59,7 +59,7 @@ spec:
       initContainers:
         - name: copy-data
           image: {{ include "graylog.image" . }}
-          imagePullPolicy: {{ .Values.graylog.custom.image.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.graylog.image.imagePullPolicy }}
           command: [ "/bin/sh", "/scripts/init-script.sh" ]
           env:
             - name: INIT_GRAYLOG_PLUGIN_URLS
@@ -68,11 +68,11 @@ spec:
               value: {{ include "graylog.mmdb.URLs" . | default "" }}
           envFrom:
             - configMapRef:
-                name: {{ include "graylog.configmapName" . }}
+                name: {{ include "graylog.configmap.name" . }}
             - secretRef:
                 name: {{ include "graylog.secretsName" . }}
           volumeMounts:
-            - name: {{ include "graylog.volumeName" . }}
+            - name: {{ include "graylog.volume.name" . }}
               mountPath: /mnt/data
             - name: init-script
               mountPath: /scripts
@@ -105,7 +105,7 @@ spec:
       containers:
         - name: graylog-app
           image: {{ include "graylog.image" . }}
-          imagePullPolicy: {{ .Values.graylog.custom.image.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.graylog.image.imagePullPolicy }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -113,20 +113,20 @@ spec:
                   fieldPath: metadata.name
             - name: GRAYLOG_HTTP_PUBLISH_URI
               value: {{ include "graylog.publishUri" . | quote }}
-          {{- if or .Values.graylog.custom.env .Values.graylog.custom.extraEnv }}
-            {{- include "graylog.custom.env" .Values.graylog | indent 12 }}
+          {{- if or .Values.graylog.env .Values.graylog.extraEnv }}
+            {{- include "graylog.env" .Values.graylog | indent 12 }}
           {{- end }}
           envFrom:
             - configMapRef:
-                name: {{ include "graylog.configmapName" . }}
+                name: {{ include "graylog.configmap.name" . }}
             - secretRef:
                 name: {{ include "graylog.secretsName" . }}
           ports:
             - name: app
-              containerPort: {{ .Values.graylog.custom.service.ports.app | int }}
+              containerPort: {{ .Values.graylog.service.ports.app | int }}
               protocol: TCP
             - name: metrics
-              containerPort: {{ .Values.graylog.custom.service.ports.metrics | int }}
+              containerPort: {{ .Values.graylog.service.ports.metrics | int }}
               protocol: TCP
             {{- range .Values.graylog.inputs }}
             - name: {{ .name }}
@@ -136,32 +136,32 @@ spec:
             - name: input-fwd-conf
               containerPort: 13302
               protocol: TCP
-          {{- if .Values.graylog.custom.livenessProbe.enabled }}
+          {{- if .Values.graylog.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
-              port: {{ .Values.graylog.custom.service.ports.app | int }}
-            initialDelaySeconds: {{ .Values.graylog.custom.livenessProbe.initialDelaySeconds | int }}
-            periodSeconds: {{ .Values.graylog.custom.livenessProbe.periodSeconds | int }}
-            timeoutSeconds: {{ .Values.graylog.custom.livenessProbe.timeoutSeconds | int }}
-            failureThreshold: {{ .Values.graylog.custom.livenessProbe.failureThreshold | int }}
-            successThreshold: {{ .Values.graylog.custom.livenessProbe.successThreshold |int }}
+              port: {{ .Values.graylog.service.ports.app | int }}
+            initialDelaySeconds: {{ .Values.graylog.livenessProbe.initialDelaySeconds | int }}
+            periodSeconds: {{ .Values.graylog.livenessProbe.periodSeconds | int }}
+            timeoutSeconds: {{ .Values.graylog.livenessProbe.timeoutSeconds | int }}
+            failureThreshold: {{ .Values.graylog.livenessProbe.failureThreshold | int }}
+            successThreshold: {{ .Values.graylog.livenessProbe.successThreshold |int }}
           {{- end }}
-          {{- if .Values.graylog.custom.readinessProbe.enabled }}
+          {{- if .Values.graylog.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.graylog.custom.service.ports.app | int }}
-            initialDelaySeconds: {{ .Values.graylog.custom.readinessProbe.initialDelaySeconds | int }}
-            periodSeconds: {{ .Values.graylog.custom.readinessProbe.periodSeconds | int }}
-            timeoutSeconds: {{ .Values.graylog.custom.readinessProbe.timeoutSeconds | int }}
-            failureThreshold: {{ .Values.graylog.custom.readinessProbe.failureThreshold | int }}
-            successThreshold: {{ .Values.graylog.custom.readinessProbe.successThreshold | int }}
+              port: {{ .Values.graylog.service.ports.app | int }}
+            initialDelaySeconds: {{ .Values.graylog.readinessProbe.initialDelaySeconds | int }}
+            periodSeconds: {{ .Values.graylog.readinessProbe.periodSeconds | int }}
+            timeoutSeconds: {{ .Values.graylog.readinessProbe.timeoutSeconds | int }}
+            failureThreshold: {{ .Values.graylog.readinessProbe.failureThreshold | int }}
+            successThreshold: {{ .Values.graylog.readinessProbe.successThreshold | int }}
           {{- end }}
-          {{- with .Values.graylog.custom.resources }}
+          {{- with .Values.graylog.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: {{ include "graylog.volumeName" . }}
+            - name: {{ include "graylog.volume.name" . }}
               mountPath: /usr/share/graylog/data
             {{- if .Values.graylog.config.tls.enabled }}
             - name: tls-creds
@@ -172,11 +172,11 @@ spec:
               mountPath: /usr/share/graylog/plugin
             {{- end }}
       tolerations:
-      {{- with .Values.graylog.custom.tolerations }}
+      {{- with .Values.graylog.tolerations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       affinity:
-      {{- with .Values.graylog.custom.affinity }}
+      {{- with .Values.graylog.affinity }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
@@ -200,36 +200,36 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
-      {{- if not .Values.graylog.custom.persistence.enabled | or .Values.graylog.custom.persistence.existingClaim }}
-      - name: {{ include "graylog.volumeName" . }}
-        {{- if .Values.graylog.custom.persistence.existingClaim }}
+      {{- if not .Values.graylog.persistence.enabled | or .Values.graylog.persistence.existingClaim }}
+      - name: {{ include "graylog.volume.name" . }}
+        {{- if .Values.graylog.persistence.existingClaim }}
         persistentVolumeClaim:
-          claimName: {{ .Values.graylog.custom.persistence.existingClaim }}
+          claimName: {{ .Values.graylog.persistence.existingClaim }}
         {{- else }}
         emptyDir: {}
         {{- end }}
       {{- end }}
-  {{- if not .Values.graylog.custom.persistence.existingClaim | and .Values.graylog.custom.persistence.enabled }}
+  {{- if not .Values.graylog.persistence.existingClaim | and .Values.graylog.persistence.enabled }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
-        name: {{ include "graylog.volumeName" . }}
-        {{- with .Values.graylog.custom.persistence.annotations }}
+        name: {{ include "graylog.volume.name" . }}
+        {{- with .Values.graylog.persistence.annotations }}
         annotations:
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.graylog.custom.persistence.labels }}
+        {{- with .Values.graylog.persistence.labels }}
         labels:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       spec:
-        {{- if or .Values.graylog.custom.persistence.storageClass .Values.global.defaultStorageClass }}
-        storageClassName: {{ .Values.graylog.custom.persistence.storageClass | default .Values.global.defaultStorageClass }}
+        {{- if or .Values.graylog.persistence.storageClass .Values.global.defaultStorageClass }}
+        storageClassName: {{ .Values.graylog.persistence.storageClass | default .Values.global.defaultStorageClass }}
         {{- end }}
         accessModes:
-        {{- if .Values.graylog.custom.persistence.accessModes }}
-        {{- range .Values.graylog.custom.persistence.accessModes }}
+        {{- if .Values.graylog.persistence.accessModes }}
+        {{- range .Values.graylog.persistence.accessModes }}
           - {{ . | quote }}
         {{- end }}
         {{- else }}
@@ -237,6 +237,6 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.graylog.custom.persistence.size | default "8Gi" | quote }}
+            storage: {{ .Values.graylog.persistence.size | default "8Gi" | quote }}
   {{- end }}
 {{- end }}

--- a/graylog/values.schema.json
+++ b/graylog/values.schema.json
@@ -2,7 +2,34 @@
   "$schema": "https://json-schema.org/schema#",
   "title": "Graylog Helm Chart Values Schema",
   "type": "object",
+  "required": [],
   "properties": {
+    "size": {
+      "type": "string",
+      "description": "Preset cluster size (optional)",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [ "xs", "small", "medium", "large", "xl", "xxl", "default", "poc", "" ]
+        },
+        { "type": "null" }
+      ]
+    },
+    "provider": {
+      "type": "string",
+      "description": "Kubernetes provider (optional)",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [ "aws", "aws-managed-sc", "azure", "gcp", "microk8s", "" ]
+        },
+        { "type": "null" }
+      ]
+    },
+    "version": {
+      "type": "string",
+      "description": "Override Graylog and Graylog Data Node version (optional)"
+    },
     "nameOverride": {
       "type": "string",
       "description": "Override the name of the chart. Affects app.kubernetes.io/name annotation"
@@ -28,9 +55,26 @@
       "properties": {
         "enabled": { "type": "boolean", "default": true },
         "enterprise": { "type": "boolean", "default": true },
-        "replicas": {
-          "type": ["integer", "null"],
-          "default": 2
+        "replicas": { "type": "integer" },
+        "service": {
+          "type": "object",
+          "properties": {
+            "nameOverride": { "type": "string" },
+            "type": { "type": "string" },
+            "ports": {
+              "type": "object",
+              "properties": {
+                "app": { "type": "integer" },
+                "metrics": { "type": "integer" }
+              }
+            },
+            "metrics": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type":  "boolean" }
+              }
+            }
+          }
         },
         "inputs": {
           "type": "array",
@@ -42,8 +86,49 @@
               "targetPort": { "type": "integer" },
               "protocol": { "type": "string" }
             },
-            "required": ["name", "port", "protocol"]
+            "required": [ "name", "port", "protocol" ]
           }
+        },
+        "plugins": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "image": { "type": "string" },
+              "existingClaim": { "type": "string" },
+              "url": { "type": "string" },
+              "checksum": { "type": "string" }
+            },
+            "required": [ "name" ],
+            "oneOf": [
+              {
+                "required": [ "image" ],
+                "not": { "required": [ "existingClaim", "url" ] }
+              },
+              {
+                "required": [ "existingClaim" ],
+                "not": { "required": [ "image", "url" ] }
+              },
+              {
+                "required": [ "url" ],
+                "not": { "required":  [ "existingClaim", "image" ] }
+              }
+            ],
+            "allOf": [
+              {
+                "if": { "required": [ "checksum" ] },
+                "then": { "required": [ "url" ] }
+              }
+            ]
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string","number","boolean"]
+          },
+          "description": "Key/value env vars rendered as literals"
         },
         "config": {
           "type": "object",
@@ -121,152 +206,113 @@
             }
           }
         },
-        "custom": {
+        "image": {
           "type": "object",
-          "description": "Custom Kubernetes-specific configuration",
           "properties": {
-            "podAnnotations": {
-              "type": "object"
-            },
-            "nodeSelector": {
-              "type": "object"
-            },
-            "tolerations": {
-              "type": "object"
-            },
-            "affinity": {
-              "type": "object"
-            },
-            "env": {
-              "type": "object",
-              "additionalProperties": {
-                "type": ["string","number","boolean"]
-              },
-              "description": "Key/value env vars rendered as literals"
-            },
-            "extraEnv": {
-              "type": "array",
-              "items": { "type": "object" },
-              "description": "Full EnvVar objects (supports valueFrom)"
-            },
-            "inputs": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "imagePullPolicy": { "type": "string" },
+            "imagePullSecrets": { "type": "array" }
+          }
+        },
+        "updateStrategy": {
+          "type": "object",
+          "properties": {
+            "type": { "type": ["string", "null"] },
+            "rollingUpdate": {
               "type": "object",
               "properties": {
-                "enabled": { "type": "boolean" }
-              }
-            },
-            "metrics": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" }
-              }
-            },
-            "image": {
-              "type": "object",
-              "properties": {
-                "repository": { "type": "string" },
-                "tag": { "type": "string" },
-                "imagePullPolicy": { "type": "string" },
-                "imagePullSecrets": { "type": "array" }
-              }
-            },
-            "updateStrategy": {
-              "type": "object",
-              "properties": {
-                "type": { "type": ["string", "null"] },
-                "rollingUpdate": {
-                  "type": "object",
-                  "properties": {
-                    "maxUnavailable": { "type": [ "string", "null" ] },
-                    "partition": { "type": [ "string", "null" ] }
-                  }
-                }
-              }
-            },
-            "service": {
-              "type": "object",
-              "properties": {
-                "nameOverride": { "type": "string" },
-                "type": { "type": "string" },
-                "ports": {
-                  "type": "object",
-                  "properties": {
-                    "app": { "type": "integer" },
-                    "metrics": { "type": "integer" }
-                  }
-                }
-              }
-            },
-            "resources": {
-              "type": "object",
-              "properties": {
-                "limits": {
-                  "type": "object",
-                  "properties": {
-                    "cpu": { "type": "string" },
-                    "memory": { "type": "string" }
-                  }
-                },
-                "requests": {
-                  "type": "object",
-                  "properties": {
-                    "cpu": { "type": "string" },
-                    "memory": { "type": "string" }
-                  }
-                }
-              }
-            },
-            "persistence": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "storageClass": { "type": [ "string", "null" ] },
-                "volumeNameOverride": { "type": [ "string", "null" ] },
-                "existingClaim": { "type": [ "string", "null" ] },
-                "mountPath": { "type": [ "string", "null" ] },
-                "accessModes": { "type": "array" },
-                "size": { "type": [ "string", "null" ] },
-                "annotations": {
-                  "type": "object"
-                },
-                "labels": {
-                  "type": "object"
-                },
-                "selector": {
-                  "type": "object"
-                }
-              }
-            },
-            "livenessProbe": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "initialDelaySeconds": { "type": "integer" },
-                "periodSeconds": { "type": "integer" },
-                "timeoutSeconds": { "type": "integer" },
-                "failureThreshold": { "type": "integer" },
-                "successThreshold": { "type": "integer" }
-              }
-            },
-            "readinessProbe": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "initialDelaySeconds": { "type": "integer" },
-                "periodSeconds": { "type": "integer" },
-                "timeoutSeconds": { "type": "integer" },
-                "failureThreshold": { "type": "integer" },
-                "successThreshold": { "type": "integer" }
-              }
-            },
-            "podDisruptionBudget": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "minAvailable": { "type": "integer" }
+                "maxUnavailable": { "type": [ "string", "null" ] },
+                "partition": { "type": [ "string", "null" ] }
               }
             }
           }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "storageClass": { "type": [ "string", "null" ] },
+            "volumeNameOverride": { "type": [ "string", "null" ] },
+            "existingClaim": { "type": [ "string", "null" ] },
+            "mountPath": { "type": [ "string", "null" ] },
+            "accessModes": { "type": "array" },
+            "size": { "type": [ "string", "null" ] },
+            "annotations": {
+              "type": "object"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "selector": {
+              "type": "object"
+            }
+          }
+        },
+        "livenessProbe": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" },
+            "successThreshold": { "type": "integer" }
+          }
+        },
+        "readinessProbe": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" },
+            "successThreshold": { "type": "integer" }
+          }
+        },
+        "podDisruptionBudget": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minAvailable": { "type": "integer" }
+          }
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "object"
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "extraEnv": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Full EnvVar objects (supports valueFrom)"
         }
       }
     },
@@ -275,9 +321,26 @@
       "description": "Graylog Datanode configuration",
       "properties": {
         "enabled": { "type": "boolean" },
-        "replicas": {
-          "type": ["integer", "null"],
-          "default": 3
+        "replicas": { "type": "integer" },
+        "service": {
+          "type": "object",
+          "properties": {
+            "ports": {
+              "type": "object",
+              "properties": {
+                "api": { "type": "integer" },
+                "data": { "type": "integer" },
+                "config": { "type": "integer" }
+              }
+            }
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string","number","boolean"]
+          },
+          "description": "Key/value env vars rendered as literals"
         },
         "config": {
           "type": "object",
@@ -289,167 +352,141 @@
             "nodeSearchCacheSize": { "type": "string" }
           }
         },
-        "custom": {
+        "image": {
           "type": "object",
-          "description": "Custom Kubernetes-specific configuration",
           "properties": {
-            "podAnnotations": {
-              "type": "object"
-            },
-            "nodeSelector": {
-              "type": "object"
-            },
-            "tolerations": {
-              "type": "object"
-            },
-            "affinity": {
-              "type": "object"
-            },
-            "env": {
-              "type": "object",
-              "additionalProperties": {
-                "type": ["string","number","boolean"]
-              },
-              "description": "Key/value env vars rendered as literals"
-            },
-            "extraEnv": {
-              "type": "array",
-              "items": { "type": "object" },
-              "description": "Full EnvVar objects (supports valueFrom)"
-            },
-            "image": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "imagePullPolicy": { "type": "string" },
+            "imagePullSecrets": { "type": "array" }
+          }
+        },
+        "updateStrategy": {
+          "type": "object",
+          "properties": {
+            "type": { "type": ["string", "null"] },
+            "rollingUpdate": {
               "type": "object",
               "properties": {
-                "repository": { "type": "string" },
-                "tag": { "type": "string" },
-                "imagePullPolicy": { "type": "string" },
-                "imagePullSecrets": { "type": "array" }
-              }
-            },
-            "updateStrategy": {
-              "type": "object",
-              "properties": {
-                "type": { "type": ["string", "null"] },
-                "rollingUpdate": {
-                  "type": "object",
-                  "properties": {
-                    "maxUnavailable": { "type": [ "string", "null" ] },
-                    "partition": { "type": [ "string", "null" ] }
-                  }
-                }
-              }
-            },
-            "service": {
-              "type": "object",
-              "properties": {
-                "ports": {
-                  "type": "object",
-                  "properties": {
-                    "api": { "type": "integer" },
-                    "data": { "type": "integer" },
-                    "config": { "type": "integer" }
-                  }
-                }
-              }
-            },
-            "resources": {
-              "type": "object",
-              "properties": {
-                "limits": {
-                  "type": "object",
-                  "properties": {
-                    "cpu": { "type": "string" },
-                    "memory": { "type": "string" }
-                  }
-                },
-                "requests": {
-                  "type": "object",
-                  "properties": {
-                    "cpu": { "type": "string" },
-                    "memory": { "type": "string" }
-                  }
-                }
-              }
-            },
-            "persistence": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "enabled": { "type": "boolean" },
-                    "storageClass": { "type": "string" },
-                    "existingClaim": { "type": "string" },
-                    "mountPath": { "type": "string" },
-                    "accessModes": { "type": "array" },
-                    "size": { "type": "string" },
-                    "annotations": {
-                      "type": "object"
-                    },
-                    "labels": {
-                      "type": "object"
-                    },
-                    "selector": {
-                      "type": "object"
-                    },
-                    "dataSource": {
-                      "type": "object"
-                    }
-                  }
-                },
-                "nativeLibs": {
-                  "type": "object",
-                  "properties": {
-                    "enabled": { "type": "boolean" },
-                    "storageClass": { "type": "string" },
-                    "existingClaim": { "type": "string" },
-                    "mountPath": { "type": "string" },
-                    "accessModes": { "type": "array" },
-                    "size": { "type": "string" },
-                    "annotations": {
-                      "type": "object"
-                    },
-                    "labels": {
-                      "type": "object"
-                    },
-                    "selector": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            },
-            "livenessProbe": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "initialDelaySeconds": { "type": "integer" },
-                "periodSeconds": { "type": "integer" },
-                "timeoutSeconds": { "type": "integer" },
-                "failureThreshold": { "type": "integer" },
-                "successThreshold": { "type": "integer" }
-              }
-            },
-            "readinessProbe": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "initialDelaySeconds": { "type": "integer" },
-                "periodSeconds": { "type": "integer" },
-                "timeoutSeconds": { "type": "integer" },
-                "failureThreshold": { "type": "integer" },
-                "successThreshold": { "type": "integer" }
-              }
-            },
-            "podDisruptionBudget": {
-              "type": "object",
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "minAvailable": { "type": "integer" }
+                "maxUnavailable": { "type": [ "string", "null" ] },
+                "partition": { "type": [ "string", "null" ] }
               }
             }
           }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "data": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "storageClass": { "type": "string" },
+                "existingClaim": { "type": "string" },
+                "mountPath": { "type": "string" },
+                "accessModes": { "type": "array" },
+                "size": { "type": "string" },
+                "annotations": {
+                  "type": "object"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "selector": {
+                  "type": "object"
+                },
+                "dataSource": {
+                  "type": "object"
+                }
+              }
+            },
+            "nativeLibs": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "storageClass": { "type": "string" },
+                "existingClaim": { "type": "string" },
+                "mountPath": { "type": "string" },
+                "accessModes": { "type": "array" },
+                "size": { "type": "string" },
+                "annotations": {
+                  "type": "object"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "selector": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "livenessProbe": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" },
+            "successThreshold": { "type": "integer" }
+          }
+        },
+        "readinessProbe": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" },
+            "successThreshold": { "type": "integer" }
+          }
+        },
+        "podDisruptionBudget": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minAvailable": { "type": "integer" }
+          }
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "object"
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "extraEnv": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Full EnvVar objects (supports valueFrom)"
         }
       }
     },

--- a/graylog/values.yaml
+++ b/graylog/values.yaml
@@ -1,10 +1,10 @@
 # Default values for Graylog.
 
 # Preset cluster size (optional)
-size:
+size: ""
 
 # Kubernetes provider (optional)
-provider:
+provider: ""
 
 # Override Graylog and Graylog Data Node version (optional)
 version: ""
@@ -24,10 +24,16 @@ global:
 # Graylog application
 graylog:
   enabled: true
-  # Enable enterprise features (license required)
   enterprise: true
-  # Custom number of Graylog nodes (defaults to 2 if empty)
-  replicas:
+  replicas: 2
+  service:
+    nameOverride: ""
+    type: ClusterIP
+    ports:
+      app: 9000
+      metrics: 9833
+    metrics:
+      enabled: true
   inputs:
     - name: input-gelf
       port: 12201
@@ -37,7 +43,8 @@ graylog:
       port: 13301
       targetPort: 13301
       protocol: TCP
-  plugins:
+  plugins: []
+  env: {}
   # Graylog server configuration (server.conf)
   config:
     rootUsername: "admin"
@@ -127,75 +134,67 @@ graylog:
         geolocation:
           enabled: false
           baseUrl:
-  # Custom Kubernetes-specific parameters
-  custom:
-    podAnnotations: {}
-    nodeSelector: {}
-    tolerations: {}
-    affinity: {}
-    env: {}
-    extraEnv: []
-    inputs:
-      enabled: true
-    metrics:
-      enabled: true
-    image:
-      repository: ""
-      tag: ""
-      imagePullPolicy: IfNotPresent
-      imagePullSecrets: []
-    updateStrategy:
-      type:
-      rollingUpdate:
-        maxUnavailable:
-        partition:
-    service:
-      nameOverride: ""
-      type: ClusterIP
-      ports:
-        app: 9000
-        metrics: 9833
-    resources:
-      limits:
-        cpu: "2"
-        memory: "2Gi"
-      requests:
-        cpu: "1"
-        memory: "1Gi"
-    persistence:
-      enabled: true
-      storageClass:
-      volumeNameOverride:
-      existingClaim:
-      mountPath:
-      accessModes: []
-      size:
-      annotations: {}
-      labels: {}
-      selector: {}
-    livenessProbe:
-      enabled: true
-      initialDelaySeconds: 60
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
-      successThreshold: 1
-    readinessProbe:
-      enabled: true
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
-      successThreshold: 1
-    podDisruptionBudget:
-      enabled: false
-      minAvailable: 1
+  image:
+    repository: ""
+    tag: ""
+    imagePullPolicy: IfNotPresent
+    imagePullSecrets: []
+  updateStrategy:
+    type:
+    rollingUpdate:
+      maxUnavailable:
+      partition:
+  resources:
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+    requests:
+      cpu: "1"
+      memory: "1Gi"
+  persistence:
+    enabled: true
+    storageClass:
+    volumeNameOverride:
+    existingClaim:
+    mountPath:
+    accessModes: []
+    size:
+    annotations: {}
+    labels: {}
+    selector: {}
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: {}
+  affinity: {}
+  extraEnv: []
 
 # Graylog Datanode
 datanode:
   enabled: true
-  # Custom number of Datanode nodes (defaults to 3 if empty)
-  replicas:
+  replicas: 3
+  service:
+    ports:
+      api: 8999
+      data: 9200
+      config: 9300
+  env: {}
   config:
     nodeIdFile: ""
     opensearchHeap: "2g"
@@ -208,77 +207,68 @@ datanode:
     s3ClientDefaultRegion: "us-east-2"
     s3ClientDefaultProtocol: "http"
     s3ClientDefaultPathStyleAccess: "true"
-
-  # Custom Kubernetes-specific parameters
-  custom:
-    podAnnotations: {}
-    nodeSelector: {}
-    tolerations: {}
-    affinity: {}
-    env: {}
-    extraEnv: []
-    image:
-      repository: ""
-      tag: ""
-      imagePullPolicy: IfNotPresent
-      imagePullSecrets: []
-    updateStrategy:
-      type:
-      rollingUpdate:
-        maxUnavailable:
-        partition:
-    service:
-      ports:
-        api: 8999
-        data: 9200
-        config: 9300
-    resources:
-      limits:
-        cpu: "1"
-        memory: "5Gi"
-      requests:
-        cpu: "500m"
-        memory: "3.5Gi"
-    persistence:
+  image:
+    repository: ""
+    tag: ""
+    imagePullPolicy: IfNotPresent
+    imagePullSecrets: []
+  updateStrategy:
+    type:
+    rollingUpdate:
+      maxUnavailable:
+      partition:
+  resources:
+    limits:
+      cpu: "1"
+      memory: "5Gi"
+    requests:
+      cpu: "500m"
+      memory: "3.5Gi"
+  persistence:
+    enabled: true
+    data:
       enabled: true
-      data:
-        enabled: true
-        storageClass: ""
-        existingClaim: ""
-        mountPath: ""
-        accessModes: []
-        size: "8Gi"
-        annotations: {}
-        labels: {}
-        selector: {}
-        dataSource: {}
-      nativeLibs:
-        enabled: false
-        storageClass: ""
-        existingClaim: ""
-        mountPath: ""
-        accessModes: []
-        size: "2Gi"
-        annotations: {}
-        labels: {}
-        selector: {}
-    livenessProbe:
-      enabled: true
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
-      successThreshold: 1
-    readinessProbe:
-      enabled: true
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
-      successThreshold: 1
-    podDisruptionBudget:
+      storageClass: ""
+      existingClaim: ""
+      mountPath: ""
+      accessModes: []
+      size: "8Gi"
+      annotations: {}
+      labels: {}
+      selector: {}
+      dataSource: {}
+    nativeLibs:
       enabled: false
-      minAvailable: 2
+      storageClass: ""
+      existingClaim: ""
+      mountPath: ""
+      accessModes: []
+      size: "2Gi"
+      annotations: {}
+      labels: {}
+      selector: {}
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 2
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: {}
+  affinity: {}
+  extraEnv: []
 
 # Graylog service account
 serviceAccount:


### PR DESCRIPTION
This PR takes care of removing the unnecessary `custom` level for both `graylog` and `datanode` values.

It also updates `values.schema.json` and renames helpers so they all begin with 'graylog.' in order to avoid eventual collisions with other charts. Finally, the value reference in README.md is also updated.

This one's tricky for validations steps. Ideally try _everything_ and see if something breaks. This would also be in order as the last PR to merge before `v0.1.0`. So, start with the README: follow every step there to enable/disable/configure different features, and then move on to values combinations not on the README.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

