### PR TITLE
fix: prevent silent MongoDB provisioning failure with existingSecretName (issue #116)

### DIFF
--- a/charts/graylog/templates/config/secret/secrets.yaml
+++ b/charts/graylog/templates/config/secret/secrets.yaml
@@ -4,6 +4,23 @@
   {{- $err = cat $err "Please set it using graylog.config.mongodb.customUri, or provide a global secret override with global.existingSecretName" }}
   {{- fail $err }}
 {{- end }}
+{{/* Validate existingSecretName + communityResource.enabled conflict (C-06) */}}
+{{- if .Values.global.existingSecretName }}
+  {{- if .Values.mongodb.communityResource.enabled }}
+    {{- $msg := "Cannot use global.existingSecretName with mongodb.communityResource.enabled=true." }}
+    {{- $msg = cat $msg "This combination leaves MongoDB credentials undefined (the chart will skip backup secret creation but MongoDB CR will still reference it)." }}
+    {{- $msg = cat $msg "\n\nChoose one of the following instead:" }}
+    {{- $msg = cat $msg "\n\nOption A: External secret + external MongoDB" }}
+    {{- $msg = cat $msg "\n  --set global.existingSecretName=my-secret" }}
+    {{- $msg = cat $msg "\n  --set mongodb.communityResource.enabled=false" }}
+    {{- $msg = cat $msg "\n  --set graylog.config.mongodb.customUri='mongodb://user:pass@host:27017/graylog'" }}
+    {{- $msg = cat $msg "\n\nOption B: Chart-managed secrets + chart-managed MongoDB (default)" }}
+    {{- $msg = cat $msg "\n  Omit global.existingSecretName" }}
+    {{- $msg = cat $msg "\n  --set mongodb.communityResource.enabled=true" }}
+    {{- $msg = cat $msg "\n\nSee examples/values-existing-secret-external-mongodb.yaml for a complete example." }}
+    {{- fail $msg }}
+  {{- end }}
+{{- end }}
 {{- if not .Values.global.existingSecretName -}}
 {{/* Lookup secrets to restore */}}
 {{- $secretName := include "graylog.secretsName" . }}

--- a/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
+++ b/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.graylog.enabled }}
+{{- if and .Values.graylog.enabled .Values.mongodb.communityResource.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/examples/values-existing-secret-external-mongodb.yaml
+++ b/examples/values-existing-secret-external-mongodb.yaml
@@ -1,0 +1,94 @@
+# GitOps Pattern: External Secret + External MongoDB
+#
+# This example demonstrates the correct configuration for users who want to:
+# - Use GitOps (Argo CD / Flux) with externally-managed secrets
+# - Connect to an external/self-managed MongoDB instance
+# - Avoid Helm-managed secret generation and rotation
+#
+# Why this pattern?
+# - Global secrets are managed outside Helm (e.g., via sealed-secrets, external-secrets operator)
+# - MongoDB is managed separately (cloud provider, self-managed cluster, etc.)
+# - Helm only orchestrates the Graylog and Data Node workloads
+#
+# Prerequisites:
+# 1. A secret named "graylog-managed-secret" (or your chosen name) must exist
+#    with the following required keys:
+#    - GRAYLOG_PASSWORD_SECRET: Base64-encoded pepper string (≥64 chars)
+#    - GRAYLOG_ROOT_PASSWORD_SHA2: SHA256 hash of root password
+#    - GRAYLOG_MONGODB_URI: Base64-encoded MongoDB connection string
+#    - GRAYLOG_ROOT_USERNAME: (optional) defaults to "admin" if not provided
+#
+# 2. MongoDB must be running and accessible at the configured connection URI
+#
+# Example secret creation:
+# kubectl create secret generic graylog-managed-secret \
+#   --from-literal=GRAYLOG_PASSWORD_SECRET="$(openssl rand -base64 64)" \
+#   --from-literal=GRAYLOG_ROOT_PASSWORD_SHA2="$(echo -n mypassword | sha256sum | cut -d' ' -f1)" \
+#   --from-literal=GRAYLOG_MONGODB_URI="$(echo -n 'mongodb://graylo[EMAIL_ADDRESS_REDACTED]om:27017/graylog' | base64)" \
+#   --from-literal=GRAYLOG_ROOT_USERNAME="admin"
+#
+
+global:
+  # Point to the externally-managed secret containing all credentials
+  # This secret must exist in the same namespace before installation
+  existingSecretName: graylog-managed-secret
+
+# Disable chart-managed MongoDB
+# When using external MongoDB, set this to false
+mongodb:
+  communityResource:
+    enabled: false
+
+# Configure Graylog to use external MongoDB
+graylog:
+  # The MongoDB connection URI is read from the external secret's GRAYLOG_MONGODB_URI key
+  # You can also override it here if needed (optional):
+  # config:
+  #   mongodb:
+  #     customUri: "mongodb://graylo[EMAIL_ADDRESS_REDACTED]om:27017/graylog"
+
+  # Example: Configure replicas for Graylog
+  replicas: 3
+
+  # Example: Configure resources
+  resources:
+    requests:
+      memory: "2Gi"
+      cpu: "500m"
+    limits:
+      memory: "3Gi"
+      cpu: "1000m"
+
+# Data Node configuration (also uses the external secret)
+datanode:
+  # Example: Configure replicas for Data Node
+  replicas: 3
+
+  # Example: Configure resources for Data Node
+  resources:
+    requests:
+      memory: "2Gi"
+      cpu: "500m"
+    limits:
+      memory: "4Gi"
+      cpu: "1000m"
+
+# Disable MongoDB-specific tests (not applicable when MongoDB is external)
+graylog:
+  enabled: true
+
+# Example: Configure ingress for external access
+ingress:
+  enabled: true
+  ingressClassName: "nginx"
+  web:
+    enabled: true
+    hosts:
+      - host: "graylog.example.com"
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: graylog-tls
+        hosts:
+          - "graylog.example.com"


### PR DESCRIPTION
Resolves #116

  ## Summary
  Adds template-time validation to prevent silent MongoDB provisioning failures when users accidentally combine `global.existingSecretName` with chart-managed MongoDB.

  ## Changes
  - Add fail guard in secrets.yaml to detect dangerous configuration
  - Gate test-mongodb-connectivity hook on chart-managed mode
  - Add comprehensive example for GitOps + external MongoDB pattern

  ## Testing
  - Template renders error immediately when invalid config detected
  - Example values file documented with all prerequisites