### PR TITLE
fix(pdb): require minAvailable < replicas so PodDisruptionBudgets stay satisfiable

### DIFF
--- a/charts/graylog/templates/policy/pdb/datanode.yaml
+++ b/charts/graylog/templates/policy/pdb/datanode.yaml
@@ -1,5 +1,9 @@
-{{- if .Values.datanode.podDisruptionBudget.enabled }}
-{{- if ge (include "graylog.datanode.replicas" . | int) 1 }}
+{{- if and .Values.datanode.enabled .Values.datanode.podDisruptionBudget.enabled }}
+{{- $replicas := include "graylog.datanode.replicas" . | int }}
+{{- $minAvailable := .Values.datanode.podDisruptionBudget.minAvailable | default 2 | int }}
+{{- if ge $minAvailable $replicas }}
+{{- printf "datanode.podDisruptionBudget.minAvailable (%d) must be less than datanode.replicas (%d); otherwise the PodDisruptionBudget permits no voluntary evictions and blocks node drains and autoscaler scale-down." $minAvailable $replicas | fail }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -9,10 +13,9 @@ metadata:
     app: graylog-datanode
     {{- include "graylog.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.datanode.podDisruptionBudget.minAvailable | default 3 | int }}
+  minAvailable: {{ $minAvailable }}
   selector:
     matchLabels:
       app: graylog-datanode
       {{- include "graylog.selectorLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/graylog/templates/policy/pdb/graylog.yaml
+++ b/charts/graylog/templates/policy/pdb/graylog.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.graylog.enabled .Values.graylog.podDisruptionBudget.enabled }}
-{{- if ge (include "graylog.replicas" . | int) 2 }}
+{{- $replicas := include "graylog.replicas" . | int }}
+{{- $minAvailable := .Values.graylog.podDisruptionBudget.minAvailable | default 1 | int }}
+{{- if ge $minAvailable $replicas }}
+{{- printf "graylog.podDisruptionBudget.minAvailable (%d) must be less than graylog.replicas (%d); otherwise the PodDisruptionBudget permits no voluntary evictions and blocks node drains and autoscaler scale-down." $minAvailable $replicas | fail }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -9,10 +13,9 @@ metadata:
     app: graylog-app
     {{- include "graylog.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.graylog.podDisruptionBudget.minAvailable | default 1 | int }}
+  minAvailable: {{ $minAvailable }}
   selector:
     matchLabels:
       app: graylog-app
       {{- include "graylog.selectorLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/graylog/tests/datanode_pdb_test.yaml
+++ b/charts/graylog/tests/datanode_pdb_test.yaml
@@ -1,0 +1,50 @@
+suite: graylog DataNode PodDisruptionBudget
+templates:
+  - policy/pdb/datanode.yaml
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  - it: does not render by default (podDisruptionBudget.enabled is false)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when datanode.enabled is false
+    set:
+      datanode.enabled: false
+      datanode.podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when enabled and minAvailable is below the replica count
+    set:
+      datanode.podDisruptionBudget.enabled: true
+      datanode.replicas: 3
+      datanode.podDisruptionBudget.minAvailable: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: fails when minAvailable equals the replica count
+    set:
+      datanode.podDisruptionBudget.enabled: true
+      datanode.replicas: 2
+      datanode.podDisruptionBudget.minAvailable: 2
+    asserts:
+      - failedTemplate:
+          errorPattern: "must be less than datanode.replicas"
+
+  - it: fails when a single-replica datanode enables the PDB with the default minAvailable
+    set:
+      datanode.podDisruptionBudget.enabled: true
+      datanode.replicas: 1
+    asserts:
+      - failedTemplate:
+          errorPattern: "must be less than datanode.replicas"

--- a/charts/graylog/tests/graylog_pdb_test.yaml
+++ b/charts/graylog/tests/graylog_pdb_test.yaml
@@ -1,0 +1,51 @@
+suite: graylog PodDisruptionBudget
+templates:
+  - policy/pdb/graylog.yaml
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  - it: does not render by default (podDisruptionBudget.enabled is false)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when graylog.enabled is false
+    set:
+      graylog.enabled: false
+      graylog.podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when enabled and minAvailable is below the replica count
+    set:
+      graylog.podDisruptionBudget.enabled: true
+      graylog.replicas: 3
+      graylog.podDisruptionBudget.minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: fails when minAvailable equals the replica count
+    set:
+      graylog.podDisruptionBudget.enabled: true
+      graylog.replicas: 2
+      graylog.podDisruptionBudget.minAvailable: 2
+    asserts:
+      - failedTemplate:
+          errorPattern: "must be less than graylog.replicas"
+
+  - it: fails when minAvailable exceeds the replica count
+    set:
+      graylog.podDisruptionBudget.enabled: true
+      graylog.replicas: 1
+      graylog.podDisruptionBudget.minAvailable: 2
+    asserts:
+      - failedTemplate:
+          errorPattern: "must be less than graylog.replicas"


### PR DESCRIPTION
## Summary
Both PodDisruptionBudgets could render as **unsatisfiable** on small clusters, silently producing `disruptionsAllowed: 0` and blocking every voluntary eviction (`kubectl drain`, node cordon for maintenance, cluster-autoscaler scale-down). The templates rendered a PDB whenever the replica count met a fixed threshold (`datanode >= 1`, `graylog >= 2`) but never compared `minAvailable` to the actual replica count. This enforces the invariant `minAvailable < replicas`, matching the fail-fast idiom the MongoDB template already uses for arbiters.

Example of the broken case (DataNode, default `minAvailable: 2`):

| `datanode.replicas` | `minAvailable` | `disruptionsAllowed` | Result |
|---|---|---|---|
| 1 | 2 | 0 | drains hang forever |
| 2 | 2 | 0 | drains hang forever |
| 3 | 2 | 1 | works |

## Details
- Replace the replica-threshold gate in both PDB templates with a `fail` when `minAvailable >= replicas`, mirroring `custom/mongo-rs.yaml` ("arbiters must be less than replicas"). The error names the misconfigured values.
- Gate the DataNode PDB on `datanode.enabled` (it previously rendered even when the DataNode was disabled).
- Align the DataNode `minAvailable` fallback (`3` -> `2`) with `values.yaml`, so nulling the value no longer silently raises the floor.
- Add helm-unittest coverage for both PDBs (no-render defaults, enabled/satisfiable case, and the fail-fast misconfig cases).

Behavior change: a PDB enabled with `minAvailable >= replicas` now fails at render/install time instead of installing a silently-broken budget — the same surface a bad arbiter count already has.

## Linked issues
No linked issue — surfaced while auditing the chart against the 2025-12 third-party evaluation (which flagged the PDB gating direction; this fixes the underlying `minAvailable`-vs-replicas relationship the gate never validated).

## PR Checklist
Please check the items that apply to your change.

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [x] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [x] `helm unittest ./charts/graylog` passes — 66 tests, incl. 10 new PDB cases
- [x] PDBs render at defaults with satisfiable `minAvailable` (graylog 1/2 replicas, datanode 2/3 replicas)
- [x] Enabling a PDB with `minAvailable >= replicas` fails with a clear message
- [x] DataNode PDB no longer renders when `datanode.enabled=false`

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)