### PR TITLE
Update mongo-rs.yaml

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -26,6 +26,8 @@ Official Helm chart for Graylog.
 * [Using External Resources](#using-external-resources)
   * [Managing Secrets Externally](#managing-secrets-externally)
   * [Bring Your Own MongoDB](#bring-your-own-mongodb)
+* [Maintenance](#maintenance)
+  * [Back Up and Restore MongoDB](#back-up-and-restore-mongodb)
 * [Uninstall](#uninstall)
   * [Removing everything](#removing-everything)
 * [Debugging](#debugging)
@@ -426,6 +428,13 @@ helm upgrade --install graylog graylog/graylog --namespace graylog --reuse-value
   --set mongodb.communityResource.enabled=false \
   --set global.existingSecretName="<your secret name>"
 ```
+
+# Maintenance
+
+## Back Up and Restore MongoDB
+
+To take a manual `mongodump` backup of Graylog's MongoDB database and restore it
+with `mongorestore`, see [docs/mongodb-backup-restore.md](../../docs/mongodb-backup-restore.md).
 
 # Uninstall
 ```sh

--- a/charts/graylog/templates/custom/mongo-rs.yaml
+++ b/charts/graylog/templates/custom/mongo-rs.yaml
@@ -30,6 +30,10 @@ spec:
           db: admin
         - name: userAdminAnyDatabase
           db: admin
+        - name: backup
+          db: admin
+        - name: restore
+          db: admin
       scramCredentialsSecretName: {{ include "graylog.mongodb.crName" . | printf "%s-admin" }}
     - name: {{ include "graylog.mongodb.crUsername" . }}
       db: {{ include "graylog.mongodb.crDatabase" . }}

--- a/docs/mongodb-backup-restore.md
+++ b/docs/mongodb-backup-restore.md
@@ -1,0 +1,80 @@
+# Back Up and Restore MongoDB
+
+This guide walks through taking a manual logical backup of Graylog's MongoDB
+database with [`mongodump`](https://www.mongodb.com/docs/database-tools/mongodump/)
+and restoring it with [`mongorestore`](https://www.mongodb.com/docs/database-tools/mongorestore/).
+It applies to the MongoDB replica set deployed by this chart (the default
+[MongoDB Community](https://www.mongodb.com/docs/kubernetes/current/) resource).
+
+> **Note:** These commands assume a release named `graylog` in the `graylog`
+> namespace. Adjust the release name, namespace, and secret name to match your
+> deployment. The connection-string secret is named
+> `<release>-mongo-rs-admin-admin`.
+
+## Prerequisites
+
+- `kubectl` access to the cluster and namespace where Graylog is installed.
+- `jq` installed locally (used to decode the connection secret).
+- Enough disk space for the dump, both inside the temporary pod and — if you
+  copy it out — on your local machine.
+
+## Back up
+
+1. Build an admin connection URI from the secret the MongoDB operator generates.
+   This decodes the standard connection string and rewrites it to authenticate
+   against the `admin` database while targeting the `graylog` database:
+
+   ```sh
+   MONGO_ADMIN_URI=$(kubectl get secret graylog-mongo-rs-admin-admin -n graylog -o jsonpath='{.data}' \
+     | jq -r '.["connectionString.standard"] | @base64d' \
+     | sed 's/admin\?/graylog\?authSource=admin\&/g')
+   ```
+
+2. Launch a throwaway pod with the MongoDB shell/tools image, passing the URI in
+   as an environment variable, and drop into a shell:
+
+   ```sh
+   kubectl run -i -t mongosh --image=alpine/mongosh -n graylog \
+     -e URI="$MONGO_ADMIN_URI" --restart=Never -- ash
+   ```
+
+3. From inside the pod, dump the database to a local directory in the pod:
+
+   ```sh
+   mongodump --uri "$URI" --out ./mongo-backup
+   ```
+
+### (Optional) Copy the backup to your local machine
+
+Run this from your local machine while the `mongosh` pod is still running:
+
+```sh
+kubectl exec mongosh -n graylog -- tar cf - /mongo-backup | tar xf - -C .
+```
+
+## Restore
+
+Restoring requires an admin connection URI for the **target** deployment
+(`$NEW_MONGO_ADMIN_URI`). Build it the same way as the backup URI in step 1,
+using the target cluster's secret.
+
+If the backup directory only exists on your local machine, copy it back into the
+pod first (the reverse of the copy-out step):
+
+```sh
+tar cf - ./mongo-backup | kubectl exec -i mongosh -n graylog -- tar xf - -C /mongo-backup
+```
+
+Then, from inside the `mongosh` pod, restore the `graylog` database:
+
+```sh
+mongorestore --uri "$NEW_MONGO_ADMIN_URI" mongo-backup/graylog
+```
+
+## Clean up
+
+Delete the temporary pod when you are done:
+
+```sh
+kubectl delete pod mongosh -n graylog
+```


### PR DESCRIPTION
## Summary
Add the `backup` and `restore` roles to the mongo `admin` user, allowing it to perform `mongodump` and `mongorestore` operations.

## Details
Added the following values to `~/graylog/templates/custom/mongo-rs.yaml`:
```
spec:
  users:
    - name:
      roles:
        - name: backup
          db: admin
        - name: restore
          db: admin
```
## Linked issues
This fixes the ability for the admin user to perform backups and restores of mongodb.

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [ ] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [ ] _describe what was specifically tested_

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
