### PR TITLE
fix(datanode): use with for each secret field

### DIFF
--- a/charts/graylog/templates/config/secret/datanode.yaml
+++ b/charts/graylog/templates/config/secret/datanode.yaml
@@ -7,5 +7,9 @@ metadata:
   annotations:
     {{- include "graylog.annotations" . | nindent 4 }}
 data:
-  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_SECRET_KEY: {{ .Values.datanode.config.s3ClientDefaultSecretKey | b64enc }}
-  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_ACCESS_KEY: {{ .Values.datanode.config.s3ClientDefaultAccessKey | b64enc }}
+  {{- with .Values.datanode.config.s3ClientDefaultSecretKey }}
+  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_SECRET_KEY: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.datanode.config.s3ClientDefaultAccessKey }}
+  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_ACCESS_KEY: {{ . | b64enc }}
+  {{- end }}


### PR DESCRIPTION
## Summary

Small refactor: prevent empty fields from being rendered in DN secrets.

## What changed
- Use `with` in template for S3 fields in `secret/datanode.yaml`

## Linked issues

This closes #68 

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [ ] This PR includes a bugfix
- [x] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [x] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [x] Web UI accessible and login works
- [x] DataNodes visible in _System > Cluster Configuration_
- [x] Inputs can be created and receive data

### Upgrade (if applicable)
- [x] Upgrade from previous release succeeds
- [x] Scaling up/down works correctly
- [x] Configuration changes apply correctly

### Specific to this PR
- [x] Verify no fields are set for a regular installation:
  ```sh
  # install normally
  helm install graylog ./charts/graylog -n graylog --create-namespace

  # decode the graylog-secrets-datanode secret
  kubectl get secret graylog-secrets-datanode -n graylog -o jsonpath='{.data}'  | jq 'map_values(@base64d)'
  ```

## Notes for reviewers
- [ ] Verify all tests above pass
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable



