### PR TITLE
Rename native-libs PVC template

### DIFF
--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -161,7 +161,7 @@ spec:
     {{- end }}
     {{- if .Values.datanode.persistence.nativeLibs.enabled }}
     - metadata:
-        name: nativeLibs
+        name: native-libs
       spec:
         accessModes:
         {{- if .Values.datanode.persistence.nativeLibs.accessModes }}


### PR DESCRIPTION
## Summary

Fix: rename `nativeLibs` volume template to maintain consistency and prevent issues with `volumeMounts`.

## What changed
- Rename volume template from `nativeLibs` to `native-libs` in `statefulsets/datanode.yaml`

## Linked issues

This fixes #66

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [x] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [x] Web UI accessible and login works
- [x] DataNodes visible in _System > Cluster Configuration_
- [x] Inputs can be created and receive data

### Upgrade (if applicable)
- [x] Upgrade from previous release succeeds
- [x] Scaling up/down works correctly
- [x] Configuration changes apply correctly

### Specific to this PR
- [x] Verify that all DN pods are scheduled and reach `Running` status after installing the chart like so:

  ```sh
  # install chart
  helm install graylog ./charts/graylog --set datanode.persistence.nativeLibs.enabled=true

  # verify all DN pods are rolled out successfully
  kubectl rollout status statefulset/graylog-datanode
  ```

## Notes for reviewers
- [x] Verify all tests above pass
- [x] Sync up with the author before merging
- [x] The commit history should be preserved - use rebase-merge or standard merge options when applicable
