### PR TITLE
fix: use release-specific templated names

### DIFF
--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -54,10 +54,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Init script ConfigMap name
+*/}}
+{{- define "graylog.cm.init.name" }}
+{{- include "graylog.fullname" . | printf "%s-init-cm" }}
+{{- end }}
+
+{{/*
 Service account name
 */}}
-{{- define "graylog.serviceAccountName" -}}
-{{ $defaultName := "default" }}
+{{- define "graylog.serviceAccountName" }}
+{{- $defaultName := "default" }}
 {{- if .Values.serviceAccount.create }}
 {{- $defaultName = include "graylog.fullname" . | printf "%s-sa" }}
 {{- end }}
@@ -67,8 +74,8 @@ Service account name
 {{/*
 MongoDB service account name
 */}}
-{{- define "graylog.mongodb.serviceAccountName" -}}
-{{ $defaultName := "default" }}
+{{- define "graylog.mongodb.serviceAccountName" }}
+{{- $defaultName := "default" }}
 {{- if .Values.mongodb.serviceAccount.create }}
 {{- $defaultName = include "graylog.fullname" . | printf "%s-mongo-sa" }}
 {{- end }}

--- a/charts/graylog/templates/config/init-graylog.yaml
+++ b/charts/graylog/templates/config/init-graylog.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: init-script-cm
+  name: {{ include "graylog.cm.init.name" . }}
 data:
   init-script.sh: |
     #!/bin/sh

--- a/charts/graylog/templates/policy/pdb/datanode.yaml
+++ b/charts/graylog/templates/policy/pdb/datanode.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: graylog-datanode
+  name: {{ include "graylog.fullname" . | printf "%s-pdb-datanode" }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: graylog-datanode

--- a/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
+++ b/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: graylog-forwarder
+  name: {{ include "graylog.fullname" . | printf "%s-forwarder" }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
   {{- with .Values.ingress.forwarder.annotations }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -182,7 +182,7 @@ spec:
       volumes:
       - name: init-script
         configMap:
-          name: init-script-cm
+          name: {{ include "graylog.cm.init.name" . }}
           defaultMode: 0755
       {{- if .Values.graylog.config.tls.enabled }}
       - name: tls-creds


### PR DESCRIPTION
## Summary

Small fix: template release-specific resource names to prevent collisions with existing releases.

## What changed
- Use new helper template for init script ConfigMap name in both `charts/graylog/templates/config/init-graylog.yaml` and `charts/graylog/templates/workload/statefulsets/graylog.yaml`
- Use template in `name` field in `charts/graylog/templates/policy/pdb/datanode.yaml`
- Use template in `name` field in `charts/graylog/templates/service/ingress/graylog-forwarder.yaml`

## Linked issues

This closes #72

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [x] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [x] Web UI accessible and login works
- [x] DataNodes visible in _System > Cluster Configuration_
- [x] Inputs can be created and receive data

### Upgrade (if applicable)
- [x] Upgrade from previous release succeeds
- [x] Scaling up/down works correctly
- [x] Configuration changes apply correctly

### Specific to this PR
- [x] Follow all steps in **"How to reproduce?"** section in linked issue, and verify no errors are encountered.

## Notes for reviewers
- [ ] Verify all tests above pass
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
