### PR TITLE
refactor: sizeOverride

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,13 +417,13 @@ stern statefulset/graylog-datanode -n graylog-helm-dev-1
 ---
 
 # Graylog Helm Chart Values Reference
-| Key Path           | Description                                                      | Default   |
-|--------------------|------------------------------------------------------------------| --------- |
-| `size`             | Preset cluster size (optional).                                  | `""`      |
-| `provider`         | Kubernetes provider (optional).                                  | `""`      |
-| `version`          | Override Graylog and Graylog Data Node version (optional).       | `""`      |
-| `nameOverride`     | Override the `app.kubernetes.io/name` label value (optional).    | `""`      |
-| `fullnameOverride` | Override the fully qualified name of the application (optional). | `""`      |
+| Key Path           | Description                                                                                      | Default   |
+|--------------------|--------------------------------------------------------------------------------------------------| --------- |
+| `provider`         | Kubernetes provider (optional).                                                                  | `""`      |
+| `version`          | Override Graylog and Graylog Data Node version (optional).                                       | `""`      |
+| `sizeOverride`     | Override Graylog and Graylog Data Node replicas and resource requests using a preset (optional). | `""`      |
+| `nameOverride`     | Override the `app.kubernetes.io/name` label value (optional).                                    | `""`      |
+| `fullnameOverride` | Override the fully qualified name of the application (optional).                                 | `""`      |
 
 ## Global
 These values affect Graylog, DataNode, and MongoDB

--- a/graylog/values.schema.json
+++ b/graylog/values.schema.json
@@ -4,17 +4,6 @@
   "type": "object",
   "required": [],
   "properties": {
-    "size": {
-      "type": "string",
-      "description": "Preset cluster size (optional)",
-      "oneOf": [
-        {
-          "type": "string",
-          "enum": [ "xs", "small", "medium", "large", "xl", "xxl", "default", "poc", "" ]
-        },
-        { "type": "null" }
-      ]
-    },
     "provider": {
       "type": "string",
       "description": "Kubernetes provider (optional)",
@@ -29,6 +18,17 @@
     "version": {
       "type": "string",
       "description": "Override Graylog and Graylog Data Node version (optional)"
+    },
+    "sizeOverride": {
+      "type": "string",
+      "description": "Override the preset cluster size (optional)",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [ "xs", "small", "medium", "large", "xl", "xxl", "default", "poc", "" ]
+        },
+        { "type": "null" }
+      ]
     },
     "nameOverride": {
       "type": "string",

--- a/graylog/values.yaml
+++ b/graylog/values.yaml
@@ -1,13 +1,13 @@
 # Default values for Graylog.
 
-# Preset cluster size (optional)
-size: ""
-
 # Kubernetes provider (optional)
 provider: ""
 
 # Override Graylog and Graylog Data Node version (optional)
 version: ""
+
+# Override the preset cluster size (optional)
+sizeOverride: ""
 
 # Override the chart name (optional)
 nameOverride: ""


### PR DESCRIPTION
This is an attempt to preserve some of the functionality of the `size` preset outlined in https://github.com/Graylog2/graylog-helm/pull/56 -- specifically, this PR modifies the expectation of `size` being a way to set default values that can later be overriden, into an override itself: `sizeOverride`

Just like before, the following is true:

```
helm upgrade -i graylog ./graylog --set sizeOverride=small
```

deploys a cluster with the same specs as this:

```
helm upgrade -i graylog ./graylog --set graylog.replicas=1 --set datanode.replicas=2 --set graylog.resources.requests.cpu=2 --set graylog.resources.requests.memory=4Gi --set datanode.resources.requests.cpu=2 --set graylog.resources.requests.memory=8Gi
```

The difference is that now, `sizeOverride` in `values.yaml` does not establish the defaults for `replicas` (and eventually container `requirements`) for both `graylog` and `datanode`. Instead it overrides the default values that live in`values.yaml` already, using a single setting instead of overriding each value individually.

Even though it keeps the same convenience/QoL feature by simplifying the number of values to set in order to achieve a given recommended configuration, this refactoring prevents any individual value override: in order to increase the `graylog.replicas` number, the `sizeOverride=""` value would need to be set first, which would unset the rest of the values like `datanode.replicas` and so on, which means all those values then need to be set individually. As such, this PR might be introducing more of a _demo_ feature.

Until we sync on this issue, this PR will remain a draft.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

