### PR TITLE
fix(secrets): Adding graylog-root-sha2 to automatic password generation

### DIFF
--- a/charts/graylog/templates/config/secret/secrets.yaml
+++ b/charts/graylog/templates/config/secret/secrets.yaml
@@ -20,8 +20,10 @@
 {{/* Restore backup */}}
 {{- if $this }}
   {{- $graylogPepper = index $this.data "GRAYLOG_PASSWORD_SECRET" }}
+  {{- $graylogSha = index $this.data "GRAYLOG_ROOT_PASSWORD_SHA2" | default $graylogSha }}
 {{ else if $backup }}
   {{- $graylogPepper = index $backup.data "graylog-secret" }}
+  {{- $graylogSha = index $backup.data "graylog-root-password-sha2" | default $graylogSha }}
 {{- end }}
 {{- if $backup }}
   {{- $mongoRootPassword = index $backup.data "mongodb-root-password" | default $mongoRootPassword }}
@@ -42,6 +44,7 @@ data:
   mongodb-db-password: {{ $mongoDbPassword }}
   {{- end }}
   graylog-secret: {{ $graylogPepper }}
+  graylog-root-password-sha2: {{ $graylogSha }}
 ---
 {{- end }}
 {{- $mongoUri := .Values.graylog.config.mongodb.customUri | default "" }}


### PR DESCRIPTION
## Summary
This PR addresses a bug with the management of auto generated Graylog application secret where `GRAYLOG_ROOT_PASSWORD_SHA2` was not sourced when pulling credentials from a backup

## Details
- List of meaningful technical changes

## Linked issues

https://github.com/Graylog2/graylog-helm/issues/102

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [ ] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [ ] _describe what was specifically tested_

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
