### PR TITLE
config(security): Updating security context handling

### DIFF
--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -383,10 +383,10 @@ backoffLimit: 2
 activeDeadlineSeconds: 900
 template:
   spec:
+    {{- with index . 3 }}
     securityContext:
-      runAsUser: 1100
-      runAsGroup: 1100
-      fsGroup: 1100
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     containers:
       - name: geoipupdate
         image: maxmindinc/geoipupdate:latest

--- a/charts/graylog/templates/workload/cronjobs/geoip.yaml
+++ b/charts/graylog/templates/workload/cronjobs/geoip.yaml
@@ -15,6 +15,7 @@ data:
 {{- $claimName := printf "%s-%s" (include "graylog.volume.name" .) (include "graylog.fullname" .) }}
 {{- $cronSchedule := .Values.graylog.config.geolocation.maxmindGeoIp.cronSchedule | default "0 0 * * *" }}
 {{- $hookIsEnabled := .Values.graylog.config.geolocation.maxmindGeoIp.postInstallRun | default true }}
+{{- $podSecurityContext := .Values.graylog.podSecurityContext }}
 {{- range $i := include "graylog.replicas" . | default 2 | int | until }}
 ---
 apiVersion: batch/v1
@@ -25,7 +26,7 @@ spec:
   schedule: {{ $cronSchedule }}
   jobTemplate:
     spec:
-      {{- list $geoSecretName $claimName $i | include "graylog.geoip.job.spec" | nindent 6 }}
+      {{- list $geoSecretName $claimName $i $podSecurityContext | include "graylog.geoip.job.spec" | nindent 6 }}
 {{- if $hookIsEnabled }}
 ---
 apiVersion: batch/v1
@@ -37,7 +38,7 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
-{{- list $geoSecretName $claimName $i | include "graylog.geoip.job.spec" | nindent 2 }}
+{{- list $geoSecretName $claimName $i $podSecurityContext | include "graylog.geoip.job.spec" | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -51,10 +51,18 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}
       {{- end }}
+      {{- with .Values.datanode.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: graylog-datanode
           image: {{ include "graylog.datanode.image" . }}
           imagePullPolicy: {{ .Values.datanode.image.imagePullPolicy }}
+          {{- with .Values.datanode.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "graylog.datanode.configmap.name" . }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -52,10 +52,10 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}
       {{- end }}
+      {{- with .Values.graylog.podSecurityContext }}
       securityContext:
-        runAsUser: 1100
-        runAsGroup: 1100
-        fsGroup: 1100
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: copy-data
           image: {{ include "graylog.image" . }}
@@ -106,6 +106,10 @@ spec:
         - name: graylog-app
           image: {{ include "graylog.image" . }}
           imagePullPolicy: {{ .Values.graylog.image.imagePullPolicy }}
+          {{- with .Values.graylog.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -177,6 +177,11 @@ graylog:
   podDisruptionBudget:
     enabled: false
     minAvailable: 1
+  podSecurityContext:
+    runAsUser: 1100
+    runAsGroup: 1100
+    fsGroup: 1100
+  containerSecurityContext: {}
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []
@@ -262,6 +267,10 @@ datanode:
   podDisruptionBudget:
     enabled: false
     minAvailable: 2
+  podSecurityContext:
+    fsGroup: 999
+    fsGroupChangePolicy: "OnRootMismatch"
+  containerSecurityContext: {}
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
## Summary
Adding `podSecurityContext` and `containerSecurityContext` as configurable values for the Graylog app, DataNode, and GeoIP CronJob — allowing clusters enforcing restricted Pod Security Standards.

## What changed
 - Graylog app: refactors the previously hardcoded runAsUser/runAsGroup/fsGroup: 1100 into values.yaml and exposes `containerSecurityContext` for per-container hardening (e.g. capabilities.drop: [ALL]).

  - DataNode: adds pod and container security context support. runAsUser/runAsGroup are intentionally omitted from defaults because the container image starts as root to run chown and setpriv --init-groups before dropping to uid 999 - setting runAsUser at the pod level breaks that flow. Only fsGroup: 999 and fsGroupChangePolicy: OnRootMismatch are defaulted, which handles volume ownership without - interfering with the image's privilege dropping.

  - GeoIP CronJob: passes graylog.podSecurityContext through to the job spec helper
  (graylog.geoip.job.spec) instead of hardcoding runAsUser/runAsGroup/fsGroup: 1100.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] `helm lint ./graylog` passes
- [x] `helm template graylog ./graylog --validate` passes

### Installation
- [x] Fresh installation completes successfully
- [x] All pods reach Running state
- [ ] `helm test graylog -n graylog` passes

### Functional (if applicable)
- [x] Web UI accessible and login works
- [x] DataNodes visible in System > Data Nodes
- [x] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [ ] _describe what was specifically tested_

## Notes for reviewers
- [ ] Verify all tests pass
- [ ] Sync up with the author before merging
- [ ] The commit history must be preserved - please use the rebase-merge or standard merge options