### PR TITLE
Update NOTES.txt

### DIFF
--- a/charts/graylog/templates/NOTES.txt
+++ b/charts/graylog/templates/NOTES.txt
@@ -109,7 +109,7 @@ ADDITIONAL NOTES
 
 · IMPORTANT: You are currently using a randomly generated password: {{ include "graylog.rootPassword" . | quote }}, which will NOT persist across upgrades. Please run the following command to set a persistent password:
 
-    echo "Enter your new password and press return:" && read -s pass && echo "Upgrading helm release {{ squote .Release.Name }}..." && helm upgrade {{ .Release.Name }} ./graylog --namespace {{ .Release.Namespace }} --reuse-values --set "graylog.config.rootPassword=$pass"; unset pass
+    echo "Enter your new password and press return:" && read -s pass && echo "Upgrading helm release {{ squote .Release.Name }}..." && helm upgrade {{ .Release.Name }} graylog/graylog --namespace {{ .Release.Namespace }} --reuse-values --set "graylog.config.rootPassword=$pass"; unset pass
 {{- end }}
 
 · Use the following command to print this status page again:


### PR DESCRIPTION
changed chart path reference from `./graylog` to `graylog/graylog` so it works when users follow our Chart install instructions and add the graylog repo, not using a local downloaded repo in the filesystem

## Summary

Short description of the change.

## What changed
- List of meaningful changes

## Checklist
- [ ] Tests added/updated
- [x] Documentation updated
- [ ] This PR includes a new feature
- [ ] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [ ] `helm lint ./graylog` passes
- [ ] `helm template graylog ./graylog --validate` passes

### Installation
- [ ] Fresh installation completes successfully
- [ ] All pods reach Running state
- [ ] `helm test graylog -n graylog` passes

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in System > Data Nodes
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [ ] _describe what was specifically tested_

## Notes for reviewers
- [ ] Verify all tests pass
- [ ] Sync up with the author before merging
- [ ] The commit history must be preserved - please use the rebase-merge or standard merge options