### PR TITLE
chore: Bumping default graylog version to 7.1

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 description: Official Graylog Helm chart for Kubernetes
-icon: "https://raw.githubusercontent.com/Graylog2/graylog2-server/refs/tags/7.0.0/graylog2-web-interface/public/images/favicon.png"
+icon: "https://raw.githubusercontent.com/Graylog2/graylog2-server/refs/tags/7.1.0/graylog2-web-interface/public/images/favicon.png"
 type: application
 home: https://graylog.org
 sources:
@@ -24,13 +24,13 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/images: |
     - name: "graylog"
-      image: "graylog/graylog:7.0"
+      image: "graylog/graylog:7.1"
       whitelisted: true
       platforms:
         - linux/amd64
         - linux/arm64
     - name: "graylog-datanode"
-      image: "graylog/graylog-datanode:7.0"
+      image: "graylog/graylog-datanode:7.1"
       whitelisted: true
       platforms:
         - linux/amd64
@@ -65,5 +65,5 @@ annotations:
 # This is the chart version.
 version: 1.0.0
 # This is the version number of the Graylog application bundled with this chart.
-appVersion: "7.0"
+appVersion: "7.1"
 # End of file. Thanks for scrolling.


### PR DESCRIPTION
## Summary
Bumping default Graylog application and datanode to 7.1

## Details
- List of meaningful technical changes

## Linked issues
https://github.com/Graylog2/graylog-helm/issues/94

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [ ] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [ ] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [x] Web UI accessible and login works
- [x] DataNodes visible in _System > Cluster Configuration_
- [x] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [ ] _describe what was specifically tested_

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
