### PR TITLE
fix: StatefulSet checksums

### DIFF
--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -546,3 +546,16 @@ Default ingress pathType
 {{- define "graylog.ingress.defaultPathType" }}
 {{- print "ImplementationSpecific" }}
 {{- end }}
+
+{{/*
+Deterministic checksum for a map.
+Sorts keys alphabetically, concatenates values, and returns sha256sum.
+Usage: {{ include "graylog.checksumMap" $mapData }}
+*/}}
+{{- define "graylog.checksumMap" -}}
+{{- $sortedValues := list -}}
+{{- range $key := keys . | sortAlpha -}}
+  {{- $sortedValues = append $sortedValues (index $ $key) -}}
+{{- end -}}
+{{- $sortedValues | join "" | sha256sum -}}
+{{- end -}}

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -546,16 +546,3 @@ Default ingress pathType
 {{- define "graylog.ingress.defaultPathType" }}
 {{- print "ImplementationSpecific" }}
 {{- end }}
-
-{{/*
-Deterministic checksum for a map.
-Sorts keys alphabetically, concatenates values, and returns sha256sum.
-Usage: {{ include "graylog.checksumMap" $mapData }}
-*/}}
-{{- define "graylog.checksumMap" -}}
-{{- $sortedValues := list -}}
-{{- range $key := keys . | sortAlpha -}}
-  {{- $sortedValues = append $sortedValues (index $ $key) -}}
-{{- end -}}
-{{- $sortedValues | join "" | sha256sum -}}
-{{- end -}}

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -546,3 +546,28 @@ Default ingress pathType
 {{- define "graylog.ingress.defaultPathType" }}
 {{- print "ImplementationSpecific" }}
 {{- end }}
+
+{{/*
+Graylog ConfigMap template checksum
+*/}}
+{{- define "graylog.configChecksum" }}
+{{- include (print $.Template.BasePath "/config/graylog.yaml") . | sha256sum }}
+{{- end }}
+
+{{/*
+Datanode ConfigMap template checksum
+*/}}
+{{- define "graylog.datanode.configChecksum" }}
+{{- include (print $.Template.BasePath "/config/datanode.yaml") . | sha256sum }}
+{{- end }}
+
+{{/*
+Secrets template checksum
+Renders the secrets template once and caches the result for consistent checksums
+*/}}
+{{- define "graylog.secretsChecksum" -}}
+{{- if not (index $ "__secretsChecksum") -}}
+  {{- $_ := include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum | set $ "__secretsChecksum" -}}
+{{- end -}}
+{{- index $ "__secretsChecksum" -}}
+{{- end -}}

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -30,8 +30,8 @@ spec:
         app: graylog-datanode
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config/datanode.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include "graylog.datanode.configChecksum" . }}
+        checksum/secret: {{ include "graylog.secretsChecksum" . }}
       {{- with .Values.datanode.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -30,12 +30,10 @@ spec:
         app: graylog-datanode
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
-        {{- $dd := randAlphaNum 5 | dict "data" }}
-        {{- $config := include "graylog.datanode.configmap.name" . | lookup "v1" "ConfigMap" .Release.Namespace | default $dd }}
-        {{- $_ := randAlphaNum 5 | set $dd "data" }}
-        {{- $secret := include "graylog.secretsName" . | lookup "v1" "Secret" .Release.Namespace | default $dd }}
-        checksum/config: {{ $config.data | quote | sha256sum }}
-        checksum/secret: {{ $secret.data | quote | sha256sum }}
+        {{- $config := lookup "v1" "ConfigMap" .Release.Namespace (include "graylog.datanode.configmap.name" .) }}
+        {{- $secret := lookup "v1" "Secret" .Release.Namespace (include "graylog.secretsName" .) }}
+        checksum/config: {{ ternary (include "graylog.checksumMap" $config.data) (include (print $.Template.BasePath "/config/datanode.yaml") . | sha256sum) (not (empty $config)) }}
+        checksum/secret: {{ ternary (include "graylog.checksumMap" $secret.data) (include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum) (not (empty $secret)) }}
       {{- with .Values.datanode.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -30,10 +30,8 @@ spec:
         app: graylog-datanode
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
-        {{- $config := lookup "v1" "ConfigMap" .Release.Namespace (include "graylog.datanode.configmap.name" .) }}
-        {{- $secret := lookup "v1" "Secret" .Release.Namespace (include "graylog.secretsName" .) }}
-        checksum/config: {{ ternary (include "graylog.checksumMap" $config.data) (include (print $.Template.BasePath "/config/datanode.yaml") . | sha256sum) (not (empty $config)) }}
-        checksum/secret: {{ ternary (include "graylog.checksumMap" $secret.data) (include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum) (not (empty $secret)) }}
+        checksum/config: {{ include (print $.Template.BasePath "/config/datanode.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum }}
       {{- with .Values.datanode.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -31,8 +31,8 @@ spec:
         app: graylog-app
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config/graylog.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum }}
+        checksum/config: {{ include "graylog.configChecksum" . }}
+        checksum/secret: {{ include "graylog.secretsChecksum" . }}
       {{- with .Values.graylog.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -31,12 +31,15 @@ spec:
         app: graylog-app
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
-        {{- $dd := randAlphaNum 5 | dict "data" }}
-        {{- $config := include "graylog.configmap.name" . | lookup "v1" "ConfigMap" .Release.Namespace | default $dd  }}
-        {{- $_ := randAlphaNum 5 | set $dd "data" }}
-        {{- $secret := include "graylog.secretsName" . | lookup "v1" "Secret" .Release.Namespace | default $dd  }}
-        checksum/config: {{ $config.data | quote | sha256sum }}
-        checksum/secret: {{ $secret.data | quote | sha256sum }}
+        {{- $random := randAlphaNum 32 | dict "random" }}
+        {{- $config := include "graylog.configmap.name" . | lookup "v1" "ConfigMap" .Release.Namespace }}
+        {{- $secret := include "graylog.secretsName" . | lookup "v1" "Secret" .Release.Namespace }}
+        checksum/config: {{ $config.data | default $random | include "graylog.checksumMap" }}
+        checksum/secret: {{ $secret.data | default $random | include "graylog.checksumMap" }}
+{{/*        {{- $config := lookup "v1" "ConfigMap" .Release.Namespace (include "graylog.configmap.name" .) }}*/}}
+{{/*        {{- $secret := lookup "v1" "Secret" .Release.Namespace (include "graylog.secretsName" .) }}*/}}
+{{/*        checksum/config: {{ ternary (include "graylog.checksumMap" $config.data) (include (print $.Template.BasePath "/config/graylog.yaml") . | sha256sum) (not (empty $config)) }}*/}}
+{{/*        checksum/secret: {{ ternary (include "graylog.checksumMap" $secret.data) (include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum) (not (empty $secret)) }}*/}}
       {{- with .Values.graylog.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -31,15 +31,8 @@ spec:
         app: graylog-app
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
-        {{- $random := randAlphaNum 32 | dict "random" }}
-        {{- $config := include "graylog.configmap.name" . | lookup "v1" "ConfigMap" .Release.Namespace }}
-        {{- $secret := include "graylog.secretsName" . | lookup "v1" "Secret" .Release.Namespace }}
-        checksum/config: {{ $config.data | default $random | include "graylog.checksumMap" }}
-        checksum/secret: {{ $secret.data | default $random | include "graylog.checksumMap" }}
-{{/*        {{- $config := lookup "v1" "ConfigMap" .Release.Namespace (include "graylog.configmap.name" .) }}*/}}
-{{/*        {{- $secret := lookup "v1" "Secret" .Release.Namespace (include "graylog.secretsName" .) }}*/}}
-{{/*        checksum/config: {{ ternary (include "graylog.checksumMap" $config.data) (include (print $.Template.BasePath "/config/graylog.yaml") . | sha256sum) (not (empty $config)) }}*/}}
-{{/*        checksum/secret: {{ ternary (include "graylog.checksumMap" $secret.data) (include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum) (not (empty $secret)) }}*/}}
+        checksum/config: {{ include (print $.Template.BasePath "/config/graylog.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/config/secret/secrets.yaml") . | sha256sum }}
       {{- with .Values.graylog.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
## Summary
Replaces runtime lookup-based checksum generation with template-based checksums for ConfigMaps and Secrets, ensuring consistent checksums during helm template and avoiding issues with cluster lookups (i.e. random checksums causing unnecessary pod restarts on every helm upgrade, even when config/secrets haven't changed).

## Details
  - New helper functions in `_helpers.tpl`:
    - `graylog.configChecksum`: computes sha256sum of the Graylog ConfigMap template
    - `graylog.datanode.configChecksum`: computes sha256sum of the Datanode ConfigMap template
    - `graylog.secretsChecksum`: computes sha256sum of the Secrets template with caching
  - Refactored `graylog.yaml` and `datanode.yaml` StatefulSets:
    - Removed `lookup` function calls and `randAlphaNum` fallback logic
    - Now uses the new helper functions for `checksum/config` and `checksum/secret` annotations

The secrets checksum helper caches its result in the template context (`$.__secretsChecksum`) to prevent regeneration on each call, ensuring both StatefulSets get the same checksum value.

## Linked issues
N/A

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [x] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog`
- [x] Helm tests pass: `helm test graylog`

### Functional (if applicable)
- [x] Web UI accessible and login works
- [x] DataNodes visible in _System > Cluster Configuration_
- [x] Inputs can be created and receive data

### Upgrade (if applicable)
- [x] Upgrade from previous release succeeds
- [x] Scaling up/down works correctly
- [x] Configuration changes apply correctly

### Specific to this PR
For all the following, watch pods using `kubectl get pods -w`:
- [x] Verify that all pods are restarted when the root credentials change:
```sh
helm upgrade graylog ./charts/graylog --reuse-values --set graylog.config.rootPassword=admin
```
- [x] Verify that only `graylog-n` pods are restarted when graylog-specific configurations options are set: `
```sh
helm upgrade graylog ./charts/graylog --reuse-values --set graylog.config.timezone="Europe/Madrid"
```
- [x] Verify that only `graylog-datanode-n` pods are restarted when datanode-specific options are set: `
```sh
helm upgrade graylog ./charts/graylog --reuse-values --set datanode.config.opensearchHeap="3g"
```
- [x] Verify that no pods are restarted when options not related to either the Graylog or DN workloads change:
```sh
helm upgrade graylog ./charts/graylog --reuse-values --set graylog.service.type=LoadBalancer
```
- [x] Verify that all pods are restarted when the MongoDB URL changes:
```sh
helm upgrade graylog ./charts/graylog --reuse-values --set mongodb.replicas=1 --set mongodb.arbiters=0
```

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable