### PR TITLE
Fix ServiceAccount override, add standard labels, document values.yaml

### DIFF
--- a/charts/graylog/templates/auth/mongo-sa.yaml
+++ b/charts/graylog/templates/auth/mongo-sa.yaml
@@ -17,12 +17,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $roleName }}
+  labels:
+    {{- include "graylog.labels" . | nindent 4 }}
 rules: {{ .Values.mongodb.serviceAccount.role.rules | toYaml | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "graylog.mongodb.serviceAccountName" . | printf "%s-rb" }}
+  labels:
+    {{- include "graylog.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "graylog.mongodb.serviceAccountName" . }}

--- a/charts/graylog/templates/auth/sa.yaml
+++ b/charts/graylog/templates/auth/sa.yaml
@@ -17,12 +17,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $roleName }}
+  labels:
+    {{- include "graylog.labels" . | nindent 4 }}
 rules: {{ .Values.serviceAccount.role.rules | toYaml | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "graylog.serviceAccountName" . | printf "%s-rb" }}
+  labels:
+    {{- include "graylog.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "graylog.serviceAccountName" . }}

--- a/charts/graylog/templates/config/datanode.yaml
+++ b/charts/graylog/templates/config/datanode.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.datanode.configmap.name" . }}
+  labels:
+    app.kubernetes.io/component: datanode
+    {{- include "graylog.labels" . | nindent 4 }}
 data:
   JAVA_OPTS: {{ .Values.datanode.config.javaOpts | quote }}
   GRAYLOG_DATANODE_NODE_ID_FILE: {{ .Values.datanode.config.nodeIdFile | default "/var/lib/graylog-datanode/node-id" | quote }}

--- a/charts/graylog/templates/config/fallback.yaml
+++ b/charts/graylog/templates/config/fallback.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.fallback.name" . | printf "%s-config" }}
+  labels:
+    app.kubernetes.io/component: default-backend
+    {{- include "graylog.labels" . | nindent 4 }}
 data:
   httpd.conf: |
     H:/var/www/html
@@ -13,6 +16,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.fallback.name" . | printf "%s-content" }}
+  labels:
+    app.kubernetes.io/component: default-backend
+    {{- include "graylog.labels" . | nindent 4 }}
 data:
   healthz: "ok"
   livez: "ok"

--- a/charts/graylog/templates/config/graylog.yaml
+++ b/charts/graylog/templates/config/graylog.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.configmap.name" . }}
+  labels:
+    app.kubernetes.io/component: server
+    {{- include "graylog.labels" . | nindent 4 }}
 data:
   GRAYLOG_PROMETHEUS_EXPORTER_ENABLED: {{ .Values.graylog.service.metrics.enabled | ternary true false | quote }}
   GRAYLOG_SELFSIGNED_STARTUP: {{ .Values.graylog.config.selfSignedStartup | default true | quote }}

--- a/charts/graylog/templates/config/init-graylog.yaml
+++ b/charts/graylog/templates/config/init-graylog.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.cm.init.name" . }}
+  labels:
+    app.kubernetes.io/component: server
+    {{- include "graylog.labels" . | nindent 4 }}
 data:
   init-script.sh: |
     #!/bin/sh

--- a/charts/graylog/templates/config/sc/aws-gp3.yaml
+++ b/charts/graylog/templates/config/sc/aws-gp3.yaml
@@ -3,6 +3,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ include "graylog.provider.storageClassName" . }}
+  labels:
+    {{- include "graylog.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"

--- a/charts/graylog/templates/custom/issuer.yaml
+++ b/charts/graylog/templates/custom/issuer.yaml
@@ -1,8 +1,18 @@
 {{- if not .Values.graylog.config.tls.enabled | and .Values.ingress.enabled .Values.ingress.config.tls.issuer.managed.enabled }}
+{{/*
+Fail early with an actionable message when the cert-manager CRDs are missing.
+The lookup guard skips the check for offline renders (helm template, unittest),
+where .Capabilities only contains built-in API versions.
+*/}}
+{{- if and (not (.Capabilities.APIVersions.Has "cert-manager.io/v1/Issuer")) (lookup "v1" "Namespace" "" .Release.Namespace) }}
+{{- fail "The cert-manager CRDs (cert-manager.io/v1) were not found in the cluster. Install cert-manager first (https://cert-manager.io/docs/installation/), or disable the managed issuer (ingress.config.tls.issuer.managed.enabled=false) and reference an existing issuer or TLS secret instead." }}
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "graylog.cert-manager.issuer.name" . }}
+  labels:
+    {{- include "graylog.labels" . | nindent 4 }}
 spec:
   acme:
     server: {{ .Values.ingress.config.tls.issuer.managed.staging | ternary "-staging" "" | printf "https://acme%s-v02.api.letsencrypt.org/directory" }}

--- a/charts/graylog/templates/custom/mongo-rs.yaml
+++ b/charts/graylog/templates/custom/mongo-rs.yaml
@@ -1,8 +1,19 @@
 {{- if .Values.mongodb.communityResource.enabled }}
+{{/*
+Fail early with an actionable message when the MongoDB operator CRD is missing.
+The lookup guard skips the check for offline renders (helm template, unittest),
+where .Capabilities only contains built-in API versions.
+*/}}
+{{- if and (not (.Capabilities.APIVersions.Has "mongodbcommunity.mongodb.com/v1/MongoDBCommunity")) (lookup "v1" "Namespace" "" .Release.Namespace) }}
+{{- fail "The MongoDBCommunity CRD (mongodbcommunity.mongodb.com/v1) was not found in the cluster. Install the MongoDB Kubernetes Operator first (https://github.com/mongodb/mongodb-kubernetes), or set mongodb.communityResource.enabled=false and provide an external MongoDB via graylog.config.mongodb.customUri." }}
+{{- end }}
 apiVersion: mongodbcommunity.mongodb.com/v1
 kind: MongoDBCommunity
 metadata:
   name: {{ include "graylog.mongodb.crName" . }}
+  labels:
+    app.kubernetes.io/component: mongodb
+    {{- include "graylog.labels" . | nindent 4 }}
 spec:
   {{- $replicas := .Values.mongodb.replicas | default 2 | int }}
   {{- $arbiters := .Values.mongodb.arbiters | default 0 | int }}

--- a/charts/graylog/templates/policy/pdb/datanode.yaml
+++ b/charts/graylog/templates/policy/pdb/datanode.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: graylog-datanode
+    app.kubernetes.io/component: datanode
     {{- include "graylog.labels" . | nindent 4 }}
 spec:
   minAvailable: {{ .Values.datanode.podDisruptionBudget.minAvailable | default 3 | int }}

--- a/charts/graylog/templates/policy/pdb/graylog.yaml
+++ b/charts/graylog/templates/policy/pdb/graylog.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: graylog-app
+    app.kubernetes.io/component: server
     {{- include "graylog.labels" . | nindent 4 }}
 spec:
   minAvailable: {{ .Values.graylog.podDisruptionBudget.minAvailable | default 1 | int }}

--- a/charts/graylog/templates/service/datanode.yaml
+++ b/charts/graylog/templates/service/datanode.yaml
@@ -4,8 +4,11 @@ kind: Service
 metadata:
   name: {{ include "graylog.datanode.service.name" . }}
   labels:
-    {{- include "graylog.labels" . | nindent 4 }}
+    app.kubernetes.io/component: datanode
+    # Deprecated: kept for backward compatibility with external selectors
+    # (e.g. ServiceMonitors); use app.kubernetes.io/component instead.
     app.kubernetes.io/app-name: graylog-datanode
+    {{- include "graylog.labels" . | nindent 4 }}
 spec:
   clusterIP: None
   ports:

--- a/charts/graylog/templates/service/fallback.yaml
+++ b/charts/graylog/templates/service/fallback.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "graylog.fallback.name" . }}
+  labels:
+    app.kubernetes.io/component: default-backend
+    {{- include "graylog.labels" . | nindent 4 }}
 spec:
   selector:
     graylog-app: {{ include "graylog.fallback.name" . }}

--- a/charts/graylog/templates/service/graylog.yaml
+++ b/charts/graylog/templates/service/graylog.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "graylog.service.name" . }}
   labels:
+    app.kubernetes.io/component: server
     {{- include "graylog.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.graylog.service.type | default "ClusterIP" }}

--- a/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
+++ b/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
@@ -4,6 +4,7 @@ kind: Ingress
 metadata:
   name: {{ include "graylog.fullname" . | printf "%s-forwarder" }}
   labels:
+    app.kubernetes.io/component: forwarder
     {{- include "graylog.labels" . | nindent 4 }}
   {{- with .Values.ingress.forwarder.annotations }}
   annotations:

--- a/charts/graylog/templates/service/ingress/graylog.yaml
+++ b/charts/graylog/templates/service/ingress/graylog.yaml
@@ -9,6 +9,7 @@ kind: Ingress
 metadata:
   name: {{ include "graylog.ingress.web.name" . }}
   labels:
+    app.kubernetes.io/component: server
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:
   {{- $clusterissuer := .Values.ingress.config.tls.clusterIssuer.existingName }}

--- a/charts/graylog/templates/workload/fallback.yaml
+++ b/charts/graylog/templates/workload/fallback.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "graylog.fallback.name" . }}
+  labels:
+    app.kubernetes.io/component: default-backend
+    {{- include "graylog.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -12,6 +15,8 @@ spec:
     metadata:
       labels:
         graylog-app: {{ include "graylog.fallback.name" . }}
+        app.kubernetes.io/component: default-backend
+        {{- include "graylog.selectorLabels" . | nindent 8 }}
     spec:
       containers:
         - name: busybox

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "graylog.datanode.name" . }}
   labels:
     app: graylog-datanode
+    app.kubernetes.io/component: datanode
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:
     {{- include "graylog.annotations" . | nindent 4 }}
@@ -28,6 +29,7 @@ spec:
     metadata:
       labels:
         app: graylog-datanode
+        app.kubernetes.io/component: datanode
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include "graylog.datanode.configChecksum" . }}
@@ -44,7 +46,7 @@ spec:
       {{- with .Values.datanode.nodeSelector }}
       nodeSelector: {{ . | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.nameOverride }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}
       {{- end }}
       {{- with .Values.datanode.podSecurityContext }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "graylog.fullname" . }}
   labels:
     app: graylog-app
+    app.kubernetes.io/component: server
     {{- include "graylog.labels" . | nindent 4 }}
   annotations:
     {{- include "graylog.annotations" . | nindent 4 }}
@@ -29,6 +30,7 @@ spec:
     metadata:
       labels:
         app: graylog-app
+        app.kubernetes.io/component: server
         {{- include "graylog.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include "graylog.configChecksum" . }}
@@ -45,7 +47,7 @@ spec:
       {{- with .Values.graylog.nodeSelector }}
       nodeSelector: {{ . | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.nameOverride }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}
       {{- end }}
       {{- with .Values.graylog.podSecurityContext }}

--- a/charts/graylog/tests/datanode_statefulset_test.yaml
+++ b/charts/graylog/tests/datanode_statefulset_test.yaml
@@ -55,3 +55,23 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].securityContext
         template: workload/statefulsets/datanode.yaml
+
+  # Service account (chart best practices): create=false + nameOverride means
+  # "use this existing, externally managed ServiceAccount"
+  - it: uses an existing service account when create is false and nameOverride is set
+    set:
+      serviceAccount.create: false
+      serviceAccount.nameOverride: existing-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-sa
+        template: workload/statefulsets/datanode.yaml
+
+  - it: omits serviceAccountName when create is false and no nameOverride is set
+    set:
+      serviceAccount.create: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.serviceAccountName
+        template: workload/statefulsets/datanode.yaml

--- a/charts/graylog/tests/graylog_statefulset_test.yaml
+++ b/charts/graylog/tests/graylog_statefulset_test.yaml
@@ -236,3 +236,23 @@ tests:
       - notExists:
           path: spec.template.spec.initContainers[1].securityContext
         template: workload/statefulsets/graylog.yaml
+
+  # Service account (chart best practices): create=false + nameOverride means
+  # "use this existing, externally managed ServiceAccount"
+  - it: uses an existing service account when create is false and nameOverride is set
+    set:
+      serviceAccount.create: false
+      serviceAccount.nameOverride: existing-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-sa
+        template: workload/statefulsets/graylog.yaml
+
+  - it: omits serviceAccountName when create is false and no nameOverride is set
+    set:
+      serviceAccount.create: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.serviceAccountName
+        template: workload/statefulsets/graylog.yaml

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -1,36 +1,56 @@
 # Default values for Graylog.
 
-# Kubernetes provider (optional)
+# provider enables provider-specific defaults (currently only "aws", which
+# provisions a gp3 StorageClass). Leave empty for provider-agnostic behavior.
 provider: ""
 
-# Override Graylog and Graylog Data Node version (optional)
+# version overrides the Graylog and Graylog Data Node image tag for both
+# workloads at once. Defaults to the chart's appVersion when empty.
 version: ""
 
-# Override the chart name (optional)
+# nameOverride replaces the chart name used in resource names and labels.
 nameOverride: ""
 
-# Override the (fully qualified) app name (optional)
+# fullnameOverride replaces the fully qualified app name used as the prefix
+# for all resource names.
 fullnameOverride: ""
 
-# Overrides values for Graylog, Datanode, and MongoDB
+# global values are shared by the Graylog, Datanode, and MongoDB workloads.
 global:
+  # imagePullSecrets is applied to the Graylog and Datanode pods unless
+  # overridden per image (MongoDB images are pulled by the operator).
   imagePullSecrets: []
+  # existingSecretName points at an externally managed Secret holding all
+  # Graylog credentials. When set, the chart does not create or manage secrets.
   existingSecretName: ""
+  # storageClass is the default StorageClass for all persistent volumes.
   storageClass: ""
 
-# Graylog application
+# graylog configures the Graylog server application.
 graylog:
+  # enabled toggles the Graylog server StatefulSet, Service, PDB, and init
+  # ConfigMap (the server ConfigMap and Secret are not gated by this flag).
   enabled: true
+  # enterprise selects the graylog/graylog-enterprise image instead of the
+  # open-source image.
   enterprise: true
+  # replicas is the number of Graylog server pods.
   replicas: 2
   service:
+    # nameOverride replaces the generated Service name.
     nameOverride: ""
+    # type is the Kubernetes Service type (ClusterIP, NodePort, LoadBalancer).
     type: ClusterIP
     ports:
+      # app is the port serving the Graylog web interface and REST API.
       app: 9000
+      # metrics is the port serving Prometheus metrics.
       metrics: 9833
     metrics:
+      # enabled exposes the Prometheus metrics port on the Service.
       enabled: true
+  # inputs declares Graylog inputs to expose as Service/container ports.
+  # Each entry needs a name, port, and protocol; targetPort defaults to port.
   inputs:
     - name: input-gelf
       port: 12201
@@ -40,30 +60,58 @@ graylog:
       port: 13301
       targetPort: 13301
       protocol: TCP
+  # plugins lists Graylog plugins to install at startup. Entries reference a
+  # download url (+ checksum), an OCI image, or an existingClaim with the jar.
   plugins: []
+  # env sets additional environment variables on the Graylog container as a
+  # simple key/value map.
   env: {}
-  # Graylog server configuration (server.conf)
+  # config maps to Graylog server configuration (server.conf) settings.
   config:
+    # rootUsername is the login of the Graylog root user.
     rootUsername: "admin"
+    # rootPassword is the root user's password. Leave empty to have the chart
+    # generate one on install (shown once in the install notes).
     rootPassword: ""
+    # customSecretPepper is the secret used to pepper stored user data
+    # (password_secret). Minimum 64 characters; generated when empty.
     customSecretPepper: ""
+    # timezone is the root user's timezone.
     timezone: "UTC"
+    # selfSignedStartup allows Graylog to boot with self-signed certificates.
     selfSignedStartup: "true"
+    # serverJavaOpts sets the JVM options for the Graylog server process.
     serverJavaOpts: "-Xms1g -Xmx1g"
+    # extraServerJavaOpts appends additional JVM options to serverJavaOpts.
     extraServerJavaOpts: []
+    # leaderElectionMode controls how the leader node is chosen.
     leaderElectionMode: "automatic"
+    # contentPacksAutoInstall installs bundled content packs on first boot.
     contentPacksAutoInstall: "true"
+    # isCloud enables Graylog Cloud mode.
     isCloud: "false"
     tls:
+      # enabled turns on TLS for the Graylog HTTP interface.
       enabled: false
+      # secretName is a kubernetes.io/tls Secret with the certificate and key.
       secretName: ""
+      # keyPassword is the password protecting the TLS private key, if any.
       keyPassword: ""
+      # updateKeyStore imports the certificate into the JVM trust store.
       updateKeyStore: true
+      # keyStorePass is the password of the JVM trust store.
       keyStorePass: "changeit"
     mongodb:
+      # customUri is a full MongoDB connection string for an externally
+      # managed MongoDB. Required when mongodb.communityResource.enabled=false.
       customUri: ""
+      # maxConnections caps the MongoDB connection pool size.
       maxConnections: "1000"
+      # versionProbeAttempts is the number of MongoDB version probe retries
+      # at startup ("0" retries forever).
       versionProbeAttempts: "0"
+    # messageJournal configures the on-disk message journal; fields map to
+    # the message_journal_* settings in server.conf.
     messageJournal:
       enabled: "true"
       flushAge: "1m"
@@ -71,6 +119,7 @@ graylog:
       maxAge: "12h"
       segmentAge: "1h"
       segmentSize: "100mb"
+    # network configures the HTTP interface of the Graylog server.
     network:
       connectTimeout: "5s"
       enableCors: "false"
@@ -78,7 +127,10 @@ graylog:
       maxHeaderSize: "8192"
       readTimeout: "10s"
       threadPoolSize: "64"
+      # externalUri is the public URI of the Graylog web interface, used when
+      # it cannot be derived from the Service, Ingress, or TLS configuration.
       externalUri: ""
+    # performance maps to the processing/buffer tuning knobs of server.conf.
     performance:
       asyncEventbusProcessors: "2"
       autoRestartInputs: "false"
@@ -93,6 +145,7 @@ graylog:
       outputBufferProcessorThreadsCorePoolSize: "3"
       outputBufferProcessors: ""
       processBufferProcessors: ""
+    # email configures the SMTP transport for notifications.
     email:
       enabled: "false"
       senderAddress: "graylog@example.com"
@@ -103,12 +156,19 @@ graylog:
       useAuth: "true"
       useSsl: "false"
       useTls: "true"
+      # webInterfaceUrl is the base URL used to build links in notification
+      # emails.
       webInterfaceUrl: "https://graylog.example.com"
     plugins:
+      # enabled turns on plugin installation via init containers.
       enabled: false
+    # geolocation configures GeoIP databases for the Graylog geolocation
+    # processor.
     geolocation:
       enabled: false
       maxmindGeoIp:
+        # enabled wires the MaxMind credentials below into the chart-managed
+        # Secret, where the GeoIP update sidecar reads them.
         enabled: true
         # MaxMind account credentials
         # When using global.existingSecretName, the external secret must contain:
@@ -119,6 +179,8 @@ graylog:
         # Comma-separated list of MaxMind database editions to download
         # Examples: "GeoLite2-City GeoLite2-ASN", "GeoIP2-City GeoIP2-ISP"
         editionIds: "GeoLite2-City GeoLite2-ASN"
+      # mmdbSources provides direct download URLs (and checksums) for the
+      # city/asn mmdb files as an alternative to the MaxMind sidecar.
       mmdbSources:
         city:
           url:
@@ -133,6 +195,7 @@ graylog:
           repository: maxmindinc
           name: geoipupdate
           tag: "7.1.1"
+        # schedule is a cron expression controlling database update frequency.
         schedule: "0 0 * * *"
         resources:
           requests:
@@ -141,6 +204,7 @@ graylog:
           limits:
             cpu: 500m
             memory: 256Mi
+        # securityContext for the sidecar; the geoipupdate image requires root.
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -152,26 +216,39 @@ graylog:
           seccompProfile:
             type: RuntimeDefault
     init:
+      # assetFetch controls download of plugins/geolocation assets by the
+      # init container.
       assetFetch:
         enabled: false
+        # skipChecksum disables checksum verification of downloaded assets.
         skipChecksum: false
+        # allowHttp permits plain-HTTP download URLs (HTTPS-only by default).
         allowHttp: false
         plugins:
           enabled: false
+          # baseUrl is prepended to relative plugin URLs.
           baseUrl:
         geolocation:
           enabled: false
+          # baseUrl is prepended to relative mmdb URLs.
           baseUrl:
   image:
+    # repository overrides the Graylog image; defaults to graylog/graylog or
+    # graylog/graylog-enterprise depending on graylog.enterprise.
     repository: ""
+    # tag overrides the image tag; defaults to `version` or the chart's
+    # appVersion.
     tag: ""
     imagePullPolicy: IfNotPresent
+    # imagePullSecrets overrides global.imagePullSecrets for this image.
     imagePullSecrets: []
+  # updateStrategy is the StatefulSet update strategy.
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
       partition:
+  # resources are the compute requests/limits of the Graylog container.
   resources:
     limits:
       cpu: "2"
@@ -179,17 +256,26 @@ graylog:
     requests:
       cpu: "1"
       memory: "1Gi"
+  # persistence configures the Graylog data volume (journal, node-id, ...).
   persistence:
     enabled: true
+    # storageClass overrides global.storageClass for this volume.
     storageClass:
+    # volumeNameOverride replaces the generated PVC/volume name.
     volumeNameOverride:
+    # existingClaim mounts a pre-provisioned PVC instead of using a
+    # volumeClaimTemplate.
     existingClaim:
     mountPath:
+    # accessModes defaults to ["ReadWriteOnce"] when empty.
     accessModes: []
+    # size is the requested volume size (default 8Gi).
     size:
     annotations: {}
     labels: {}
     selector: {}
+  # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
+  # for the Graylog container (TCP checks against the app port).
   livenessProbe:
     enabled: true
     initialDelaySeconds: 60
@@ -210,6 +296,9 @@ graylog:
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
+  # podSecurityContext / initContainerSecurityContext / containerSecurityContext
+  # expose the standard Kubernetes securityContext fields; defaults follow a
+  # non-root, no-privilege-escalation baseline.
   podSecurityContext:
     # fsGroup is required to make mounted volumes writable
     runAsUser: 1100
@@ -233,28 +322,51 @@ graylog:
       add: ["NET_BIND_SERVICE"]
     seccompProfile:
       type: RuntimeDefault
+  # podAnnotations is added to the Graylog pod template metadata.
   podAnnotations: {}
+  # nodeSelector constrains Graylog pods to matching nodes.
   nodeSelector: {}
+  # tolerations lets Graylog pods schedule onto tainted nodes.
   tolerations: []
+  # affinity overrides the default anti-affinity that spreads Graylog pods
+  # across nodes.
   affinity: {}
+  # extraEnv sets additional environment variables using full EnvVar syntax
+  # (supports valueFrom); entries here win over graylog.env keys.
   extraEnv: []
 
-# Graylog Datanode
+# datanode configures the Graylog Data Node (managed OpenSearch).
 datanode:
+  # enabled toggles the Datanode StatefulSet, Service, and PDB (the Datanode
+  # ConfigMap and Secret are not gated by this flag).
   enabled: true
+  # replicas is the number of Datanode pods.
   replicas: 3
   service:
     ports:
+      # api is the Datanode REST API port.
       api: 8999
+      # data is the OpenSearch HTTP port.
       data: 9200
+      # config is the OpenSearch transport port.
       config: 9300
+  # env sets additional environment variables on the Datanode container as a
+  # simple key/value map.
   env: {}
+  # config maps to Graylog Data Node configuration settings.
   config:
+    # nodeIdFile is the path of the node-id file inside the container.
     nodeIdFile: ""
+    # opensearchHeap is the heap size of the embedded OpenSearch process.
     opensearchHeap: "2g"
+    # javaOpts sets JVM options for the Datanode process itself.
     javaOpts: "-Xms1g -Xmx1g"
+    # skipPreflightChecks bypasses the Datanode preflight validation.
     skipPreflightChecks: "false"
+    # nodeSearchCacheSize is the OpenSearch search cache size.
     nodeSearchCacheSize: "10gb"
+    # s3ClientDefault* configure the S3 client used for searchable snapshots;
+    # endpoint, accessKey, and secretKey must be set together.
     s3ClientDefaultSecretKey: ""
     s3ClientDefaultAccessKey: ""
     s3ClientDefaultEndpoint: ""
@@ -262,10 +374,16 @@ datanode:
     s3ClientDefaultProtocol: "http"
     s3ClientDefaultPathStyleAccess: "true"
   image:
+    # repository overrides the Datanode image (default graylog/graylog-datanode).
     repository: ""
+    # tag overrides the image tag; defaults to `version` or the chart's
+    # appVersion.
     tag: ""
     imagePullPolicy: IfNotPresent
+    # imagePullSecrets overrides global.imagePullSecrets for this image.
     imagePullSecrets: []
+  # sysctlInit runs a privileged init container that raises vm.max_map_count
+  # for OpenSearch on nodes where the default is too low.
   sysctlInit:
     enabled: false
     image:
@@ -275,11 +393,13 @@ datanode:
     securityContext:
       privileged: true
     vmMaxMapCount: 262144
+  # updateStrategy is the StatefulSet update strategy.
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
       partition:
+  # resources are the compute requests/limits of the Datanode container.
   resources:
     limits:
       cpu: "1"
@@ -287,8 +407,14 @@ datanode:
     requests:
       cpu: "500m"
       memory: "3.5Gi"
+  # persistence configures the Datanode volumes. Each volume consumes its
+  # enabled, storageClass, mountPath, accessModes, and size fields; the
+  # remaining fields (existingClaim, annotations, labels, selector,
+  # dataSource) and the parent enabled flag are currently not consumed by
+  # the templates.
   persistence:
     enabled: true
+    # data is the OpenSearch data volume.
     data:
       enabled: true
       storageClass: ""
@@ -300,6 +426,7 @@ datanode:
       labels: {}
       selector: {}
       dataSource: {}
+    # nativeLibs is an optional volume for OpenSearch native libraries.
     nativeLibs:
       enabled: false
       storageClass: ""
@@ -310,6 +437,8 @@ datanode:
       annotations: {}
       labels: {}
       selector: {}
+  # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
+  # for the Datanode container.
   livenessProbe:
     enabled: true
     initialDelaySeconds: 30
@@ -342,18 +471,33 @@ datanode:
       add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID"]
     seccompProfile:
       type: RuntimeDefault
+  # podAnnotations is added to the Datanode pod template metadata.
   podAnnotations: {}
+  # nodeSelector constrains Datanode pods to matching nodes.
   nodeSelector: {}
+  # tolerations lets Datanode pods schedule onto tainted nodes.
   tolerations: []
+  # affinity overrides the default anti-affinity that spreads Datanode pods
+  # across nodes.
   affinity: {}
+  # extraEnv sets additional environment variables using full EnvVar syntax
+  # (supports valueFrom); entries here win over datanode.env keys.
   extraEnv: []
 
-# Graylog service account
+# serviceAccount configures the ServiceAccount used by the Graylog and
+# Datanode pods.
 serviceAccount:
+  # create makes the chart manage the ServiceAccount. Set create=false and
+  # nameOverride to use an existing, externally managed ServiceAccount.
   create: true
+  # automount controls automountServiceAccountToken on the ServiceAccount.
   automount: true
+  # annotations is added to the ServiceAccount (e.g. IRSA role ARNs).
   annotations: {}
+  # nameOverride replaces the generated ServiceAccount name, or names the
+  # existing ServiceAccount to use when create=false.
   nameOverride: ""
+  # role optionally creates a namespaced Role/RoleBinding with these rules.
   role:
     create: false
     rules: []
@@ -364,20 +508,31 @@ serviceAccount:
 # Ingress configuration
 # more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
+  # enabled is the master switch for all Ingress resources.
   enabled: false
   config:
+    # defaultBackend deploys a small "waiting room" fallback service that
+    # answers while Graylog is starting up.
     defaultBackend:
       enabled: true
+    # tls selects how Ingress certificates are issued via cert-manager.
     tls:
       clusterIssuer:
+        # existingName references a pre-existing ClusterIssuer.
         existingName:
       issuer:
+        # existingName references a pre-existing namespaced Issuer.
         existingName:
+        # managed creates a Let's Encrypt ACME Issuer owned by this chart.
         managed:
           enabled: false
+          # staging uses the Let's Encrypt staging endpoint (untrusted certs,
+          # generous rate limits).
           staging: true
+  # web exposes the Graylog web interface/API.
   web:
     enabled: false
+    # className is the IngressClass to use.
     className: ""
     annotations: {}
     hosts:
@@ -389,6 +544,7 @@ ingress:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+  # forwarder exposes the Graylog forwarder input.
   forwarder:
     enabled: false
     className: ""
@@ -404,7 +560,10 @@ ingress:
 # Requires MongoDB Kubernetes Operator: https://github.com/mongodb/mongodb-kubernetes/tree/master/docs/mongodbcommunity
 mongodb:
   communityResource:
+    # enabled renders a MongoDBCommunity resource for the operator to manage.
+    # Set to false to bring your own MongoDB via graylog.config.mongodb.customUri.
     enabled: true
+  # version is the MongoDB server version deployed by the operator.
   version: "7.0.25"
   # For production deployments, use 3 data-bearing replicas with no arbiters.
   # This configuration supports w:majority writes even with one replica down.
@@ -413,15 +572,20 @@ mongodb:
   replicas: 3
   arbiters: 0
   persistence:
+    # storageClass overrides global.storageClass for the MongoDB volumes.
     storageClass: ""
     size:
       data: "10G"
       logs: "2G"
+  # serviceAccount configures the ServiceAccount used by the MongoDB pods;
+  # fields mirror the top-level serviceAccount block.
   serviceAccount:
     create: true
     automount: true
     annotations: {}
     nameOverride: ""
+    # role creates the Role/RoleBinding required by the MongoDB operator's
+    # readiness/version-upgrade hooks.
     role:
       create: true
       rules:


### PR DESCRIPTION
## Summary
Chart cleanup with one real bugfix: a bring-your-own ServiceAccount was silently ignored. The rest adds the standard Kubernetes labels to every rendered resource, fails early when required operator CRDs are missing, and fully comments values.yaml.

## Details
- Both StatefulSets now set `serviceAccountName` when `serviceAccount.nameOverride` is set with `create: false`. Previously the guard only checked `create`, so pods fell back to the namespace `default` ServiceAccount and the override was ignored.
- Resources that rendered without any labels (the ConfigMaps, AWS gp3 StorageClass, cert-manager Issuer, MongoDBCommunity resource, fallback Deployment/Service, and both Role/RoleBinding pairs) now include the `graylog.labels` helper, so `helm.sh/chart`, `app.kubernetes.io/name`, `instance`, and `managed-by` appear on everything the release owns.
- Added `app.kubernetes.io/component` labels (`server`, `datanode`, `mongodb`, `forwarder`, `default-backend`) next to the legacy `app:` labels. No selector was changed, so this is upgrade-safe. The nonstandard `app.kubernetes.io/app-name` label on the datanode Service is kept and marked deprecated so existing external selectors (ServiceMonitors etc.) keep matching.
- The MongoDBCommunity and Issuer templates now fail at install time with an instructive error when the required operator CRDs are absent, instead of a raw API error. Offline renders (`helm template`, helm-unittest) skip the check.
- Every property in values.yaml now has a comment, each starting with the property name. The values themselves are untouched: both versions were parsed and compared, and they are semantically identical.
- Four new unit tests pin the ServiceAccount behavior (positive and negative cases for both StatefulSets).

## Linked issues
Related to #120: the unused datanode persistence fields it describes are now documented as inert in values.yaml, but this PR does not remove or implement them. No issue exists for the ServiceAccount override bug fixed here; it surfaced during review.

## PR Checklist
Please check the items that apply to your change.

- [x] Tests added/updated
- [x] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [x] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [x] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [x] All 148 helm-unittest tests pass (4 new). I rendered the chart with `provider=aws`, ingress, and plugins enabled and checked every resulting resource for the chart labels with a small script. I also parsed values.yaml against main to confirm no value changed, and had the diff independently reviewed by a second AI reviewer (OpenAI Codex); its findings are addressed in the review-fix commits.
- [x] Deployed end to end on minikube (6GB/4CPU, MongoDB Kubernetes Operator 1.6.1): fresh install, all pods ready, all 5 `helm test` suites pass, API login with generated credentials works, indexer health green. Two deviations from defaults were needed for the local environment, both now filed as follow-ups: `mongodb.version=7.0.25` (the CI overlay's 8.0.23 cannot start on Linux kernel 6.19+, upstream SERVER-121912) and `graylog.livenessProbe.enabled=false` for first boot (the default probe can kill Graylog mid-provisioning and permanently wedge the cluster; needs a startupProbe). The CRD fail-fast check from this PR was also verified live: installing without the operator produces the new actionable error.
- [x] The new CRD check was additionally exercised in its skip path (offline `helm template` renders fine without a cluster).

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable

Heads up for the upgrade path: the new pod-template labels trigger one rolling restart of both StatefulSets on the first upgrade. No StatefulSet, Deployment, or Service selector changed, so there is no immutable-field conflict. The `app:` selector migration to `app.kubernetes.io/component` was deliberately left out; selectors are immutable, so that belongs in a major version.
