### PR TITLE
sysctl Init datanode init container to set vm.max_map_count

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -40,6 +40,54 @@ Official Helm chart for Graylog.
 - Helm **v3.0+**
 - MongoDB Controllers for Kubernetes Operator **v1.6.1** (required unless a [user-provided MongoDB](#bring-your-own-mongodb) is supplied)
 
+## Prerequisites
+
+### Data Node
+
+#### Kernel Parameter: vm.max_map_count
+
+The Data Node component embeds OpenSearch, which requires the kernel parameter `vm.max_map_count` to be set to at least **262144**. 
+Most cloud-managed Kubernetes clusters (EKS, GKE, AKS) default to **65530**, which will cause the Data Node to fail at startup.
+
+**Check the current value on your cluster nodes:**
+```sh
+sysctl vm.max_map_count
+```
+
+**If the value is less than 262144, you have two options:**
+
+**Option 1: Manual cluster-wide fix (recommended for existing clusters)**
+```sh
+# Run on each node (or via a DaemonSet)
+sudo sysctl -w vm.max_map_count=262144
+
+# Make it permanent
+echo "vm.max_map_count=262144" | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
+```
+
+**Option 2: Automatic fix via Helm (opt-in)**
+Enable the `sysctlInit` container when installing. This runs a privileged init container once during pod startup to set the kernel parameter.
+
+**Values file approach (recommended):**
+```yaml
+# values.yaml
+datanode:
+  sysctlInit:
+    enabled: true
+    vmMaxMapCount: 262144  # optional, defaults to 262144
+```
+
+Then install: `helm install graylog graylog/graylog -n graylog --create-namespace -f values.yaml`
+
+This runs a one-time privileged init container on each Data Node pod to adjust the kernel parameter. The container runs only during startup and does not affect the main application container.
+
+
+The default value is **262144** (the minimum required by OpenSearch). The value must be at least 262144.
+> [!NOTE]
+> This does not retroactively fix nodes that already exist in your cluster; existing nodes must be updated manually.
+
+
 ## External Dependencies
 
 This Helm chart is designed as a turnkey solution for quick demos and proofs of concept,

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -51,6 +51,20 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- if .Values.datanode.sysctlInit.enabled }}
+        - name: sysctl-init
+          image: "{{ .Values.datanode.sysctlInit.image.repository }}:{{ .Values.datanode.sysctlInit.image.tag }}"
+          imagePullPolicy: {{ .Values.datanode.sysctlInit.image.imagePullPolicy | default "IfNotPresent" }}
+          {{- with .Values.datanode.sysctlInit.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - sysctl -w vm.max_map_count={{ .Values.datanode.sysctlInit.vmMaxMapCount }}
+        {{- end }}
       containers:
         - name: graylog-datanode
           image: {{ include "graylog.datanode.image" . }}

--- a/charts/graylog/values.schema.json
+++ b/charts/graylog/values.schema.json
@@ -472,6 +472,26 @@
             }
           }
         },
+        "sysctlInit": {
+          "type": "object",
+          "description": "Optional privileged init container to set vm.max_map_count during pod startup",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": {
+              "type": "object",
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string" },
+                "imagePullPolicy": { "type": "string" }
+              }
+            },
+            "securityContext": {
+              "type": "object",
+              "description": "Container security context"
+            },
+            "vmMaxMapCount": { "type": "integer", "minimum": 262144, "description": "Kernel vm.max_map_count value for OpenSearch (minimum 262144)" }
+          }
+        },
         "updateStrategy": {
           "type": "object",
           "properties": {

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -233,6 +233,15 @@ datanode:
     tag: ""
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
+  sysctlInit:
+    enabled: false
+    image:
+      repository: "busybox"
+      tag: "1.35"
+      imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: true
+    vmMaxMapCount: 262144
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Summary
This addresses review reference `C-05`.

Fix vm.max_map_count kernel parameter requirement for OpenSearch initialization in Data
Node. Implements configurable privileged init container that runs during Data Node pod
startup to set the required kernel parameter. This resolves bootstrap failures on
clusters where the default vm.max_map_count (65530) is below the OpenSearch minimum
(262144).

## Details

- Added sysctlInit block to datanode values with configurable image, securityContext,
and vmMaxMapCount parameter
- Implemented privileged init container in Datanode StatefulSet that runs sysctl -w
vm.max_map_count=<value> during pod startup
- Added comprehensive Prerequisites section to README documenting both manual
cluster-wide fix and automatic opt-in approach via Helm
- Added schema validation for sysctlInit configuration with minimum vmMaxMapCount
constraint of 262144
- Init container is opt-in (disabled by default) to maintain backwards compatibility
- Supports custom image pull secrets via pod-spec inheritance

## Linked issues

This fixes #106

## PR Checklist

Please check the items that apply to your change.

- [x] Tests added/updated
- [x] Documentation updated
- [x] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation

- [x] Linter check passes: helm lint ./charts/graylog
- [x] Helm renders local template successfully: helm template graylog ./charts/graylog
--validate

### Installation

- [x] Fresh installation completes successfully with sysctlInit enabled
- [x] All pods reach Running state with init container completing
- [x] Fresh installation completes successfully with sysctlInit enabled
- [x] All pods reach Running state with init container completing
- [x] Helm tests pass: helm test graylog

### Functional (if applicable)

- [x] Init container successfully sets vm.max_map_count on Data Node pods
- [x] Data Node bootstrap completes without OpenSearch memory mapping errors
- [x] DataNodes visible in System > Cluster Configuration

### Upgrade (if applicable)

- [ ] Upgrade from previous release succeeds with sysctlInit disabled by default
- [ ] Scaling up/down works correctly with init container
- [ ] Configuration changes apply correctly

### Specific to this PR

- [x] Verified privileged init container can set kernel parameter
- [x] Confirmed init container runs during pod startup before main container
- [x] Tested with both opt-in enabled and disabled (default) configurations

## Notes for reviewers

- This is an opt-in feature disabled by default to maintain backwards compatibility
- The init container uses privileged: true to allow kernel parameter modification
- Consider Option B follow-up (DaemonSet approach) if pre-node preparation becomes a requirement
- Documentation includes both manual and automatic remediation options for operators