### PR TITLE
Document resetting a lost root password

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -14,6 +14,7 @@ Official Helm chart for Graylog.
   * [Installing on AWS EKS](#installing-on-aws-eks)
 * [Post-installation](#post-installation)
   * [Set root Graylog password](#set-root-graylog-password)
+  * [Reset a lost root password](#reset-a-lost-root-password)
   * [Set external access](#set-external-access)
 * [Usage](#usage)
   * [Scale Graylog](#scale-graylog)
@@ -214,6 +215,25 @@ the following command:
 echo "Enter your new password and press return:" && read -s pass
 helm upgrade graylog graylog/graylog --namespace graylog --reuse-values --set "graylog.config.rootPassword=$pass"; unset pass
 ```
+
+## Reset a lost root password
+
+If the password is lost and you cannot set a new one through Helm (for example when
+your values are managed by GitOps), patch the new password's SHA-256 into both
+Secrets and restart Graylog:
+
+```sh
+PASS="your-new-password"
+SHA=$(printf '%s' "$PASS" | sha256sum | awk '{print $1}')
+SHA64=$(printf '%s' "$SHA" | base64 -w0)
+kubectl patch secret graylog-secrets --namespace graylog -p "{\"data\":{\"GRAYLOG_ROOT_PASSWORD_SHA2\":\"$SHA64\"}}"
+kubectl patch secret graylog-backup-secret --namespace graylog -p "{\"data\":{\"graylog-root-password-sha2\":\"$SHA64\"}}"
+kubectl rollout restart statefulset graylog --namespace graylog
+```
+
+Do not delete the Secrets to force a reset. The backup Secret also holds the
+password pepper (`graylog-secret`), and losing that invalidates every stored
+user credential.
 
 ## Set external access
 


### PR DESCRIPTION
## Summary
The README now explains how to reset the root password with kubectl when Helm cannot be used, and warns against deleting the backup Secret, which also holds the password pepper.

## Details
- New "Reset a lost root password" section after the password setup docs, plus a table of contents entry.
- Docs only, no template changes.

## Linked issues
This fixes #141

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] This PR includes a new feature
- [ ] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [x] The documented commands were run against a live minikube release before writing them down: both Secrets patched, StatefulSet restarted, and login with the new password returned HTTP 200. Docs-only change, so the installation and functional checklists were not repeated here.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
