### PR TITLE
Fix BYO OpenSearch CA truststore persistence

### DIFF
--- a/charts/graylog/templates/config/init-graylog.yaml
+++ b/charts/graylog/templates/config/init-graylog.yaml
@@ -63,12 +63,23 @@ data:
     fi
     {{- end }}
     {{- if and .Values.opensearch.enabled .Values.opensearch.tls.enabled .Values.opensearch.tls.caSecret }}
-    # Trust the BYO OpenSearch CA by importing it into the Graylog Java truststore.
-    CACERTS_SRC="/usr/share/graylog/data/cacerts"
-    mkdir -p "${CACERTS_SRC}"
+    # Trust the BYO OpenSearch CA. The truststore must live on the data volume
+    # (/mnt/data here, /usr/share/graylog/data in the main container) and is seeded
+    # from the JDK CA bundle so public CAs (license checks, GeoIP, notifications)
+    # stay trusted. Built in a temp file and mv'd so a failed init can't leave a
+    # half-built store behind.
+    CACERTS_DST="/mnt/data/cacerts"
+    mkdir -p "${CACERTS_DST}"
+    TRUSTSTORE_TMP="${CACERTS_DST}/graylog.jks.tmp"
+    if [ -f "${CACERTS_DST}/graylog.jks" ]; then
+      cp "${CACERTS_DST}/graylog.jks" "${TRUSTSTORE_TMP}"
+    else
+      cp "${JAVA_HOME}/lib/security/cacerts" "${TRUSTSTORE_TMP}"
+    fi
     # delete-then-import so a rotated CA is picked up on pod restart
-    keytool -delete -alias byo-opensearch-ca -keystore "${CACERTS_SRC}/graylog.jks" -storepass {{ .Values.graylog.config.tls.keyStorePass | default "changeit" }} 2>/dev/null || true
-    keytool -importcert -noprompt -alias byo-opensearch-ca -file "/mnt/os-tls/{{ .Values.opensearch.tls.caKey }}" -keystore "${CACERTS_SRC}/graylog.jks" -storepass {{ .Values.graylog.config.tls.keyStorePass | default "changeit" }}
+    keytool -delete -alias byo-opensearch-ca -keystore "${TRUSTSTORE_TMP}" -storepass {{ .Values.graylog.config.tls.keyStorePass | default "changeit" }} >/dev/null 2>&1 || true
+    keytool -importcert -noprompt -alias byo-opensearch-ca -file "/mnt/os-tls/{{ .Values.opensearch.tls.caKey }}" -keystore "${TRUSTSTORE_TMP}" -storepass {{ .Values.graylog.config.tls.keyStorePass | default "changeit" }}
+    mv "${TRUSTSTORE_TMP}" "${CACERTS_DST}/graylog.jks"
     echo "Imported OpenSearch CA into Graylog truststore."
     {{- end }}
     {{- if .Values.graylog.config.plugins.enabled }}


### PR DESCRIPTION
## Summary
Fixes the BYO OpenSearch CA truststore from #135: it was built in a path that doesn't survive the init container, so Graylog started without it and every TLS connection to OpenSearch failed certificate validation.

## Details
- The init script imported the OpenSearch CA into `/usr/share/graylog/data/cacerts/graylog.jks`, but in the init container the data volume is mounted at `/mnt/data` — the keystore landed on the container's ephemeral filesystem and was discarded, while the main container's `-Djavax.net.ssl.trustStore` pointed at the now-missing file (endless `VersionProbe: certificate_unknown`).
- `keytool -importcert` also created the keystore from scratch, so it held only the OpenSearch CA — public CAs (license checks, GeoIP downloads, HTTP notifications) would have been untrusted even if it had persisted.
- The truststore is now built on the data volume (`/mnt/data/cacerts`), seeded from the JDK CA bundle (`$JAVA_HOME/lib/security/cacerts`), and imported via a temp file `mv`'d into place so a failed init can't leave a half-built store behind.

## Linked issues
Fix for the `byo-os` feature branch (#135).

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog`
- [x] Helm tests pass: `helm test graylog`

### Functional (if applicable)
- [x] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_ — n/a, external OpenSearch mode
- [x] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [x] Verified against an OpenSearch Kubernetes Operator cluster (3 nodes, operator-generated TLS, CA from the operator's `<cluster>-ca` secret): without this fix Graylog loops on `certificate_unknown`; with it, `keytool -list` in the app container shows the JDK CAs plus `byo-opensearch-ca`, indexer health is green, and messages are ingested and searchable.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
