### PR TITLE
fix(ingress): pin default-backend image to busybox:1.38.0

### DIFF
--- a/charts/graylog/templates/workload/fallback.yaml
+++ b/charts/graylog/templates/workload/fallback.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: busybox
-          image: busybox:latest
+          image: busybox:1.38.0
           command: ["httpd", "-f", "-v", "-h", "/home", "-p", "3000", "-h", "/var/www/html", "-c", "/etc/httpd.conf"]
           volumeMounts:
             - name: content


### PR DESCRIPTION
## Summary
The ingress default backend (the static "nodes not ready" waiting page) ran `busybox:latest`. An unpinned tag makes image selection non-reproducible — a chart upgrade or pod reschedule could silently pull a different busybox build. This pins it to a specific release tag, consistent with how the chart pins its other images.

## Details
- `templates/workload/fallback.yaml`: `busybox:latest` → `busybox:1.38.0` (latest stable busybox release; verified as an active tag on Docker Hub).

Kept intentionally minimal: the default backend is a cosmetic, nginx-ingress-only static page, and `ingress.config.defaultBackend.enabled=false` already provides a clean opt-out for environments where `docker.io` is unreachable — so no new values/schema surface was added.

## Linked issues
No linked issue — addresses the "pin fallback image tag" recommendation from the 2025-12 third-party chart evaluation.

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state

### Specific to this PR
- [x] Live install on EKS with `ingress.enabled=true` + `ingress.config.defaultBackend.enabled=true`
- [x] Default-backend pod runs `busybox:1.38.0` (digest `sha256:fd8d9aa6…`), 0 restarts
- [x] httpd serves `/healthz`, `/livez`, `/readyz` → `ok`
- [x] Error page served via the `E404` handler for unmatched routes (default-backend behavior unchanged)

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)