### PR TITLE
Store the generated root password in the backup Secret

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -208,8 +208,17 @@ helm install graylog graylog/graylog --namespace graylog --create-namespace --se
 # Post-Installation
 
 ## Set root Graylog password
-Graylog is installed with a random password by default. We recommend setting a persistent password once all pods achieve the `RUNNING` state using 
-the following command:
+Graylog is installed with a random password by default. It is stored in the release's
+backup Secret, which survives upgrades and uninstalls, and can be printed at any time:
+
+```sh
+kubectl get secret graylog-backup-secret --namespace graylog -o jsonpath="{.data.graylog-root-password}" | base64 -d
+```
+
+If you set `graylog.config.rootPassword` (or use `global.existingSecretName`), the
+chart stores only the SHA-256 hash of the password and you are responsible for keeping
+the plaintext. We recommend setting a persistent password once all pods achieve the
+`RUNNING` state using the following command:
 
 ```sh
 echo "Enter your new password and press return:" && read -s pass

--- a/charts/graylog/templates/NOTES.txt
+++ b/charts/graylog/templates/NOTES.txt
@@ -37,14 +37,18 @@ EXTERNAL ACCESS
   {{- if empty .Values.global.existingSecretName }}:
 
   - username: {{ .Values.graylog.config.rootUsername | quote }}
-  {{- if and (include "graylog.storedRootPasswordSha" .) (empty .Values.graylog.config.rootPassword) }}
+  {{- if .Values.graylog.config.rootPassword }}
+  - password: the graylog.config.rootPassword value from your configuration.
+  {{- else if and (include "graylog.storedRootPasswordSha" .) (not (include "graylog.storedRootPassword" .)) }}
   - password: unchanged from the initial install, and cannot be shown here.
 
   Only the SHA-256 hash of a generated root password is stored, so the password
   itself cannot be recovered from the cluster. If you no longer have it, set a new
   one with the `helm upgrade` command shown under ADDITIONAL NOTES below.
   {{- else }}
-  - password: {{ include "graylog.rootPassword" .  | quote }}
+  - password: kept in the {{ include "graylog.backupSecretName" . }} Secret. Print it with:
+
+    kubectl get secret {{ include "graylog.backupSecretName" . }} --namespace {{ .Release.Namespace }} -o jsonpath="{.data.graylog-root-password}" | base64 -d
   {{- end }}
   {{- else -}}
     {{ .Values.global.existingSecretName | quote | print " managed externally using the existing secret " }}.
@@ -123,16 +127,16 @@ ADDITIONAL NOTES
     - graylog.config.tls.keyPassword
 {{- else if empty .Values.graylog.config.rootPassword }}
 
-{{- if include "graylog.storedRootPasswordSha" . }}
+{{- if and (include "graylog.storedRootPasswordSha" .) (not (include "graylog.storedRootPassword" .)) }}
 · IMPORTANT: This release uses a randomly generated root password, set when the release
   was first installed. It persists across upgrades, but only its SHA-256 hash is stored,
   so it cannot be shown here or recovered from the cluster. To set a password you
   control — which also makes the release reproducible from your values file — run:
 {{- else }}
-· IMPORTANT: You are using a randomly generated root password. It persists across
-  upgrades, but only its SHA-256 hash is stored, so the chart cannot show it to you
-  again after this release. Record it now, or set a password you control — which also
-  makes the release reproducible from your values file:
+· NOTE: You are using a randomly generated root password. It is kept in the
+  {{ include "graylog.backupSecretName" . }} Secret, which survives upgrades and
+  uninstalls, so the print command above works at any time. To set a password you
+  control instead, run:
 {{- end }}
 
     echo "Enter your new password and press return:" && read -s pass && echo "Upgrading helm release {{ squote .Release.Name }}..." && helm upgrade {{ .Release.Name }} graylog/graylog --namespace {{ .Release.Namespace }} --reuse-values --set "graylog.config.rootPassword=$pass"; unset pass

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -180,6 +180,29 @@ nothing, which correctly matches the secret being (re)generated in that render.
 {{- end }}
 
 {{/*
+Generated root password already stored in the cluster, base64-encoded, or "" if none.
+
+The plaintext of a generated root password lives in the backup secret so users can
+retrieve it after install. It is only returned when its SHA-256 matches the stored
+hash: a stale value left behind by an explicit password reset is never surfaced.
+Returns "" when the user manages the password themselves (rootPassword set or
+global.existingSecretName in use).
+*/}}
+{{- define "graylog.storedRootPassword" -}}
+{{- if and (not .Values.global.existingSecretName) (empty .Values.graylog.config.rootPassword) }}
+{{- $backup := lookup "v1" "Secret" .Release.Namespace (include "graylog.backupSecretName" .) }}
+{{- $plain := "" }}
+{{- if $backup }}
+{{- $plain = index $backup.data "graylog-root-password" | default "" }}
+{{- end }}
+{{- $sha := include "graylog.storedRootPasswordSha" . }}
+{{- if and $plain $sha (eq ($plain | b64dec | sha256sum | b64enc) $sha) }}
+{{- $plain }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Graylog secret pepper
 */}}
 {{- define "graylog.secretPepper" }}

--- a/charts/graylog/templates/config/secret/secrets.yaml
+++ b/charts/graylog/templates/config/secret/secrets.yaml
@@ -63,6 +63,9 @@ data:
   {{- end }}
   graylog-secret: {{ $graylogPepper }}
   graylog-root-password-sha2: {{ $graylogSha }}
+  {{- if and (empty .Values.graylog.config.rootPassword) (not (include "graylog.storedRootPasswordSha" .)) }}
+  graylog-root-password: {{ include "graylog.rootPassword" . | b64enc }}
+  {{- end }}
 ---
 {{- end }}
 {{- $mongoUri := .Values.graylog.config.mongodb.customUri | default "" }}

--- a/charts/graylog/tests/graylog_secret_test.yaml
+++ b/charts/graylog/tests/graylog_secret_test.yaml
@@ -85,3 +85,20 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "A MongoDB connection URI must be specified"
+
+  # Generated-password path: override the suite-level explicit password with "".
+  # The plaintext must land in the backup secret so users can retrieve it later,
+  # and must never be stored when the user manages the password themselves.
+  - it: stores the generated root password in the backup secret
+    set:
+      graylog.config.rootPassword: ""
+    documentIndex: 0
+    asserts:
+      - isNotEmpty:
+          path: data.graylog-root-password
+
+  - it: does not store the plaintext when the root password is set explicitly
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: data.graylog-root-password


### PR DESCRIPTION
## Summary
The generated root password used to be printed once in the install notes and then became unrecoverable, since only its hash is stored. Now it lives in the backup Secret and the notes print the kubectl command to read it, which is the pattern most charts follow.

## Details
- A generated password is written to the backup Secret (`graylog-root-password`), which already survives upgrades and uninstalls. The server still only ever sees the SHA-256.
- NOTES print a retrieval command instead of the plaintext, so the password no longer lands in terminals, CI logs, or the Helm release record.
- Passwords set via `graylog.config.rootPassword` or `global.existingSecretName` keep the hash-only behavior.
- The new `graylog.storedRootPassword` helper only surfaces a stored plaintext when it hashes to the stored SHA, so a stale value left behind by a password reset is never shown.
- Releases installed before this change keep the old "cannot be shown" notes; nothing is rewritten retroactively.

## Linked issues
This fixes #139

## PR Checklist
Please check the items that apply to your change.

- [x] Tests added/updated
- [x] Documentation updated
- [x] This PR includes a new feature
- [ ] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [x] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [x] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [x] 146 helm-unittest tests pass (2 new) covering the generated and explicit password paths. On a fresh minikube install from this branch: the notes print the retrieval command and no plaintext, the command returns the password, its SHA-256 matches the live secret, and API login with the retrieved password succeeds. The plaintext is not part of the env-injected secret, so upgrades do not restart pods. Install used the CI values plus `mongodb.version=7.0.25` and `graylog.livenessProbe.enabled=false`, both local-environment workarounds unrelated to this change.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
