### PR TITLE
feat(datanode): delegate OpenSearch roles across node groups

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -23,6 +23,7 @@ Official Helm chart for Graylog.
   * [Customize deployed Kubernetes resources](#customize-deployed-kubernetes-resources)
   * [Add inputs](#add-inputs)
   * [Enable TLS](#enable-tls)
+  * [Delegate Data Node Roles](#delegate-data-node-roles)
 * [Using External Resources](#using-external-resources)
   * [Managing Secrets Externally](#managing-secrets-externally)
   * [Bring Your Own MongoDB](#bring-your-own-mongodb)
@@ -388,6 +389,25 @@ Use the following paths when enabling the Geo-location processor in the Graylog 
 - Path to the city database: `/usr/share/graylog/data/geolocation/GeoLite2-City.mmdb`
 - Path to the ASN database: `/usr/share/graylog/data/geolocation/GeoLite2-ASN.mmdb`
 
+## Delegate Data Node Roles
+
+By default, every Data Node carries all OpenSearch roles. In larger clusters you can dedicate
+groups of Data Nodes to specific roles (e.g. a dedicated search/warm tier or dedicated
+cluster-manager nodes) via `datanode.roles` and the `datanode.extraNodeGroups` map:
+
+```yaml
+datanode:
+  roles: [cluster_manager, data, ingest, remote_cluster_client]  # primary (hot) tier
+  extraNodeGroups:
+    search:
+      roles: [search]
+      replicas: 2
+```
+
+See the [Data Node Roles & Node Groups guide](https://github.com/Graylog2/graylog-helm/blob/main/docs/datanode-node-roles.md)
+for the full list of roles, guardrails, the search/warm-tier repository requirement, and how to
+migrate an existing installation to use node groups.
+
 # Using External Resources
 
 ## Managing Secrets Externally
@@ -665,6 +685,8 @@ These values affect Graylog, DataNode, and MongoDB.
 |--------------------------------------------------------|-------------------------------------------------|-------------------|
 | `datanode.enabled`                                     | Enable Graylog datanode.                        | `true`            |
 | `datanode.replicas`                                    | Number of datanode replicas.                    | `3`               |
+| `datanode.roles`                                       | OpenSearch roles for the primary node group; empty = Data Node default. [Guide](https://github.com/Graylog2/graylog-helm/blob/main/docs/datanode-node-roles.md). | `[]` |
+| `datanode.extraNodeGroups`                             | Map of additional node groups keyed by name, each inheriting and overriding `datanode.*`. [Guide](https://github.com/Graylog2/graylog-helm/blob/main/docs/datanode-node-roles.md). | `{}` |
 | `datanode.service.ports.api`                           | API communication port.                         | `8999`            |
 | `datanode.service.ports.data`                          | Data communication port.                        | `9200`            |
 | `datanode.service.ports.config`                        | Configuration communication port.               | `9300`            |

--- a/charts/graylog/templates/NOTES.txt
+++ b/charts/graylog/templates/NOTES.txt
@@ -26,6 +26,24 @@ SUMMARY
   volume ownership (e.g. AWS EBS). See the "Hardened Environments" section of the README before opting out.
   {{- end }}
 
+  {{- $repoConfigured := .Values.datanode.config.s3ClientDefaultEndpoint | empty | not }}
+  {{- $dataEligible := false }}
+  {{- $searchNoRepo := list }}
+  {{- range $g := include "graylog.datanode.groups" . | fromYamlArray }}
+  {{- if or (empty $g.roles) (has "data" $g.roles) }}{{- $dataEligible = true }}{{- end }}
+  {{- if and (has "search" $g.roles) (not $repoConfigured) }}{{- $searchNoRepo = append $searchNoRepo ($g.name | default "primary") }}{{- end }}
+  {{- end }}
+  {{- if not $dataEligible }}
+
+  WARNING: no Data Node group is eligible to hold data (every group sets explicit roles and none includes
+  'data'). Indices will have nowhere to be allocated. Add 'data' to datanode.roles or to an extraNodeGroups entry.
+  {{- end }}
+  {{- if $searchNoRepo }}
+
+  WARNING: node group(s) {{ $searchNoRepo | join ", " }} declare the 'search' role but no snapshot repository is
+  configured (datanode.config.s3ClientDefault*). Searchable snapshots / warm tier will not work until one is set.
+  {{- end }}
+
   Use the following command to list all the resources deployed with this release:
 
     helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -299,6 +299,24 @@ have to pass (root, group) dicts around:
 {{- end }}
 
 {{/*
+Validate datanode node-group role coverage. Hard-fails when no group is eligible to be
+a cluster manager (i.e. every group sets explicit roles and none includes
+cluster_manager). A group with empty roles uses the Data Node default, which already
+includes cluster_manager, so the all-defaults install never trips this.
+*/}}
+{{- define "graylog.datanode.validate" -}}
+{{- $manager := false -}}
+{{- range $g := include "graylog.datanode.groups" . | fromYamlArray -}}
+{{- if or (empty $g.roles) (has "cluster_manager" $g.roles) -}}
+{{- $manager = true -}}
+{{- end -}}
+{{- end -}}
+{{- if not $manager -}}
+{{- fail "datanode: no node group is eligible to be a cluster_manager. Add 'cluster_manager' to datanode.roles or to at least one datanode.extraNodeGroups entry's roles." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Graylog Datanode service name (shared across all node groups)
 */}}
 {{- define "graylog.datanode.service.name" -}}

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -86,14 +86,18 @@ MongoDB service account name
 Graylog replicas
 */}}
 {{- define "graylog.replicas" }}
-{{- .Values.graylog.replicas | default 2 | int }}
+{{- .Values.graylog.replicas | int }}
 {{- end }}
 
 {{/*
 Datanode replicas
 */}}
 {{- define "graylog.datanode.replicas" }}
-{{- .Values.datanode.replicas | default 3 | int }}
+{{- $total := 0 }}
+{{- range $group := include "graylog.datanode.groups" . | fromYamlArray }}
+{{- $total = add $total (int $group.replicas) }}
+{{- end }}
+{{- $total }}
 {{- end }}
 
 {{/*
@@ -249,35 +253,71 @@ Graylog data PVC/volume name
 {{- end }}
 
 {{/*
-Graylog Datanode pod prefix
+Normalized Datanode node-group list, returned as a YAML array.
+Parse with: include "graylog.datanode.groups" . | fromYamlArray
+
+The top-level datanode block is the primary group (legacy unsuffixed names); every
+entry in datanode.extraNodeGroups (a map keyed by name) is an additional group that
+inherits the primary's values and overrides only what its value declares. Lists are
+replaced wholesale and an explicit false/0/"" does override a truthy default (e.g. a
+group may set persistence.data.enabled: false).
+
+Each returned group is enriched with derived, ready-to-use fields so templates never
+have to pass (root, group) dicts around:
+  .name, .fullname, .configmapName, .pdbName, .dataStorageClass, .nativeLibsStorageClass
+  .groupLabel  - value for the graylog-datanode-group label; empty unless extra groups
+                 exist (so a plain install keeps today's unlabeled selector).
 */}}
-{{- define "graylog.datanode.name" -}}
-{{- include "graylog.fullname" . | printf "%s-datanode" }}
+{{- define "graylog.datanode.groups" -}}
+{{- $root := . -}}
+{{- $base := omit .Values.datanode "extraNodeGroups" -}}
+{{- $extras := .Values.datanode.extraNodeGroups | default dict -}}
+{{- $multi := gt (len $extras) 0 -}}
+{{- $raw := list (dict "key" "" "spec" (deepCopy $base)) -}}
+{{- range $name, $spec := $extras -}}
+{{- $raw = append $raw (dict "key" $name "spec" (mergeOverwrite (deepCopy $base) (deepCopy ($spec | default dict)))) -}}
+{{- end -}}
+{{- $prefix := printf "%s-datanode" (include "graylog.fullname" $root) -}}
+{{- $pdbPrefix := printf "%s-pdb-datanode" (include "graylog.fullname" $root) -}}
+{{- $provider := include "graylog.provider.storageClassName" $root -}}
+{{- $global := $root.Values.global.storageClass -}}
+{{- $out := list -}}
+{{- range $r := $raw -}}
+{{- $g := $r.spec -}}
+{{- $key := $r.key -}}
+{{- $fullname := $key | empty | ternary $prefix (printf "%s-%s" $prefix $key) -}}
+{{- $_ := set $g "name" $key -}}
+{{- $_ := set $g "fullname" $fullname -}}
+{{- $_ := set $g "configmapName" (printf "%s-config" $fullname) -}}
+{{- $_ := set $g "pdbName" ($key | empty | ternary $pdbPrefix (printf "%s-%s" $pdbPrefix $key)) -}}
+{{- $_ := set $g "groupLabel" ($multi | ternary ($key | empty | ternary "default" $key) "") -}}
+{{- $_ := set $g "dataStorageClass" (coalesce (dig "persistence" "data" "storageClass" "" $g) $global $provider | default "") -}}
+{{- $_ := set $g "nativeLibsStorageClass" (coalesce (dig "persistence" "nativeLibs" "storageClass" "" $g) $global $provider | default "") -}}
+{{- $out = append $out $g -}}
+{{- end -}}
+{{- $out | toYaml -}}
 {{- end }}
 
 {{/*
-Graylog Datanode service name
+Graylog Datanode service name (shared across all node groups)
 */}}
 {{- define "graylog.datanode.service.name" -}}
 {{- include "graylog.fullname" . | printf "%s-datanode-svc" }}
 {{- end }}
 
 {{/*
-Graylog Datanode hosts
+Graylog Datanode discovery seed hosts, spanning every node group.
 */}}
 {{- define "graylog.datanode.hosts" -}}
-{{- $builder := list }}
-{{- range $i := include "graylog.datanode.replicas" . | int | until }}
-{{- $builder = printf "%s-%d.%s.%s.svc.cluster.local" (include "graylog.datanode.name" $) $i (include "graylog.datanode.service.name" $) ($.Release.Namespace) | append $builder }}
-{{- end }}
-{{- join "," $builder | quote }}
-{{- end }}
-
-{{/*
-Datanode configmap name
-*/}}
-{{- define "graylog.datanode.configmap.name" -}}
-{{- include "graylog.fullname" . | printf "%s-datanode-config" }}
+{{- $svc := include "graylog.datanode.service.name" . -}}
+{{- $ns := .Release.Namespace -}}
+{{- $builder := list -}}
+{{- range $g := include "graylog.datanode.groups" . | fromYamlArray -}}
+{{- range $i := until (int $g.replicas) -}}
+{{- $builder = printf "%s-%d.%s.%s.svc.cluster.local" $g.fullname $i $svc $ns | append $builder -}}
+{{- end -}}
+{{- end -}}
+{{- join "," $builder | quote -}}
 {{- end }}
 
 {{/*
@@ -295,20 +335,6 @@ Graylog Storage Class name
 */}}
 {{- define "graylog.storageClassName" }}
 {{- include "graylog.provider.storageClassName" . | coalesce .Values.graylog.persistence.storageClass .Values.global.storageClass | default "" }}
-{{- end }}
-
-{{/*
-Datanode data Storage Class name
-*/}}
-{{- define "graylog.datanode.data.storageClassName" }}
-{{- include "graylog.provider.storageClassName" . | coalesce .Values.datanode.persistence.data.storageClass .Values.global.storageClass | default "" }}
-{{- end }}
-
-{{/*
-Datanode native libs Storage Class name
-*/}}
-{{- define "graylog.datanode.nativeLibs.storageClassName" }}
-{{- include "graylog.provider.storageClassName" . | coalesce .Values.datanode.persistence.nativeLibs.storageClass .Values.global.storageClass | default "" }}
 {{- end }}
 
 {{/*

--- a/charts/graylog/templates/config/datanode.yaml
+++ b/charts/graylog/templates/config/datanode.yaml
@@ -1,20 +1,27 @@
+{{- $c := .Values.datanode.config }}
+{{- $sk := $c.s3ClientDefaultSecretKey }}
+{{- $ak := $c.s3ClientDefaultAccessKey }}
+{{- $endpoint := $c.s3ClientDefaultEndpoint }}
+{{- if or (not $ak | and $sk) (not $endpoint | and $ak) (not $sk | and $endpoint) }}
+  {{ fail "All three values are required: datanode.config.s3ClientDefaultEndpoint, datanode.config.s3ClientDefaultSecretKey, and datanode.config.s3ClientDefaultAccessKey" }}
+{{- end }}
+{{- range include "graylog.datanode.groups" $ | fromYamlArray }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "graylog.datanode.configmap.name" . }}
+  name: {{ .configmapName }}
 data:
-  JAVA_OPTS: {{ .Values.datanode.config.javaOpts | quote }}
-  GRAYLOG_DATANODE_NODE_ID_FILE: {{ .Values.datanode.config.nodeIdFile | default "/var/lib/graylog-datanode/node-id" | quote }}
-  GRAYLOG_DATANODE_OPENSEARCH_HEAP: {{ .Values.datanode.config.opensearchHeap | quote }}
-  GRAYLOG_DATANODE_SKIP_PREFLIGHT_CHECKS: {{ .Values.datanode.config.skipPreflightChecks | quote }}
-  GRAYLOG_DATANODE_NODE_SEARCH_CACHE_SIZE: {{ .Values.datanode.config.nodeSearchCacheSize | quote }}
-  {{- $sk := .Values.datanode.config.s3ClientDefaultSecretKey }}
-  {{- $ak := .Values.datanode.config.s3ClientDefaultAccessKey }}
-  {{- $endpoint := .Values.datanode.config.s3ClientDefaultEndpoint }}
-  {{- if or (not $ak | and $sk) (not $endpoint | and $ak) (not $sk | and $endpoint) }}
-    {{ fail "All three values are required: datanode.config.s3ClientDefaultEndpoint, datanode.config.s3ClientDefaultSecretKey, and datanode.config.s3ClientDefaultAccessKey" }}
+  JAVA_OPTS: {{ .config.javaOpts | quote }}
+  GRAYLOG_DATANODE_NODE_ID_FILE: {{ .config.nodeIdFile | default "/var/lib/graylog-datanode/node-id" | quote }}
+  GRAYLOG_DATANODE_OPENSEARCH_HEAP: {{ .config.opensearchHeap | quote }}
+  GRAYLOG_DATANODE_SKIP_PREFLIGHT_CHECKS: {{ .config.skipPreflightChecks | quote }}
+  GRAYLOG_DATANODE_NODE_SEARCH_CACHE_SIZE: {{ .config.nodeSearchCacheSize | quote }}
+  {{- with .roles }}
+  GRAYLOG_DATANODE_NODE_ROLES: {{ join "," . | quote }}
   {{- end }}
-  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_ENDPOINT: {{ .Values.datanode.config.s3ClientDefaultEndpoint | quote }}
-  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_REGION: {{ .Values.datanode.config.s3ClientDefaultRegion | quote }}
-  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_PROTOCOL: {{ .Values.datanode.config.s3ClientDefaultProtocol | quote }}
-  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_PATH_STYLE_ACCESS: {{ .Values.datanode.config.s3ClientDefaultPathStyleAccess | quote }}
+  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_ENDPOINT: {{ .config.s3ClientDefaultEndpoint | quote }}
+  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_REGION: {{ .config.s3ClientDefaultRegion | quote }}
+  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_PROTOCOL: {{ .config.s3ClientDefaultProtocol | quote }}
+  GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_PATH_STYLE_ACCESS: {{ .config.s3ClientDefaultPathStyleAccess | quote }}
+{{- end }}

--- a/charts/graylog/templates/policy/pdb/datanode.yaml
+++ b/charts/graylog/templates/policy/pdb/datanode.yaml
@@ -1,18 +1,27 @@
 {{- if .Values.datanode.podDisruptionBudget.enabled }}
-{{- if ge (include "graylog.datanode.replicas" . | int) 1 }}
+{{- range include "graylog.datanode.groups" $ | fromYamlArray }}
+{{- if ge (.replicas | int) 1 }}
+---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-pdb-datanode" }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ .pdbName }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: graylog-datanode
-    {{- include "graylog.labels" . | nindent 4 }}
+    {{- with .groupLabel }}
+    graylog-datanode-group: {{ . }}
+    {{- end }}
+    {{- include "graylog.labels" $ | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.datanode.podDisruptionBudget.minAvailable | default 3 | int }}
+  minAvailable: {{ .podDisruptionBudget.minAvailable | default 3 | int }}
   selector:
     matchLabels:
       app: graylog-datanode
-      {{- include "graylog.selectorLabels" . | nindent 6 }}
+      {{- with .groupLabel }}
+      graylog-datanode-group: {{ . }}
+      {{- end }}
+      {{- include "graylog.selectorLabels" $ | nindent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -1,26 +1,34 @@
-{{ if .Values.datanode.enabled  }}
+{{- if .Values.datanode.enabled }}
+{{- range include "graylog.datanode.groups" $ | fromYamlArray }}
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "graylog.datanode.name" . }}
+  name: {{ .fullname }}
   labels:
     app: graylog-datanode
-    {{- include "graylog.labels" . | nindent 4 }}
+    {{- with .groupLabel }}
+    graylog-datanode-group: {{ . }}
+    {{- end }}
+    {{- include "graylog.labels" $ | nindent 4 }}
   annotations:
-    {{- include "graylog.annotations" . | nindent 4 }}
+    {{- include "graylog.annotations" $ | nindent 4 }}
 spec:
-  replicas: {{ include "graylog.datanode.replicas" . | int }}
-  serviceName: {{ include "graylog.datanode.service.name" . }}
+  replicas: {{ .replicas | int }}
+  serviceName: {{ include "graylog.datanode.service.name" $ }}
   selector:
     matchLabels:
       app: graylog-datanode
-      {{- include "graylog.selectorLabels" . | nindent 6 }}
+      {{- with .groupLabel }}
+      graylog-datanode-group: {{ . }}
+      {{- end }}
+      {{- include "graylog.selectorLabels" $ | nindent 6 }}
   updateStrategy:
-    type: {{ .Values.datanode.updateStrategy.type | default "RollingUpdate" | quote }}
-    {{- if .Values.datanode.updateStrategy.type | default "RollingUpdate" | eq "RollingUpdate" }}
+    type: {{ .updateStrategy.type | default "RollingUpdate" | quote }}
+    {{- if .updateStrategy.type | default "RollingUpdate" | eq "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.datanode.updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
-      {{- with .Values.datanode.updateStrategy.rollingUpdate.partition }}
+      maxUnavailable: {{ .updateStrategy.rollingUpdate.maxUnavailable | default 1 }}
+      {{- with .updateStrategy.rollingUpdate.partition }}
       partition: {{ int . }}
       {{- end }}
     {{- end }}
@@ -28,159 +36,163 @@ spec:
     metadata:
       labels:
         app: graylog-datanode
-        {{- include "graylog.selectorLabels" . | nindent 8 }}
+        {{- with .groupLabel }}
+        graylog-datanode-group: {{ . }}
+        {{- end }}
+        {{- include "graylog.selectorLabels" $ | nindent 8 }}
       annotations:
-        checksum/config: {{ include "graylog.datanode.configChecksum" . }}
-        checksum/secret: {{ include "graylog.secretsChecksum" . }}
-      {{- with .Values.datanode.podAnnotations }}
+        checksum/config: {{ include "graylog.datanode.configChecksum" $ }}
+        checksum/secret: {{ include "graylog.secretsChecksum" $ }}
+      {{- with .podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       dnsPolicy: ClusterFirst
-      {{- with .Values.datanode.image.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      {{- with $.Values.datanode.image.imagePullSecrets | default $.Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.datanode.nodeSelector }}
+      {{- with .nodeSelector }}
       nodeSelector: {{ . | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ include "graylog.serviceAccountName" . }}
+      {{- if $.Values.serviceAccount.create }}
+      serviceAccountName: {{ include "graylog.serviceAccountName" $ }}
       {{- end }}
-      {{- with .Values.datanode.podSecurityContext }}
+      {{- with .podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: graylog-datanode
-          image: {{ include "graylog.datanode.image" . }}
-          imagePullPolicy: {{ .Values.datanode.image.imagePullPolicy }}
-          {{- with .Values.datanode.containerSecurityContext }}
+          image: {{ include "graylog.datanode.image" $ }}
+          imagePullPolicy: {{ $.Values.datanode.image.imagePullPolicy }}
+          {{- with .containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           envFrom:
             - configMapRef:
-                name: {{ include "graylog.datanode.configmap.name" . }}
+                name: {{ .configmapName }}
             - secretRef:
-                name: {{ include "graylog.datanode.secretsName" . }}
+                name: {{ include "graylog.datanode.secretsName" $ }}
           env:
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
             - name: GRAYLOG_DATANODE_NODE_NAME
-              value: $(POD_NAME).{{ include "graylog.datanode.service.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
+              value: $(POD_NAME).{{ include "graylog.datanode.service.name" $ }}.{{ $.Release.Namespace }}.svc.cluster.local
             - name: GRAYLOG_DATANODE_OPENSEARCH_DISCOVERY_SEED_HOSTS
-              value: {{ include "graylog.datanode.hosts" . }}
+              value: {{ include "graylog.datanode.hosts" $ }}
             - name: GRAYLOG_DATANODE_PASSWORD_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "graylog.secretsName" . }}
+                  name: {{ include "graylog.secretsName" $ }}
                   key: GRAYLOG_PASSWORD_SECRET
             - name: GRAYLOG_DATANODE_MONGODB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "graylog.secretsName" . }}
+                  name: {{ include "graylog.secretsName" $ }}
                   key: GRAYLOG_MONGODB_URI
-            {{- include "graylog.env" .Values.datanode | indent 12 }}
+            {{- include "graylog.env" . | indent 12 }}
           ports:
             - name: api
-              containerPort: {{ .Values.datanode.service.ports.api | default 8999 | int }}
+              containerPort: {{ .service.ports.api | default 8999 | int }}
               protocol: TCP
             - name: data
-              containerPort: {{ .Values.datanode.service.ports.data | default 9200 | int }}
+              containerPort: {{ .service.ports.data | default 9200 | int }}
               protocol: TCP
             - name: config
-              containerPort: {{ .Values.datanode.service.ports.config | default 9300 | int }}
+              containerPort: {{ .service.ports.config | default 9300 | int }}
               protocol: TCP
           volumeMounts:
             - name: "data"
-              mountPath: {{ .Values.datanode.persistence.data.mountPath | default "/var/lib/graylog-datanode" | quote }}
+              mountPath: {{ .persistence.data.mountPath | default "/var/lib/graylog-datanode" | quote }}
             - name: native-libs
-              mountPath: {{ .Values.datanode.persistence.nativeLibs.mountPath | default "/native_libs" | quote }}
-          {{- if .Values.datanode.livenessProbe.enabled }}
+              mountPath: {{ .persistence.nativeLibs.mountPath | default "/native_libs" | quote }}
+          {{- if .livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
-              port: {{ .Values.datanode.service.ports.api | default 8999 | int }}
-            initialDelaySeconds: {{ .Values.datanode.livenessProbe.initialDelaySeconds | int }}
-            periodSeconds: {{ .Values.datanode.livenessProbe.periodSeconds | int }}
-            timeoutSeconds: {{ .Values.datanode.livenessProbe.timeoutSeconds | int }}
-            failureThreshold: {{ .Values.datanode.livenessProbe.failureThreshold | int }}
-            successThreshold: {{ .Values.datanode.livenessProbe.successThreshold | int }}
+              port: {{ .service.ports.api | default 8999 | int }}
+            initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds | int }}
+            periodSeconds: {{ .livenessProbe.periodSeconds | int }}
+            timeoutSeconds: {{ .livenessProbe.timeoutSeconds | int }}
+            failureThreshold: {{ .livenessProbe.failureThreshold | int }}
+            successThreshold: {{ .livenessProbe.successThreshold | int }}
           {{- end }}
-          {{- if .Values.datanode.readinessProbe.enabled }}
+          {{- if .readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.datanode.service.ports.api | default 8999 | int }}
-            initialDelaySeconds: {{ .Values.datanode.readinessProbe.initialDelaySeconds | int }}
-            periodSeconds: {{ .Values.datanode.readinessProbe.periodSeconds | int }}
-            timeoutSeconds: {{ .Values.datanode.readinessProbe.timeoutSeconds | int }}
-            failureThreshold: {{ .Values.datanode.readinessProbe.failureThreshold | int }}
-            successThreshold: {{ .Values.datanode.readinessProbe.successThreshold | int }}
+              port: {{ .service.ports.api | default 8999 | int }}
+            initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds | int }}
+            periodSeconds: {{ .readinessProbe.periodSeconds | int }}
+            timeoutSeconds: {{ .readinessProbe.timeoutSeconds | int }}
+            failureThreshold: {{ .readinessProbe.failureThreshold | int }}
+            successThreshold: {{ .readinessProbe.successThreshold | int }}
           {{- end }}
-          {{- with .Values.datanode.resources }}
+          {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       tolerations:
-      {{- with .Values.datanode.tolerations }}
+      {{- with .tolerations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       affinity:
-      {{- with .Values.datanode.affinity }}
+      {{- with .affinity }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.datanode.persistence.data.enabled .Values.datanode.persistence.nativeLibs.enabled | not }}
+      {{- if and .persistence.data.enabled .persistence.nativeLibs.enabled | not }}
       volumes:
-        {{- if not .Values.datanode.persistence.nativeLibs.enabled }}
+        {{- if not .persistence.nativeLibs.enabled }}
         - name: native-libs
           emptyDir: {}
         {{- end }}
-        {{- if not .Values.datanode.persistence.data.enabled }}
+        {{- if not .persistence.data.enabled }}
         - name: data
           emptyDir: {}
         {{- end }}
       {{- end }}
-  {{- if or .Values.datanode.persistence.data.enabled .Values.datanode.persistence.nativeLibs.enabled }}
+  {{- if or .persistence.data.enabled .persistence.nativeLibs.enabled }}
   volumeClaimTemplates:
-    {{- if .Values.datanode.persistence.data.enabled }}
+    {{- if .persistence.data.enabled }}
     - metadata:
         name: data
       spec:
         accessModes:
-        {{- if .Values.datanode.persistence.data.accessModes }}
-        {{- range .Values.datanode.persistence.data.accessModes }}
+        {{- if .persistence.data.accessModes }}
+        {{- range .persistence.data.accessModes }}
           - {{ . | quote }}
         {{- end }}
         {{- else }}
           - "ReadWriteOnce"
         {{- end }}
-        {{- with (include "graylog.datanode.data.storageClassName" . ) }}
+        {{- with .dataStorageClass }}
         storageClassName: {{ . | quote }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.datanode.persistence.data.size | default "8Gi" | quote }}
+            storage: {{ .persistence.data.size | default "8Gi" | quote }}
     {{- end }}
-    {{- if .Values.datanode.persistence.nativeLibs.enabled }}
+    {{- if .persistence.nativeLibs.enabled }}
     - metadata:
         name: native-libs
       spec:
         accessModes:
-        {{- if .Values.datanode.persistence.nativeLibs.accessModes }}
-        {{- range .Values.datanode.persistence.nativeLibs.accessModes }}
+        {{- if .persistence.nativeLibs.accessModes }}
+        {{- range .persistence.nativeLibs.accessModes }}
           - {{ . | quote }}
         {{- end }}
         {{- else }}
           - "ReadWriteOnce"
         {{- end }}
-        {{- with (include "graylog.datanode.nativeLibs.storageClassName" . ) }}
+        {{- with .nativeLibsStorageClass }}
         storageClassName: {{ . | quote }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.datanode.persistence.nativeLibs.size | default "8Gi" | quote }}
+            storage: {{ .persistence.nativeLibs.size | default "8Gi" | quote }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.datanode.enabled }}
+{{- include "graylog.datanode.validate" . }}
 {{- range include "graylog.datanode.groups" $ | fromYamlArray }}
 ---
 apiVersion: apps/v1

--- a/charts/graylog/tests/datanode_guardrails_test.yaml
+++ b/charts/graylog/tests/datanode_guardrails_test.yaml
@@ -1,0 +1,78 @@
+suite: datanode node-group guardrails
+templates:
+  # StatefulSet (where the hard-fail validation is included) plus its checksum
+  # dependencies, and NOTES.txt where the soft warnings are emitted.
+  - workload/statefulsets/datanode.yaml
+  - config/datanode.yaml
+  - config/secret/secrets.yaml
+  - NOTES.txt
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  # Hard fail: no cluster_manager-eligible group.
+  - it: renders by default (all-default roles cover cluster_manager)
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: workload/statefulsets/datanode.yaml
+
+  - it: fails when no node group is eligible to be a cluster_manager
+    set:
+      datanode.roles: [data, ingest]
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+    asserts:
+      - failedTemplate:
+          errorMessage: "datanode: no node group is eligible to be a cluster_manager. Add 'cluster_manager' to datanode.roles or to at least one datanode.extraNodeGroups entry's roles."
+        template: workload/statefulsets/datanode.yaml
+
+  - it: does not fail when the primary keeps default roles
+    set:
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+    asserts:
+      - hasDocuments:
+          count: 2
+        template: workload/statefulsets/datanode.yaml
+
+  # Soft warning: no data-eligible group.
+  - it: warns when no node group is eligible to hold data
+    set:
+      datanode.roles: [cluster_manager, ingest]
+    asserts:
+      - matchRegexRaw:
+          pattern: "no Data Node group is eligible to hold data"
+        template: NOTES.txt
+
+  - it: emits no data warning with default roles
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "no Data Node group is eligible to hold data"
+        template: NOTES.txt
+
+  # Soft warning: search role without a snapshot repository.
+  - it: warns when a search group has no snapshot repository
+    set:
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+    asserts:
+      - matchRegexRaw:
+          pattern: "node group\\(s\\) search declare the 'search' role but no snapshot repository"
+        template: NOTES.txt
+
+  - it: emits no search warning when a repository is configured
+    set:
+      datanode.config.s3ClientDefaultEndpoint: "https://s3.example.com"
+      datanode.config.s3ClientDefaultAccessKey: "ak"
+      datanode.config.s3ClientDefaultSecretKey: "sk"
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "declare the 'search' role but no snapshot repository"
+        template: NOTES.txt

--- a/charts/graylog/tests/datanode_statefulset_test.yaml
+++ b/charts/graylog/tests/datanode_statefulset_test.yaml
@@ -7,6 +7,7 @@ templates:
   - workload/statefulsets/datanode.yaml
   - config/datanode.yaml          # checksum/config dependency
   - config/secret/secrets.yaml    # checksum/secret dependency
+  - policy/pdb/datanode.yaml      # node-group PDB coverage
 release:
   name: graylog
   namespace: graylog
@@ -55,3 +56,193 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].securityContext
         template: workload/statefulsets/datanode.yaml
+
+  # ---------------------------------------------------------------------------
+  # Node groups (issue #107): role delegation across dedicated StatefulSets.
+  # The top-level datanode block is the primary group; datanode.extraNodeGroups
+  # (a map keyed by name) adds dedicated groups that inherit and override it.
+  # ---------------------------------------------------------------------------
+
+  # Back-compat: empty extraNodeGroups renders one StatefulSet with the legacy
+  # (unsuffixed) name, no node-group label, and (with roles unset) no node_roles.
+  - it: renders a single legacy-named datanode StatefulSet with no extra groups
+    asserts:
+      - equal:
+          path: metadata.name
+          value: graylog-datanode
+        template: workload/statefulsets/datanode.yaml
+      - notExists:
+          path: metadata.labels['graylog-datanode-group']
+        template: workload/statefulsets/datanode.yaml
+      - notExists:
+          path: data.GRAYLOG_DATANODE_NODE_ROLES
+        template: config/datanode.yaml
+
+  - it: back-compat seed hosts span the default replica count
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: GRAYLOG_DATANODE_OPENSEARCH_DISCOVERY_SEED_HOSTS
+        template: workload/statefulsets/datanode.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "graylog-datanode-0.graylog-datanode-svc.graylog.svc.cluster.local,graylog-datanode-1.graylog-datanode-svc.graylog.svc.cluster.local,graylog-datanode-2.graylog-datanode-svc.graylog.svc.cluster.local"
+        template: workload/statefulsets/datanode.yaml
+
+  - it: emits node_roles on the primary group when datanode.roles is set
+    set:
+      datanode.roles: [cluster_manager, data, ingest, remote_cluster_client]
+    asserts:
+      - equal:
+          path: data.GRAYLOG_DATANODE_NODE_ROLES
+          value: "cluster_manager,data,ingest,remote_cluster_client"
+        template: config/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode-config
+
+  - it: labels the primary group `default` once extra groups exist
+    set:
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+          replicas: 2
+    asserts:
+      - equal:
+          path: metadata.labels['graylog-datanode-group']
+          value: default
+        template: workload/statefulsets/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode
+      - equal:
+          path: spec.selector.matchLabels['graylog-datanode-group']
+          value: default
+        template: workload/statefulsets/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode
+
+  - it: renders a StatefulSet per extra group with suffixed name and group label
+    set:
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+          replicas: 2
+          config:
+            opensearchHeap: "4g"
+    asserts:
+      - equal:
+          path: metadata.labels['graylog-datanode-group']
+          value: search
+        template: workload/statefulsets/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode-search
+      - equal:
+          path: spec.replicas
+          value: 2
+        template: workload/statefulsets/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode-search
+
+  - it: extra group inherits top-level resources it does not override
+    set:
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+          replicas: 2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 5Gi
+        template: workload/statefulsets/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode-search
+
+  - it: emits per-group node_roles and heap in each group's ConfigMap
+    set:
+      datanode.roles: [cluster_manager, data, ingest, remote_cluster_client]
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+          config:
+            opensearchHeap: "3g"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_DATANODE_NODE_ROLES
+          value: "cluster_manager,data,ingest,remote_cluster_client"
+        template: config/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode-config
+      - equal:
+          path: data.GRAYLOG_DATANODE_NODE_ROLES
+          value: "search"
+        template: config/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode-search-config
+      - equal:
+          path: data.GRAYLOG_DATANODE_OPENSEARCH_HEAP
+          value: "3g"
+        template: config/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode-search-config
+
+  - it: seed hosts span the primary and every extra group
+    set:
+      datanode.replicas: 2
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+          replicas: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "graylog-datanode-0.graylog-datanode-svc.graylog.svc.cluster.local,graylog-datanode-1.graylog-datanode-svc.graylog.svc.cluster.local,graylog-datanode-search-0.graylog-datanode-svc.graylog.svc.cluster.local"
+        template: workload/statefulsets/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode
+
+  - it: supports hyphenated extra group names
+    set:
+      datanode.extraNodeGroups:
+        warm-tier:
+          roles: [search]
+          replicas: 1
+    asserts:
+      - equal:
+          path: metadata.labels['graylog-datanode-group']
+          value: warm-tier
+        template: workload/statefulsets/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-datanode-warm-tier
+
+  - it: renders a PDB per group with distinct suffixed names and selectors
+    set:
+      datanode.podDisruptionBudget.enabled: true
+      datanode.extraNodeGroups:
+        search:
+          roles: [search]
+          replicas: 2
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels['graylog-datanode-group']
+          value: default
+        template: policy/pdb/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-pdb-datanode
+      - equal:
+          path: spec.selector.matchLabels['graylog-datanode-group']
+          value: search
+        template: policy/pdb/datanode.yaml
+        documentSelector:
+          path: metadata.name
+          value: graylog-pdb-datanode-search

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -210,11 +210,7 @@ graylog:
 datanode:
   enabled: true
   replicas: 3
-  # OpenSearch roles for this (primary) node group, inherited as the default by every
-  # extraNodeGroups entry. Empty = Data Node default (cluster_manager,data,ingest,
-  # remote_cluster_client, plus search auto-added when a snapshot repo is configured).
-  # Set explicitly to dedicate roles; valid values: cluster_manager, data, ingest,
-  # remote_cluster_client, search.
+  # Empty = default roles: cluster_manager,data,ingest,remote_cluster_client (search is auto-added with a snapshot repo).
   roles: []
   service:
     ports:
@@ -308,21 +304,10 @@ datanode:
   tolerations: []
   affinity: {}
   extraEnv: []
-  # Additional dedicated node groups, keyed by name. Each renders its own StatefulSet
-  # (+ ConfigMap and PDB), inheriting every datanode value above and overriding only what
-  # its entry declares. Use to delegate roles in larger clusters (e.g. a dedicated search
-  # tier). A search group requires a configured snapshot repository (S3 via config above).
-  # Enabling this relabels the primary StatefulSet's selector, which is immutable: the
-  # first time you add a group, the graylog-datanode StatefulSet must be recreated.
   extraNodeGroups: {}
   #  search:
   #    roles: [search]
   #    replicas: 2
-  #    config:
-  #      opensearchHeap: "2g"
-  #    persistence:
-  #      data:
-  #        size: "500Gi"
 # Graylog service account
 serviceAccount:
   create: true

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -210,6 +210,12 @@ graylog:
 datanode:
   enabled: true
   replicas: 3
+  # OpenSearch roles for this (primary) node group, inherited as the default by every
+  # extraNodeGroups entry. Empty = Data Node default (cluster_manager,data,ingest,
+  # remote_cluster_client, plus search auto-added when a snapshot repo is configured).
+  # Set explicitly to dedicate roles; valid values: cluster_manager, data, ingest,
+  # remote_cluster_client, search.
+  roles: []
   service:
     ports:
       api: 8999
@@ -302,7 +308,21 @@ datanode:
   tolerations: []
   affinity: {}
   extraEnv: []
-
+  # Additional dedicated node groups, keyed by name. Each renders its own StatefulSet
+  # (+ ConfigMap and PDB), inheriting every datanode value above and overriding only what
+  # its entry declares. Use to delegate roles in larger clusters (e.g. a dedicated search
+  # tier). A search group requires a configured snapshot repository (S3 via config above).
+  # Enabling this relabels the primary StatefulSet's selector, which is immutable: the
+  # first time you add a group, the graylog-datanode StatefulSet must be recreated.
+  extraNodeGroups: {}
+  #  search:
+  #    roles: [search]
+  #    replicas: 2
+  #    config:
+  #      opensearchHeap: "2g"
+  #    persistence:
+  #      data:
+  #        size: "500Gi"
 # Graylog service account
 serviceAccount:
   create: true

--- a/docs/datanode-node-roles.md
+++ b/docs/datanode-node-roles.md
@@ -1,0 +1,109 @@
+# Data Node Roles & Node Groups
+
+By default, every Graylog Data Node carries all OpenSearch roles. In larger clusters
+you may want to dedicate groups of Data Nodes to specific responsibilities. For example,
+a dedicated `search` (warm) tier, or dedicated cluster-manager nodes.
+
+This chart supports dedicated groups of same-role nodes through **node groups**.
+
+## DataNode Roles
+
+A Data Node's roles map directly to OpenSearch node roles. Valid values:
+
+| Role                    | Responsibility                                                          |
+|-------------------------|-------------------------------------------------------------------------|
+| `cluster_manager`       | Cluster coordination / "control" (master-eligible).                     |
+| `data`                  | Holds index shards.                                                     |
+| `ingest`                | Runs ingest pipelines.                                                  |
+| `remote_cluster_client` | Connects to remote clusters (cross-cluster search).                     |
+| `search`                | Searchable snapshots / warm tier (requires an object store repository). |
+
+If you leave roles unset, the Data Node uses its default set
+(`cluster_manager,data,ingest,remote_cluster_client`, plus `search` is added automatically
+when a snapshot repository is configured).
+
+## Node Groups: the primary group and extra groups
+
+- The top-level `datanode` block is the **primary node group**. `datanode.roles` sets its
+  roles (empty array = the default set above). It renders the `<release>-datanode` StatefulSet.
+- `datanode.extraNodeGroups` is a **map keyed by group name**. Each entry renders its own
+  StatefulSet (`<release>-datanode-<name>`), ConfigMap and PodDisruptionBudget, and
+  **inherits every `datanode.*` value**, overriding only what it declares.
+
+All groups share one headless Service for discovery, and the OpenSearch discovery seed hosts
+span every group, so they form a single cluster.
+
+### Example: hot tier + dedicated search/warm tier
+
+```yaml
+datanode:
+  # Primary = hot tier
+  roles: [cluster_manager, data, ingest, remote_cluster_client]
+  replicas: 3
+  config:
+    opensearchHeap: "4g"
+    # Snapshot repository required for the search role (see Data Tiering docs)
+    s3ClientDefaultEndpoint: "https://s3.us-east-1.amazonaws.com"
+    s3ClientDefaultAccessKey: "…"
+    s3ClientDefaultSecretKey: "…"
+  extraNodeGroups:
+    search:
+      roles: [search]
+      replicas: 2
+      config:
+        opensearchHeap: "2g"
+      persistence:
+        data:
+          size: "500Gi"
+```
+
+The `search` role only does something useful when a snapshot repository is configured. See
+the [Data Tiering / warm tier](https://go2docs.graylog.org/current/setting_up_graylog/create_warm_tier_on_data_node.htm)
+documentation.
+
+## Guardrails
+
+The chart validates role coverage:
+
+- **Hard fail**: the release will not render if no group is eligible to be a `cluster_manager` (i.e. every group sets
+  explicit roles and none includes it).
+- **Warning**: if no group is eligible to hold `data`. Shown in the post-install notes.
+- **Warning**: if a group declares the `search` role but no S3-compatible snapshot repository is configured.
+
+Empty roles fall back to the default set, which includes `cluster_manager` and`data`.
+
+## Migrating an existing installation to node groups
+
+> [!IMPORTANT]
+> Adding `extraNodeGroups` to a running installation relabels the primary StatefulSet's pod
+> selector, and a StatefulSet's `spec.selector` is **immutable**. Patching it in place (a plain
+> `helm upgrade`) is rejected by the API server:
+> `updates to statefulset spec for fields other than 'replicas', … are forbidden`.
+
+Recreate the primary `<release>-datanode` StatefulSet so the upgrade **creates** it (with the new selector) instead of 
+patching it. Delete it *first*, then upgrade, in a single step. The StatefulSet will be absent only momentarily. Its
+PersistentVolumeClaims are **retained**, so data is preserved:
+
+```sh
+kubectl delete statefulset graylog-datanode -n graylog \
+  && helm upgrade graylog graylog/graylog -n graylog -f your-values.yaml
+```
+
+> [!NOTE]
+> The default `kubectl delete` is a cascade delete, so the primary datanode pods are removed
+> and then recreated by the new StatefulSet. Expect one brief restart of those pods (they
+> remount the same `data-<release>-datanode-*` PVCs).
+
+Adding groups while keeping the primary **data-capable** (i.e. roles not narrowed) is **safe**: the primary keeps its
+volumes and cluster state, remains the cluster manager, and the new group's nodes join its cluster.
+
+> [!WARNING]
+> **Do not narrow a node's roles to drop `data` while reusing its data volume.** OpenSearch
+> refuses to start a node that no longer has the `data` role but still has shard data on disk
+> (`node does not have the data role but has shard data … Use 'opensearch-node repurpose'`).
+> If you must repurpose a node, wipe (or `opensearch-node repurpose`) its data PVC first.
+>
+> Converting an existing all-role cluster into dedicated **manager-only** and data tiers
+> replaces the manager quorum and moves data placement at the same time; this is effectively a
+> **rebuild**, not an in-place migration. Plan it as a new cluster (fresh volumes) with
+> snapshots/replicas to preserve data, rather than an upgrade.


### PR DESCRIPTION
This is a first pass at the DataNode roles issue. While **it has been validated against a live EKS cluster**, it has **not been tested thoroughly.**

## Summary
Allow Data Nodes to be dedicated to specific OpenSearch roles so larger clusters can delegate responsibilities (e.g. a dedicated search/warm tier or dedicated cluster-manager nodes) instead of every Data Node carrying all roles.

## Details
- The top-level `datanode` block is now the **primary node group**; `datanode.roles` (default `[]` = Data Node default set of roles) sets its OpenSearch roles and is inherited as the default by extra groups.
- New `datanode.extraNodeGroups` **map** (keyed by group name) — each entry renders its own StatefulSet, ConfigMap and PDB, inheriting every `datanode.*` value and overriding only what it declares. The headless Service and Secret stay shared; discovery seed hosts span all groups so they form a single OpenSearch cluster.
- `graylog.datanode.groups` helper normalizes + enriches each group (fullname, configmap/pdb names, storage classes, group label) so templates iterate with `.`/`$`.
- Group labels (`graylog-datanode-group`) are emitted only when extra groups exist, so a plain install keeps today's unlabeled selector and upgrades in place.
- Guardrails: hard-fail when no group is `cluster_manager`-eligible; NOTES.txt warnings when no group is `data`-eligible or when a `search` group has no snapshot repository configured.
- Dropped the `| default N` fallbacks from `graylog.replicas` / `graylog.datanode.replicas` values.yaml is authoritative; explicit `replicas: 0` is no longer coerced); `graylog.datanode.replicas` now sums across groups.
- Docs: new `docs/datanode-node-roles.md` guide (roles, node groups, guardrails, search-tier repository requirement, flat→groups migration), linked from the README and values reference.

## Linked issues
This fixes #107

## PR Checklist
Please check the items that apply to your change.

- [x] Tests added/updated
- [x] Documentation updated
- [x] This PR includes a new feature
- [ ] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully (verified on EKS with node groups)
- [x] All pods reach Running state
- [x] Helm unit tests pass: `helm unittest charts/graylog` (73 tests)

### Functional (if applicable)
- [x] DataNodes visible / registered (all groups `CONNECTED`/`AVAILABLE`, indexer cluster green)
- [ ] Web UI accessible and login works
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [x] Upgrade from a flat install to node groups succeeds (see below)
- [x] Scaling up/down works correctly

### Specific to this PR
Verified live on EKS (fresh EKS cluster, `provider=aws`):
- **Role delegation:** primary `cluster_manager`-only + a `data,ingest,remote_cluster_client` group. Each pod's generated `opensearch.yml` carried exactly the delegated `node.roles`; the two StatefulSets had **distinct selectors** (no cross-adoption); all datanodes registered in one cluster; indexer health green with 0 unassigned shards.
- **Guardrails:** confirmed the hard-fail blocks a real `helm upgrade --dry-run` when no group is `cluster_manager`-eligible; NOTES warnings render for the no-data / search-without-repo cases.
- **Migration:** enabling `extraNodeGroups` on a running flat install fails an in-place upgrade on the immutable StatefulSet selector; the documented `kubectl delete statefulset graylog-datanode && helm upgrade` recreates it (PVCs retained) and the cluster returns green as one cluster. The role-narrowing / dedicated-manager rebuild caveats are documented in the guide.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
