### PR TITLE
Fix serviceAccount.automount: false being ignored

### DIFF
--- a/charts/graylog/templates/auth/mongo-sa.yaml
+++ b/charts/graylog/templates/auth/mongo-sa.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.mongodb.serviceAccount.automount | default true }}
+automountServiceAccountToken: {{ if eq (.Values.mongodb.serviceAccount.automount | toString) "false" }}false{{ else }}true{{ end }}
 {{- if empty .Values.mongodb.serviceAccount.role.rules | not | and .Values.mongodb.serviceAccount.role.create }}
 {{- $roleName := include "graylog.mongodb.serviceAccountName" . | printf "%s-role" }}
 ---

--- a/charts/graylog/templates/auth/sa.yaml
+++ b/charts/graylog/templates/auth/sa.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount | default true }}
+automountServiceAccountToken: {{ if eq (.Values.serviceAccount.automount | toString) "false" }}false{{ else }}true{{ end }}
 {{- if empty .Values.serviceAccount.role.rules | not | and .Values.serviceAccount.role.create }}
 {{- $roleName := include "graylog.serviceAccountName" . | printf "%s-role" }}
 ---


### PR DESCRIPTION
## Problem
Setting `serviceAccount.automount: false` had no effect due to a Helm template idiom where `| default true` treats `false` as empty. This is a security issue - token automounting could not be disabled even when explicitly configured.

## Fixes
- https://github.com/Graylog2/graylog-helm/issues/117

## Solution
Replace the `| default true` pattern with explicit string comparison to properly handle false values:
```go
if eq (.Values.serviceAccount.automount | toString) "false" }}false{{ else }}true{{ end }}

Changes

- Fix serviceAccount.automount in auth/sa.yaml
- Fix mongodb.serviceAccount.automount in auth/mongo-sa.yaml

Verification: Tested rendering with automount: false, automount: true, and unset — all produce correct behavior.