### PR TITLE
fix: enforcing safe release name lenghts

### DIFF
--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -31,6 +31,58 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Join a base name and a suffix into a name that always fits the 63-character
+DNS label limit.
+
+The base is truncated to leave room for the suffix, so the suffix survives
+intact. Truncating the joined string instead would eat into the suffix and
+collapse distinct resources onto one name -- with a 62-character base, both
+"<base>-secrets" and "<base>-secrets-datanode" reduce to "<base>", silently
+making two Secrets share a name.
+
+Every derived name in this chart must go through this helper.
+
+Usage:
+  {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "datanode-svc") }}
+*/}}
+{{- define "graylog.name.suffixed" -}}
+{{- $suffix := .suffix | toString -}}
+{{- $base := .base | toString -}}
+{{- $reserve := .reserve | default 0 | int -}}
+{{- /* 62 = the 63-character limit minus the joining hyphen */ -}}
+{{- $room := sub 62 (len $suffix) | int -}}
+{{- $room = sub $room $reserve | int -}}
+{{- if lt $room 1 -}}
+{{- fail (printf "graylog.name.suffixed: suffix %q leaves no room for a base within 63 characters" $suffix) -}}
+{{- end -}}
+{{- printf "%s-%s" ($base | trunc $room | trimSuffix "-") $suffix -}}
+{{- end }}
+
+{{/*
+Characters reserved on any name that Kubernetes extends with a StatefulSet
+ordinal. Pod names are "<statefulset>-<ordinal>" and that whole string is the
+pod hostname, which must be a DNS label of at most 63 characters. Holding back
+4 characters keeps hostnames valid up to 999 replicas.
+
+This is a fixed reserve on purpose: deriving it from the replica count would
+rename the StatefulSet when scaling past 9 or 99, and a StatefulSet name cannot
+be changed in place.
+*/}}
+{{- define "graylog.name.ordinalReserve" -}}4{{- end }}
+
+{{/*
+Graylog StatefulSet name
+
+Kept separate from "graylog.fullname" because this name gains a pod ordinal.
+For every release name short enough to not need truncation the two are
+identical, so this does not rename anything on an existing install.
+*/}}
+{{- define "graylog.statefulset.name" -}}
+{{- $reserve := include "graylog.name.ordinalReserve" . | int -}}
+{{- include "graylog.fullname" . | trunc (sub 63 $reserve | int) | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "graylog.labels" -}}
@@ -148,7 +200,7 @@ Usage:
 Init script ConfigMap name
 */}}
 {{- define "graylog.cm.init.name" }}
-{{- include "graylog.fullname" . | printf "%s-init-cm" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "init-cm") }}
 {{- end }}
 
 {{/*
@@ -157,7 +209,7 @@ Service account name
 {{- define "graylog.serviceAccountName" }}
 {{- $defaultName := "default" }}
 {{- if .Values.serviceAccount.create }}
-{{- $defaultName = include "graylog.fullname" . | printf "%s-sa" | trunc 63 | trimSuffix "-" }}
+{{- $defaultName = include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "sa") }}
 {{- end }}
 {{- .Values.serviceAccount.nameOverride | default $defaultName }}
 {{- end }}
@@ -168,7 +220,7 @@ MongoDB service account name
 {{- define "graylog.mongodb.serviceAccountName" }}
 {{- $defaultName := "default" }}
 {{- if .Values.mongodb.serviceAccount.create }}
-{{- $defaultName = include "graylog.fullname" . | printf "%s-mongo-sa" | trunc 63 | trimSuffix "-" }}
+{{- $defaultName = include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "mongo-sa") }}
 {{- end }}
 {{- .Values.mongodb.serviceAccount.nameOverride | default $defaultName }}
 {{- end }}
@@ -309,7 +361,7 @@ Graylog secret pepper
 Graylog secret name
 */}}
 {{- define "graylog.secretsName" -}}
-{{- $defaultName := include "graylog.fullname" . | printf "%s-secrets" | trunc 63 | trimSuffix "-" }}
+{{- $defaultName := include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "secrets") }}
 {{- if .Values.global.existingSecretName }}
 {{- $defaultName = .Values.global.existingSecretName }}
 {{- end }}
@@ -320,21 +372,21 @@ Graylog secret name
 Graylog Datanode secret name
 */}}
 {{- define "graylog.datanode.secretsName" -}}
-{{- include "graylog.secretsName" . | printf "%s-datanode" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.secretsName" .) "suffix" "datanode") }}
 {{- end }}
 
 {{/*
 Graylog backup-secret name
 */}}
 {{- define "graylog.backupSecretName" -}}
-{{- include "graylog.fullname" . | printf "%s-backup-secret" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "backup-secret") }}
 {{- end }}
 
 {{/*
 MongoDB Community Resource name
 */}}
 {{- define "graylog.mongodb.crName" -}}
-{{- include "graylog.fullname" . | printf "%s-mongo-rs" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "mongo-rs") }}
 {{- end }}
 
 {{/*
@@ -353,6 +405,11 @@ MongoDB Community Resource main database
 
 {{/*
 MongoDB Community Resource Secret name
+
+Deliberately NOT routed through "graylog.name.suffixed". This names a Secret the
+MongoDB Community Operator creates, which the chart then looks up by name. The
+operator builds it as "<cr>-<user>-<db>" without truncating, so shortening it
+here would only make the lookup miss a Secret that does exist.
 */}}
 {{- define "graylog.mongodb.crSecretName" -}}
 {{- $crName := include "graylog.mongodb.crName" . }}
@@ -365,7 +422,7 @@ MongoDB Community Resource Secret name
 Graylog service name
 */}}
 {{- define "graylog.service.name" -}}
-{{- $defaultName := include "graylog.fullname" . | printf "%s-svc" | trunc 63 | trimSuffix "-" }}
+{{- $defaultName := include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "svc") }}
 {{- .Values.graylog.service.nameOverride | default $defaultName }}
 {{- end }}
 
@@ -418,14 +475,14 @@ Always exposed by the service; the forwarder polls it for configuration updates.
 Graylog configmap name
 */}}
 {{- define "graylog.configmap.name" -}}
-{{- include "graylog.fullname" . | printf "%s-config" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "config") }}
 {{- end }}
 
 {{/*
 Graylog data PVC/volume name
 */}}
 {{- define "graylog.volume.name" -}}
-{{- $defaultName := include "graylog.fullname" . | printf "%s-data" | trunc 63 | trimSuffix "-" }}
+{{- $defaultName := include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "data") }}
 {{- .Values.graylog.persistence.volumeNameOverride | default $defaultName }}
 {{- end }}
 
@@ -433,14 +490,14 @@ Graylog data PVC/volume name
 Graylog Datanode pod prefix
 */}}
 {{- define "graylog.datanode.name" -}}
-{{- include "graylog.fullname" . | printf "%s-datanode" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "datanode" "reserve" (include "graylog.name.ordinalReserve" . | int)) }}
 {{- end }}
 
 {{/*
 Graylog Datanode service name
 */}}
 {{- define "graylog.datanode.service.name" -}}
-{{- include "graylog.fullname" . | printf "%s-datanode-svc" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "datanode-svc") }}
 {{- end }}
 
 {{/*
@@ -458,7 +515,7 @@ Graylog Datanode hosts
 Datanode configmap name
 */}}
 {{- define "graylog.datanode.configmap.name" -}}
-{{- include "graylog.fullname" . | printf "%s-datanode-config" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "datanode-config") }}
 {{- end }}
 
 {{/*
@@ -645,7 +702,7 @@ Kept separate from the main Graylog secret so GRAYLOG_ELASTICSEARCH_HOSTS is inj
 even when the user supplies their own secret via global.existingSecretName.
 */}}
 {{- define "graylog.opensearch.secretName" -}}
-{{- include "graylog.fullname" . | printf "%s-opensearch" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "opensearch") }}
 {{- end }}
 
 {{/*
@@ -664,7 +721,7 @@ Provider-defined Storage Class name
 */}}
 {{- define "graylog.provider.storageClassName" }}
 {{- $names := dict }}
-{{- $_ := include "graylog.fullname" . | printf "%s-gp3" | trunc 63 | trimSuffix "-" | set $names "aws" -}}
+{{- $_ := include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "gp3") | set $names "aws" -}}
 {{/* add more entries here */}}
 {{- .Values.provider | default "" | get $names }}
 {{- end }}
@@ -865,28 +922,28 @@ Graylog Java Options
 Ingress name
 */}}
 {{- define "graylog.ingress.web.name" }}
-{{- include "graylog.fullname" . | printf "%s-web" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "web") }}
 {{- end }}
 
 {{/*
 Forwarder message channel ingress name
 */}}
 {{- define "graylog.ingress.forwarder.message.name" }}
-{{- include "graylog.fullname" . | printf "%s-forwarder-message-channel" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "forwarder-message-channel") }}
 {{- end }}
 
 {{/*
 Forwarder configuration channel ingress name
 */}}
 {{- define "graylog.ingress.forwarder.config.name" }}
-{{- include "graylog.fullname" . | printf "%s-forwarder-config-channel" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "forwarder-config-channel") }}
 {{- end }}
 
 {{/*
 Cert-manager issuer name
 */}}
 {{- define "graylog.cert-manager.issuer.name" }}
-{{- include "graylog.fullname" . | printf "%s-letsencrypt" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "letsencrypt") }}
 {{- end }}
 
 {{/*
@@ -911,7 +968,7 @@ Usage: if (include "cert-manager.issuer.exists.any" . | eq "true") ...
 Fallback service/deployment name
 */}}
 {{- define "graylog.fallback.name" }}
-{{- include "graylog.fullname" . | printf "%s-waiting-room" | trunc 63 | trimSuffix "-" }}
+{{- include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "waiting-room") }}
 {{- end }}
 
 {{/*

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -57,7 +57,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Init script ConfigMap name
 */}}
 {{- define "graylog.cm.init.name" }}
-{{- include "graylog.fullname" . | printf "%s-init-cm" }}
+{{- include "graylog.fullname" . | printf "%s-init-cm" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -66,7 +66,7 @@ Service account name
 {{- define "graylog.serviceAccountName" }}
 {{- $defaultName := "default" }}
 {{- if .Values.serviceAccount.create }}
-{{- $defaultName = include "graylog.fullname" . | printf "%s-sa" }}
+{{- $defaultName = include "graylog.fullname" . | printf "%s-sa" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- .Values.serviceAccount.nameOverride | default $defaultName }}
 {{- end }}
@@ -77,7 +77,7 @@ MongoDB service account name
 {{- define "graylog.mongodb.serviceAccountName" }}
 {{- $defaultName := "default" }}
 {{- if .Values.mongodb.serviceAccount.create }}
-{{- $defaultName = include "graylog.fullname" . | printf "%s-mongo-sa" }}
+{{- $defaultName = include "graylog.fullname" . | printf "%s-mongo-sa" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- .Values.mongodb.serviceAccount.nameOverride | default $defaultName }}
 {{- end }}
@@ -195,7 +195,7 @@ Graylog secret pepper
 Graylog secret name
 */}}
 {{- define "graylog.secretsName" -}}
-{{- $defaultName := include "graylog.fullname" . | printf "%s-secrets" }}
+{{- $defaultName := include "graylog.fullname" . | printf "%s-secrets" | trunc 63 | trimSuffix "-" }}
 {{- if .Values.global.existingSecretName }}
 {{- $defaultName = .Values.global.existingSecretName }}
 {{- end }}
@@ -206,21 +206,21 @@ Graylog secret name
 Graylog Datanode secret name
 */}}
 {{- define "graylog.datanode.secretsName" -}}
-{{- include "graylog.secretsName" . | printf "%s-datanode" }}
+{{- include "graylog.secretsName" . | printf "%s-datanode" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Graylog backup-secret name
 */}}
 {{- define "graylog.backupSecretName" -}}
-{{- include "graylog.fullname" . | printf "%s-backup-secret" }}
+{{- include "graylog.fullname" . | printf "%s-backup-secret" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 MongoDB Community Resource name
 */}}
 {{- define "graylog.mongodb.crName" -}}
-{{- include "graylog.fullname" . | printf "%s-mongo-rs" }}
+{{- include "graylog.fullname" . | printf "%s-mongo-rs" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -251,7 +251,7 @@ MongoDB Community Resource Secret name
 Graylog service name
 */}}
 {{- define "graylog.service.name" -}}
-{{- $defaultName := include "graylog.fullname" . | printf "%s-svc" }}
+{{- $defaultName := include "graylog.fullname" . | printf "%s-svc" | trunc 63 | trimSuffix "-" }}
 {{- .Values.graylog.service.nameOverride | default $defaultName }}
 {{- end }}
 
@@ -266,14 +266,14 @@ Graylog service app port
 Graylog configmap name
 */}}
 {{- define "graylog.configmap.name" -}}
-{{- include "graylog.fullname" . | printf "%s-config" }}
+{{- include "graylog.fullname" . | printf "%s-config" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Graylog data PVC/volume name
 */}}
 {{- define "graylog.volume.name" -}}
-{{- $defaultName := include "graylog.fullname" . | printf "%s-data" }}
+{{- $defaultName := include "graylog.fullname" . | printf "%s-data" | trunc 63 | trimSuffix "-" }}
 {{- .Values.graylog.persistence.volumeNameOverride | default $defaultName }}
 {{- end }}
 
@@ -281,14 +281,14 @@ Graylog data PVC/volume name
 Graylog Datanode pod prefix
 */}}
 {{- define "graylog.datanode.name" -}}
-{{- include "graylog.fullname" . | printf "%s-datanode" }}
+{{- include "graylog.fullname" . | printf "%s-datanode" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Graylog Datanode service name
 */}}
 {{- define "graylog.datanode.service.name" -}}
-{{- include "graylog.fullname" . | printf "%s-datanode-svc" }}
+{{- include "graylog.fullname" . | printf "%s-datanode-svc" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -306,7 +306,7 @@ Graylog Datanode hosts
 Datanode configmap name
 */}}
 {{- define "graylog.datanode.configmap.name" -}}
-{{- include "graylog.fullname" . | printf "%s-datanode-config" }}
+{{- include "graylog.fullname" . | printf "%s-datanode-config" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -314,7 +314,7 @@ Provider-defined Storage Class name
 */}}
 {{- define "graylog.provider.storageClassName" }}
 {{- $names := dict }}
-{{- $_ := include "graylog.fullname" . | printf "%s-gp3" | set $names "aws" -}}
+{{- $_ := include "graylog.fullname" . | printf "%s-gp3" | trunc 63 | trimSuffix "-" | set $names "aws" -}}
 {{/* add more entries here */}}
 {{- .Values.provider | default "" | get $names }}
 {{- end }}
@@ -498,14 +498,14 @@ Graylog Java Options
 Ingress name
 */}}
 {{- define "graylog.ingress.web.name" }}
-{{- include "graylog.fullname" . | printf "%s-web" }}
+{{- include "graylog.fullname" . | printf "%s-web" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Cert-manager issuer name
 */}}
 {{- define "graylog.cert-manager.issuer.name" }}
-{{- include "graylog.fullname" . | printf "%s-letsencrypt" }}
+{{- include "graylog.fullname" . | printf "%s-letsencrypt" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/charts/graylog/templates/auth/mongo-sa.yaml
+++ b/charts/graylog/templates/auth/mongo-sa.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 automountServiceAccountToken: {{ if eq (.Values.mongodb.serviceAccount.automount | toString) "false" }}false{{ else }}true{{ end }}
 {{- if empty .Values.mongodb.serviceAccount.role.rules | not | and .Values.mongodb.serviceAccount.role.create }}
-{{- $roleName := include "graylog.mongodb.serviceAccountName" . | printf "%s-role" }}
+{{- $roleName := include "graylog.mongodb.serviceAccountName" . | printf "%s-role" | trunc 63 | trimSuffix "-" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -22,7 +22,7 @@ rules: {{ .Values.mongodb.serviceAccount.role.rules | toYaml | nindent 2 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "graylog.mongodb.serviceAccountName" . | printf "%s-rb" }}
+  name: {{ include "graylog.mongodb.serviceAccountName" . | printf "%s-rb" | trunc 63 | trimSuffix "-" }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "graylog.mongodb.serviceAccountName" . }}

--- a/charts/graylog/templates/auth/mongo-sa.yaml
+++ b/charts/graylog/templates/auth/mongo-sa.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.serviceAccount.annotations "indent" 2) }}
 automountServiceAccountToken: {{ if eq (.Values.mongodb.serviceAccount.automount | toString) "false" }}false{{ else }}true{{ end }}
 {{- if empty .Values.mongodb.serviceAccount.role.rules | not | and .Values.mongodb.serviceAccount.role.create }}
-{{- $roleName := include "graylog.mongodb.serviceAccountName" . | printf "%s-role" | trunc 63 | trimSuffix "-" }}
+{{- $roleName := include "graylog.name.suffixed" (dict "base" (include "graylog.mongodb.serviceAccountName" .) "suffix" "role") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -20,7 +20,7 @@ rules: {{ .Values.mongodb.serviceAccount.role.rules | toYaml | nindent 2 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "graylog.mongodb.serviceAccountName" . | printf "%s-rb" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.mongodb.serviceAccountName" .) "suffix" "rb") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.serviceAccount.role.labels "indent" 2) }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.serviceAccount.role.annotations "indent" 2) }}
 subjects:

--- a/charts/graylog/templates/auth/sa.yaml
+++ b/charts/graylog/templates/auth/sa.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 automountServiceAccountToken: {{ dig "automount" true .Values.serviceAccount }}
 {{- if empty .Values.serviceAccount.role.rules | not | and .Values.serviceAccount.role.create }}
-{{- $roleName := include "graylog.serviceAccountName" . | printf "%s-role" }}
+{{- $roleName := include "graylog.serviceAccountName" . | printf "%s-role" | trunc 63 | trimSuffix "-" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -22,7 +22,7 @@ rules: {{ .Values.serviceAccount.role.rules | toYaml | nindent 2 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "graylog.serviceAccountName" . | printf "%s-rb" }}
+  name: {{ include "graylog.serviceAccountName" . | printf "%s-rb" | trunc 63 | trimSuffix "-" }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "graylog.serviceAccountName" . }}

--- a/charts/graylog/templates/auth/sa.yaml
+++ b/charts/graylog/templates/auth/sa.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.serviceAccount.annotations "indent" 2) }}
 automountServiceAccountToken: {{ dig "automount" true .Values.serviceAccount }}
 {{- if empty .Values.serviceAccount.role.rules | not | and .Values.serviceAccount.role.create }}
-{{- $roleName := include "graylog.serviceAccountName" . | printf "%s-role" | trunc 63 | trimSuffix "-" }}
+{{- $roleName := include "graylog.name.suffixed" (dict "base" (include "graylog.serviceAccountName" .) "suffix" "role") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -20,7 +20,7 @@ rules: {{ .Values.serviceAccount.role.rules | toYaml | nindent 2 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "graylog.serviceAccountName" . | printf "%s-rb" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.serviceAccountName" .) "suffix" "rb") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.serviceAccount.role.labels "indent" 2) }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.serviceAccount.role.annotations "indent" 2) }}
 subjects:

--- a/charts/graylog/templates/config/fallback.yaml
+++ b/charts/graylog/templates/config/fallback.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "graylog.fallback.name" . | printf "%s-config" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fallback.name" .) "suffix" "config") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "fixed" (dict "app.kubernetes.io/component" "default-backend") "indent" 2) }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "indent" 2) }}
 data:
@@ -14,7 +14,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "graylog.fallback.name" . | printf "%s-content" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fallback.name" .) "suffix" "content") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "fixed" (dict "app.kubernetes.io/component" "default-backend") "indent" 2) }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "indent" 2) }}
 data:

--- a/charts/graylog/templates/config/geoip-sidecar-entrypoint.yaml
+++ b/charts/graylog/templates/config/geoip-sidecar-entrypoint.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "graylog.fullname" . }}-geoip-entrypoint
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "geoip-entrypoint") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app" "graylog-app") "indent" 2) }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "indent" 2) }}
 data:

--- a/charts/graylog/templates/custom/issuer.yaml
+++ b/charts/graylog/templates/custom/issuer.yaml
@@ -17,7 +17,7 @@ spec:
   acme:
     server: {{ .Values.ingress.config.tls.issuer.managed.staging | ternary "-staging" "" | printf "https://acme%s-v02.api.letsencrypt.org/directory" }}
     privateKeySecretRef:
-      name: {{ include "graylog.fullname" . | printf "%s-acme-pk" }}
+      name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "acme-pk") }}
     solvers:
       - http01:
           ingress:

--- a/charts/graylog/templates/custom/mongo-rs.yaml
+++ b/charts/graylog/templates/custom/mongo-rs.yaml
@@ -44,7 +44,7 @@ spec:
           db: admin
         - name: restore
           db: admin
-      scramCredentialsSecretName: {{ include "graylog.mongodb.crName" . | printf "%s-admin" }}
+      scramCredentialsSecretName: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.mongodb.crName" .) "suffix" "admin") }}
     - name: {{ include "graylog.mongodb.crUsername" . }}
       db: {{ include "graylog.mongodb.crDatabase" . }}
       passwordSecretRef:
@@ -53,7 +53,7 @@ spec:
       roles:
         - name: readWrite
           db: {{ include "graylog.mongodb.crDatabase" . }}
-      scramCredentialsSecretName: {{ printf "%s-%s" (include "graylog.mongodb.crName" .) (include "graylog.mongodb.crUsername" .) }}
+      scramCredentialsSecretName: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.mongodb.crName" .) "suffix" (include "graylog.mongodb.crUsername" .)) }}
   statefulSet:
     spec:
       template:
@@ -85,7 +85,7 @@ spec:
                         # The MongoDB Community operator is the only thing that labels
                         # these pods, and it sets `app: <service name>` and nothing else.
                         # The chart's own labels are not present here.
-                        app: {{ include "graylog.mongodb.crName" . | printf "%s-svc" }}
+                        app: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.mongodb.crName" .) "suffix" "svc") }}
                     topologyKey: kubernetes.io/hostname
       volumeClaimTemplates:
         - metadata:

--- a/charts/graylog/templates/policy/pdb/datanode.yaml
+++ b/charts/graylog/templates/policy/pdb/datanode.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-pdb-datanode" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "pdb-datanode") }}
   namespace: {{ .Release.Namespace }}
   {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.podDisruptionBudget.labels "fixed" (dict "app.kubernetes.io/component" "datanode" "app" "graylog-datanode") "indent" 2) }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.podDisruptionBudget.annotations "indent" 2) }}

--- a/charts/graylog/templates/policy/pdb/graylog.yaml
+++ b/charts/graylog/templates/policy/pdb/graylog.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-pdb" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "pdb") }}
   namespace: {{ .Release.Namespace }}
   {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.podDisruptionBudget.labels "fixed" (dict "app.kubernetes.io/component" "server" "app" "graylog-app") "indent" 2) }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.podDisruptionBudget.annotations "indent" 2) }}

--- a/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
+++ b/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
@@ -37,7 +37,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName | default (include "graylog.fullname" $root | printf "%s-tls") }}
+      secretName: {{ .secretName | default (include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" $root) "suffix" "tls")) }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/graylog/templates/service/ingress/graylog.yaml
+++ b/charts/graylog/templates/service/ingress/graylog.yaml
@@ -40,7 +40,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName | default (include "graylog.fullname" $ | printf "%s-tls") }}
+      secretName: {{ .secretName | default (include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" $) "suffix" "tls")) }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/graylog/templates/tests/test-credentials-secret.yaml
+++ b/charts/graylog/templates/tests/test-credentials-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-credentials") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
   {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-weight" "-5" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed" }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}

--- a/charts/graylog/templates/tests/test-credentials-secret.yaml
+++ b/charts/graylog/templates/tests/test-credentials-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "graylog.fullname" . }}-test-credentials
+  name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:

--- a/charts/graylog/templates/tests/test-datanode-registration.yaml
+++ b/charts/graylog/templates/tests/test-datanode-registration.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-test-datanode-registration" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-datanode-registration") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
   {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}
@@ -56,12 +56,12 @@ spec:
         - name: GRAYLOG_ROOT_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
+              name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-credentials") }}
               key: GRAYLOG_ROOT_USERNAME
         - name: GRAYLOG_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
+              name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-credentials") }}
               key: GRAYLOG_ROOT_PASSWORD
   restartPolicy: Never
 {{- end }}

--- a/charts/graylog/templates/tests/test-datanode-registration.yaml
+++ b/charts/graylog/templates/tests/test-datanode-registration.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graylog.fullname" . }}-test-datanode-registration
+  name: {{ include "graylog.fullname" . | printf "%s-test-datanode-registration" | trunc 63 | trimSuffix "-" }} | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:
@@ -58,12 +58,12 @@ spec:
         - name: GRAYLOG_ROOT_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . }}-test-credentials
+              name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
               key: GRAYLOG_ROOT_USERNAME
         - name: GRAYLOG_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . }}-test-credentials
+              name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
               key: GRAYLOG_ROOT_PASSWORD
   restartPolicy: Never
 {{- end }}

--- a/charts/graylog/templates/tests/test-graylog-api-health.yaml
+++ b/charts/graylog/templates/tests/test-graylog-api-health.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graylog.fullname" . }}-test-api-health
+  name: {{ include "graylog.fullname" . | printf "%s-test-api-health" | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:

--- a/charts/graylog/templates/tests/test-graylog-api-health.yaml
+++ b/charts/graylog/templates/tests/test-graylog-api-health.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-test-api-health" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-api-health") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
   {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}

--- a/charts/graylog/templates/tests/test-graylog-cluster-status.yaml
+++ b/charts/graylog/templates/tests/test-graylog-cluster-status.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graylog.fullname" . }}-test-cluster-status
+  name: {{ include "graylog.fullname" . | printf "%s-test-cluster-status" | trunc 63 | trimSuffix "-" }} | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:
@@ -45,12 +45,12 @@ spec:
         - name: GRAYLOG_ROOT_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . }}-test-credentials
+              name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
               key: GRAYLOG_ROOT_USERNAME
         - name: GRAYLOG_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . }}-test-credentials
+              name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
               key: GRAYLOG_ROOT_PASSWORD
   restartPolicy: Never
 {{- end }}

--- a/charts/graylog/templates/tests/test-graylog-cluster-status.yaml
+++ b/charts/graylog/templates/tests/test-graylog-cluster-status.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-test-cluster-status" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-cluster-status") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
   {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}
@@ -43,12 +43,12 @@ spec:
         - name: GRAYLOG_ROOT_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
+              name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-credentials") }}
               key: GRAYLOG_ROOT_USERNAME
         - name: GRAYLOG_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ include "graylog.fullname" . | printf "%s-test-credentials" | trunc 63 | trimSuffix "-" }}
+              name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-credentials") }}
               key: GRAYLOG_ROOT_PASSWORD
   restartPolicy: Never
 {{- end }}

--- a/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
+++ b/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-test-mongodb" | trunc 63 | trimSuffix "-" }}
+  name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "test-mongodb") }}
   {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
   {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}

--- a/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
+++ b/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graylog.fullname" . }}-test-mongodb
+  name: {{ include "graylog.fullname" . | printf "%s-test-mongodb" | trunc 63 | trimSuffix "-" }} | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:

--- a/charts/graylog/templates/workload/fallback.yaml
+++ b/charts/graylog/templates/workload/fallback.yaml
@@ -40,8 +40,8 @@ spec:
       volumes:
         - name: content
           configMap:
-            name: {{ include "graylog.fallback.name" . | printf "%s-content" }}
+            name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fallback.name" .) "suffix" "content") }}
         - name: config
           configMap:
-            name: {{ include "graylog.fallback.name" . | printf "%s-config" }}
+            name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fallback.name" .) "suffix" "config") }}
 {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "graylog.fullname" . }}
+  name: {{ include "graylog.statefulset.name" . }}
   {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app" "graylog-app" "app.kubernetes.io/component" "server") "indent" 2) }}
   {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "indent" 2) }}
 spec:
@@ -276,7 +276,7 @@ spec:
       {{- if and .Values.graylog.config.geolocation.enabled .Values.graylog.config.geolocation.sidecar.enabled }}
       - name: geoip-entrypoint
         configMap:
-          name: {{ include "graylog.fullname" . }}-geoip-entrypoint
+          name: {{ include "graylog.name.suffixed" (dict "base" (include "graylog.fullname" .) "suffix" "geoip-entrypoint") }}
           defaultMode: 0755
       - name: geoip-tmp
         emptyDir: {}

--- a/charts/graylog/tests/name_length_test.yaml
+++ b/charts/graylog/tests/name_length_test.yaml
@@ -1,0 +1,136 @@
+suite: derived resource names stay within the DNS limit
+# Helm caps a release name at 53 characters, but the chart appends suffixes to
+# it ("-datanode-svc", "-secrets-datanode", ...). Left unchecked those derived
+# names run well past the 63-character DNS label limit that Services and pod
+# hostnames are held to.
+#
+# The fix is "graylog.name.suffixed": it truncates the BASE to leave room for
+# the suffix, then joins. The order matters. Truncating the joined string
+# instead eats into the suffix, and once the base reaches 62 characters every
+# suffix is consumed entirely — "<base>-secrets" and "<base>-secrets-datanode"
+# both collapse to "<base>", quietly giving two Secrets the same name.
+#
+# The contract these tests pin:
+#   1. No derived name exceeds 63 characters.
+#   2. The suffix always survives in full, so names stay distinct.
+#   3. StatefulSet names hold back room for the pod ordinal, because a pod
+#      name "<statefulset>-<ordinal>" is itself a DNS label.
+#   4. Release names short enough not to need truncation are untouched, so
+#      this never renames resources on an existing install.
+#
+# If you add a resource whose name is built from another name, route it through
+# "graylog.name.suffixed" and add it here.
+templates:
+  - service/graylog.yaml
+  - service/datanode.yaml
+  - workload/statefulsets/graylog.yaml
+  - workload/statefulsets/datanode.yaml
+  - config/secret/secrets.yaml
+  - config/secret/datanode.yaml
+  - policy/pdb/graylog.yaml
+  - policy/pdb/datanode.yaml
+  # The StatefulSets' checksum helpers `include` these by path, so the template
+  # filter has to list them for the includes to resolve.
+  - config/graylog.yaml
+  - config/datanode.yaml
+
+tests:
+  # ---------------------------------------------------------------- long name
+  # 52 characters, so the fullname is "<release>-graylog" = 60 characters and
+  # every suffix below would overflow without truncation.
+  - it: keeps Service names inside the 63-character limit, suffix intact
+    release:
+      name: prod-eu-central-1-observability-platform-cluster-tie
+    asserts:
+      - equal:
+          path: metadata.name
+          value: prod-eu-central-1-observability-platform-cluster-tie-graylo-svc
+        template: service/graylog.yaml
+      - equal:
+          path: metadata.name
+          value: prod-eu-central-1-observability-platform-cluster-t-datanode-svc
+        template: service/datanode.yaml
+
+  - it: does not let two Secrets collapse onto one name
+    release:
+      name: prod-eu-central-1-observability-platform-cluster-tie
+    asserts:
+      # Would both be "<base>" if the joined string were truncated instead.
+      - equal:
+          path: metadata.name
+          value: prod-eu-central-1-observability-platform-cluster-tie-gr-secrets
+        template: config/secret/secrets.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: prod-eu-central-1-observability-platform-cluster-tie-g-datanode
+        template: config/secret/datanode.yaml
+
+  - it: does not let the two PodDisruptionBudgets collapse onto one name
+    set:
+      graylog.replicas: 3
+      graylog.podDisruptionBudget.enabled: true
+      datanode.podDisruptionBudget.enabled: true
+    release:
+      name: prod-eu-central-1-observability-platform-cluster-tie
+    asserts:
+      - equal:
+          path: metadata.name
+          value: prod-eu-central-1-observability-platform-cluster-tie-graylo-pdb
+        template: policy/pdb/graylog.yaml
+      - equal:
+          path: metadata.name
+          value: prod-eu-central-1-observability-platform-cluster-t-pdb-datanode
+        template: policy/pdb/datanode.yaml
+
+  - it: leaves room on StatefulSet names for the pod ordinal
+    release:
+      name: prod-eu-central-1-observability-platform-cluster-tie
+    asserts:
+      # 59 characters, so "<name>-999" is still a valid 63-character label.
+      - equal:
+          path: metadata.name
+          value: prod-eu-central-1-observability-platform-cluster-tie-graylo
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: metadata.name
+          value: prod-eu-central-1-observability-platform-cluster-t-datanode
+        template: workload/statefulsets/datanode.yaml
+      # A StatefulSet must point at its own headless Service.
+      - equal:
+          path: spec.serviceName
+          value: prod-eu-central-1-observability-platform-cluster-t-datanode-svc
+        template: workload/statefulsets/datanode.yaml
+
+  # --------------------------------------------------------------- short name
+  # Truncation must be a no-op here. If any of these change, the chart is
+  # renaming resources on upgrade for releases that were never too long.
+  - it: leaves names untouched when the release name is short
+    release:
+      name: graylog
+    asserts:
+      - equal:
+          path: metadata.name
+          value: graylog-svc
+        template: service/graylog.yaml
+      - equal:
+          path: metadata.name
+          value: graylog-datanode-svc
+        template: service/datanode.yaml
+      - equal:
+          path: metadata.name
+          value: graylog
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: metadata.name
+          value: graylog-datanode
+        template: workload/statefulsets/datanode.yaml
+      - equal:
+          path: metadata.name
+          value: graylog-secrets
+        template: config/secret/secrets.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: graylog-secrets-datanode
+        template: config/secret/datanode.yaml


### PR DESCRIPTION
## Summary
Short description of the change.

## Details
- List of meaningful technical changes

## Linked issues
This fixes #??

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [ ] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [ ] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [ ] _describe what was specifically tested_

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
