### PR TITLE
Security Hardening: run DataNode fully non-root

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -432,20 +432,21 @@ helm upgrade --install graylog graylog/graylog --namespace graylog --reuse-value
 
 # Hardened Environments
 
-All workloads run with tightened pod and container security contexts by default (non-root where possible, dropped
-capabilities, and `seccompProfile: RuntimeDefault`). The Graylog application is compliant with the Kubernetes
+All Graylog workloads run with tightened pod and container security contexts by default (non-root, dropped capabilities,
+and `seccompProfile: RuntimeDefault`). Both the Graylog application and the DataNode are compliant with the Kubernetes
 [`restricted` Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 
-Two components cannot yet meet `restricted` and need an exemption if you enforce it:
+> [!NOTE]
+> If you enforce [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) at the
+> `restricted` level and let the chart provision MongoDB, you might need to exempt the MongoDB pods (or
+> [bring your own MongoDB](#bring-your-own-mongodb)). With an external MongoDB, all chart-managed workloads are
+> `restricted`-compliant.
 
-- **DataNode** must currently start as root to prepare its data directory before dropping privileges to a non-root
-  user. We are working on updating the entrypoint upstream to remove this requirement; until then, the DataNode
-  requires the `baseline` level (not `restricted`) or a namespace exemption.
-- **MongoDB**, when provisioned by the MCK operator, runs pods that are not `restricted`-compliant. Either exempt
-  them, or [bring your own MongoDB](#bring-your-own-mongodb) for hardened environments.
-
-If you enforce [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/), set the
-namespace to `baseline` rather than `restricted`, or apply the exemptions above.
+> [!NOTE]
+> The DataNode runs non-root by relying on `fsGroup` for volume ownership and setting `GDN_RUN_AS_NONROOT`, which
+> tells the container entrypoint to skip its root-only privilege-drop path. This requires a DataNode image whose
+> entrypoint supports `GDN_RUN_AS_NONROOT` (graylog-datanode `7.1`+). If you pin an older `datanode.image.tag`,
+> override `datanode.podSecurityContext` and `datanode.containerSecurityContext` to run the container as root.
 
 # Maintenance
 

--- a/charts/graylog/templates/config/datanode.yaml
+++ b/charts/graylog/templates/config/datanode.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "graylog.datanode.configmap.name" . }}
 data:
+  # Required by the datanode entrypoint to take the non-root startup path
+  # (mkdir + chmod instead of chown + setpriv). Ignored when the container
+  # runs as root. See graylog-docker entrypoint.sh (PR #306).
+  GDN_RUN_AS_NONROOT: "true"
   JAVA_OPTS: {{ .Values.datanode.config.javaOpts | quote }}
   GRAYLOG_DATANODE_NODE_ID_FILE: {{ .Values.datanode.config.nodeIdFile | default "/var/lib/graylog-datanode/node-id" | quote }}
   GRAYLOG_DATANODE_OPENSEARCH_HEAP: {{ .Values.datanode.config.opensearchHeap | quote }}

--- a/charts/graylog/tests/datanode_statefulset_test.yaml
+++ b/charts/graylog/tests/datanode_statefulset_test.yaml
@@ -17,6 +17,9 @@ tests:
       - equal:
           path: spec.template.spec.securityContext
           value:
+            runAsUser: 999
+            runAsGroup: 999
+            runAsNonRoot: true
             fsGroup: 999
             fsGroupChangePolicy: "OnRootMismatch"
             seccompProfile:
@@ -31,7 +34,7 @@ tests:
           path: spec.template.spec.securityContext
         template: workload/statefulsets/datanode.yaml
 
-  - it: renders containerSecurityContext with the startup capabilities on the datanode container
+  - it: renders the default non-root containerSecurityContext on the datanode container
     asserts:
       - equal:
           path: spec.template.spec.containers[0].name
@@ -40,10 +43,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext
           value:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID"]
             seccompProfile:
               type: RuntimeDefault
         template: workload/statefulsets/datanode.yaml
@@ -55,3 +58,12 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].securityContext
         template: workload/statefulsets/datanode.yaml
+
+  # The non-root securityContext above only works if the entrypoint takes its
+  # non-root path, which it does when GDN_RUN_AS_NONROOT is set (graylog-docker #306).
+  - it: sets GDN_RUN_AS_NONROOT so the datanode entrypoint takes the non-root path
+    asserts:
+      - equal:
+          path: data.GDN_RUN_AS_NONROOT
+          value: "true"
+        template: config/datanode.yaml

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -286,15 +286,18 @@ datanode:
     enabled: false
     minAvailable: 2
   podSecurityContext:
+    runAsUser: 999
+    runAsGroup: 999
+    runAsNonRoot: true
     fsGroup: 999
     fsGroupChangePolicy: "OnRootMismatch"
     seccompProfile:
       type: RuntimeDefault
   containerSecurityContext:
+    runAsNonRoot: true
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
-      add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID"]
     seccompProfile:
       type: RuntimeDefault
   podAnnotations: {}


### PR DESCRIPTION
> [!IMPORTANT]
> ⚠️ Depends on a released image
> Depends on https://github.com/Graylog2/graylog-docker/pull/306 being merged. It adds support for optionally running the datanode container as non-root. Once merged, this requires a DataNode image whose entrypoint supports `GDN_RUN_AS_NONROOT`. On older images the container must still start as root and override `datanode.podSecurityContext` / `datanode.containerSecurityContext` accordingly.

**Do not merge until graylog-docker #306 has landed in a released image, and confirm the `7.1` version reference** (in the README and commit) matches the actual release.

## Summary
Locks the DataNode down to the same `restricted` posture as the Graylog application: fully non-root, all capabilities dropped. This builds on the security hardening merged in  #100.

## Details
- `datanode.podSecurityContext``: adds `runAsUser: 999`, `runAsGroup: 999`, `runAsNonRoot: true` (keeps `fsGroup: 999` + `OnRootMismatch` + `seccompProfile`).
- `datanode.containerSecurityContext`: drops the entire capability `add` list (`CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`) so it's now `drop: [ALL]` only, plus `runAsNonRoot: true`.
- set `GDN_RUN_AS_NONROOT=tru`e so the entrypoint skips its root-only `chown`/`setpriv` path and relies on `fsGroup` for volume ownership.
- Updates the DataNode unit tests and the README **Hardened Environments** section.

## PR Checklist
Please check the items that apply to your change.

- [x] Tests added/updated
- [x] Documentation updated
- [x] This PR includes a new feature
- [ ] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`
- [x] All unit tests pass: `helm unittest ./charts/graylog`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
  - [ ] Fresh installation completes successfully with new image and default datanode `securityContext`
  - [ ] DataNode pods reach Running state as non-root (uid 999)
  - [ ] DataNodes visible in _System > Data Nodes_
   - [ ] Installation still completes successfully with old image and previously-required datanode `securityContext` (add `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID` capabilities, allow running as root)

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
