### PR TITLE
Update Helm Tests

### DIFF
--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -167,6 +167,19 @@ Graylog secret name
 {{- end }}
 
 {{/*
+Graylog test credentials secret name
+Returns the existing secret name when global.existingSecretName is set (user must include
+GRAYLOG_ROOT_USERNAME and GRAYLOG_ROOT_PASSWORD keys), otherwise the generated test-credentials secret.
+*/}}
+{{- define "graylog.testCredentialsSecretName" -}}
+{{- if .Values.global.existingSecretName -}}
+{{- .Values.global.existingSecretName -}}
+{{- else -}}
+{{- include "graylog.fullname" . }}-test-credentials
+{{- end -}}
+{{- end }}
+
+{{/*
 Graylog Datanode secret name
 */}}
 {{- define "graylog.datanode.secretsName" -}}

--- a/charts/graylog/templates/tests/test-credentials-secret.yaml
+++ b/charts/graylog/templates/tests/test-credentials-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.graylog.enabled }}
+{{- if and .Values.graylog.enabled (not .Values.global.existingSecretName) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/graylog/templates/tests/test-datanode-registration.yaml
+++ b/charts/graylog/templates/tests/test-datanode-registration.yaml
@@ -58,12 +58,12 @@ spec:
         - name: GRAYLOG_ROOT_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . }}-test-credentials
+              name: {{ include "graylog.testCredentialsSecretName" . }}
               key: GRAYLOG_ROOT_USERNAME
         - name: GRAYLOG_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . }}-test-credentials
+              name: {{ include "graylog.testCredentialsSecretName" . }}
               key: GRAYLOG_ROOT_PASSWORD
   restartPolicy: Never
 {{- end }}

--- a/charts/graylog/templates/tests/test-graylog-cluster-status.yaml
+++ b/charts/graylog/templates/tests/test-graylog-cluster-status.yaml
@@ -45,12 +45,12 @@ spec:
         - name: GRAYLOG_ROOT_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . }}-test-credentials
+              name: {{ include "graylog.testCredentialsSecretName" . }}
               key: GRAYLOG_ROOT_USERNAME
         - name: GRAYLOG_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . }}-test-credentials
+              name: {{ include "graylog.testCredentialsSecretName" . }}
               key: GRAYLOG_ROOT_PASSWORD
   restartPolicy: Never
 {{- end }}

--- a/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
+++ b/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.graylog.enabled }}
+{{- if and .Values.graylog.enabled .Values.mongodb.communityResource.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
## Summary
Helm tests currently expect to be ran with the chart's packaged Mongo, and chart created secrets. This PR skips the Mongo test if it's a BYO Mongo, and uses the `global.existingSecretName` credentials for the other tests, if present.

## What changed
- Minor refactor of how tests are supplied secrets and whether they run.
- `test-mongodb-connectivity.yaml` if we're bringing our own Mongo.
- Utilize the existing secret for credentials if they are present.

I'd be open to a conversation around using the Mongo credentials in the existing secret potentially, if we want to still run the `MongoDB-connectivity` test for BYO mongo setups.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [ ] This PR includes a bugfix
- [x] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] `helm lint ./graylog` passes
- [x] `helm template graylog ./graylog --validate` passes

### Installation
- [x] Fresh installation completes successfully
- [x] All pods reach Running state
- [x] `helm test graylog -n graylog` passes

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in System > Data Nodes
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
 - [x] `helm test` passes with supplied secret

## Notes for reviewers
- [ ] Verify all tests pass
- [ ] Sync up with the author before merging
- [ ] The commit history must be preserved - please use the rebase-merge or standard merge options