### PR TITLE
fix: use toYaml with each nodeSelector

### DIFF
--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -45,8 +45,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.datanode.nodeSelector }}
-      nodeSelector: {{ .Values.datanode.nodeSelector }}
+      {{- with .Values.datanode.nodeSelector }}
+      nodeSelector: {{ . | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -46,8 +46,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.graylog.nodeSelector }}
-      nodeSelector: {{ .Values.graylog.nodeSelector }}
+      {{- with .Values.graylog.nodeSelector }}
+      nodeSelector: {{ . | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}


### PR DESCRIPTION
## Summary

Small fix: render valid YAML for StatefulSet resources configured with node selectors.

## What changed
- Use `with` and `toYaml` in template for`nodeSelector` fields in `statefulsets/graylog.yaml` and `statefulsets/datanode.yaml`

## Linked issues

This closes #69

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [x] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [x] Web UI accessible and login works
- [x] DataNodes visible in _System > Cluster Configuration_
- [x] Inputs can be created and receive data

### Upgrade (if applicable)
- [x] Upgrade from previous release succeeds
- [x] Scaling up/down works correctly
- [x] Configuration changes apply correctly

### Specific to this PR
- [x] Verify node selectors are renderes as valid YAML maps instead of Go map strings (see linked issue)
  ```sh
  helm template graylog ./charts/graylog --set graylog.nodeSelector.kubernetes.os=linux --set datanode.nodeSelector.kubernetes.os=linux | grep "nodeSelector"
  ```

## Notes for reviewers
- [ ] Verify all tests above pass
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable





