### PR TITLE
fix(geo-ip): Updating default maxmind image tag

### DIFF
--- a/charts/graylog/tests/geolocation_sidecar_test.yaml
+++ b/charts/graylog/tests/geolocation_sidecar_test.yaml
@@ -22,7 +22,7 @@ tests:
           any: true
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "maxmindinc/geoipupdate:7.1.1"
+          value: "maxmindinc/geoipupdate:v7.1.1"
 
   # Test: Sidecar not rendered when geolocation disabled
   - it: should not render sidecar when geolocation disabled

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -132,7 +132,7 @@ graylog:
         image:
           repository: maxmindinc
           name: geoipupdate
-          tag: "7.1.1"
+          tag: "v7.1.1"
         schedule: "0 0 * * *"
         resources:
           requests:


### PR DESCRIPTION
## Summary
Updating default geoip image tag.

## Details
- The previous default maxmind geoip image tag was incorrect, this pulls the proper image tag.

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [x] geoip side car pulls image and runs successfully

