### PR TITLE
feat: Safe Graylog Journal Draining

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -67,6 +67,18 @@ jobs:
       - name: Run helm unittest
         run: helm unittest charts/graylog
 
+      # helm-unittest can only assert on rendered text. These two run the shipped
+      # shell scripts for real: the preStop drain against a stubbed metrics
+      # endpoint, and the init script against fixture volumes (including the
+      # upgrade path, where an existing volume must not be clobbered).
+      - name: preStop drain behaviour tests
+        run: sh charts/graylog/tests/scripts/prestop-drain-behavior-test.sh
+
+      - name: init-script behaviour tests
+        # always() so a drain failure above does not hide an init failure here.
+        if: always()
+        run: sh charts/graylog/tests/scripts/init-graylog-behavior-test.sh
+
   helm-ct-install:
     runs-on: ubuntu-latest
     needs: [helm-ct-lint, helm-unittest]

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -1155,15 +1155,50 @@ Mutually exclusive with `datanode.enabled`. See [Bring Your Own OpenSearch](#bri
 
 ### Forwarder Ingress
 
-| Key Path                                       | Description                           | Default                  |
-|------------------------------------------------|---------------------------------------|--------------------------|
-| `ingress.forwarder.enabled`                    | Enable ingress for Graylog Forwarder. | `false`                  |
-| `ingress.forwarder.className`                  | Ingress class name.                   | `""`                     |
-| `ingress.forwarder.annotations`                | Annotations for ingress resource.     | `{}`                     |
-| `ingress.forwarder.hosts[0].host`              | Hostname for ingress.                 | `chart-example.local`    |
-| `ingress.forwarder.hosts[0].paths[0].path`     | Path for routing.                     | `/`                      |
-| `ingress.forwarder.hosts[0].paths[0].pathType` | Path matching type.                   | `ImplementationSpecific` |
-| `ingress.forwarder.tls`                        | TLS configuration.                    | `[]`                     |
+A [Graylog Forwarder](https://go2docs.graylog.org/current/getting_in_log_data/forwarder.html) requires **both**
+gRPC channels to be reachable: the message channel (port `13301`) it ships log data on, and the configuration
+channel (port `13302`) it polls for configuration updates. Because the two channels listen on different ports
+and an Ingress routes on host/path rather than listener port, each channel is rendered as its own Ingress
+resource — `<release>-forwarder-message-channel` and `<release>-forwarder-config-channel`.
+
+Setting `ingress.forwarder.enabled: true` enables both channels; disable one with
+`ingress.forwarder.<channel>.enabled: false`.
+
+The Forwarder is an enterprise feature and requires a valid license. Enabling the ingress also sets
+`GRAYLOG_FORWARDER_BIND_ADDRESS` (see `graylog.config.forwarder` below) — without it Graylog never listens on
+`13301`/`13302` and forwarders fail with `Code=<UNAVAILABLE>` no matter how the endpoint is exposed.
+
+In addition, a **Forwarder input** must exist. Graylog Cloud provisions it automatically; self-managed
+deployments must create it manually under **System > Inputs**. Creating a forwarder token under
+**System > Forwarders** is not sufficient — until the input exists, the ports stay closed and load balancer
+targets remain unhealthy.
+
+| Key Path                                  | Description                                                                                    | Default     |
+|-------------------------------------------|------------------------------------------------------------------------------------------------|-------------|
+| `graylog.config.forwarder.enabled`        | Listen for forwarder connections. Unset defaults to `ingress.forwarder.enabled`.                | `null`      |
+| `graylog.config.forwarder.bindAddress`    | `GRAYLOG_FORWARDER_BIND_ADDRESS`.                                                              | `0.0.0.0`   |
+| `graylog.config.forwarder.grpcEnableTls`  | Encrypt forwarder&nbsp;→&nbsp;Graylog transport. Leave `false` when a load balancer terminates TLS. | `false` |
+
+| Key Path                                                      | Description                                     | Default                  |
+|---------------------------------------------------------------|-------------------------------------------------|--------------------------|
+| `ingress.forwarder.enabled`                                   | Enable ingress for Graylog Forwarder ingest.    | `false`                  |
+| `ingress.forwarder.messageChannel.enabled`                    | Expose the message channel (port `13301`).      | `true`                   |
+| `ingress.forwarder.messageChannel.className`                  | Ingress class name.                             | `""`                     |
+| `ingress.forwarder.messageChannel.annotations`                | Annotations for ingress resource.               | `{}`                     |
+| `ingress.forwarder.messageChannel.hosts[0].host`              | Hostname for ingress (optional).                | `""`                     |
+| `ingress.forwarder.messageChannel.hosts[0].paths[0].path`     | Path for routing.                               | `/`                      |
+| `ingress.forwarder.messageChannel.hosts[0].paths[0].pathType` | Path matching type.                             | `ImplementationSpecific` |
+| `ingress.forwarder.messageChannel.tls`                        | TLS configuration.                              | `[]`                     |
+| `ingress.forwarder.configChannel.enabled`                     | Expose the configuration channel (port `13302`).| `true`                   |
+| `ingress.forwarder.configChannel.className`                   | Ingress class name.                             | `""`                     |
+| `ingress.forwarder.configChannel.annotations`                 | Annotations for ingress resource.               | `{}`                     |
+| `ingress.forwarder.configChannel.hosts[0].host`               | Hostname for ingress (optional).                | `""`                     |
+| `ingress.forwarder.configChannel.hosts[0].paths[0].path`      | Path for routing.                               | `/`                      |
+| `ingress.forwarder.configChannel.hosts[0].paths[0].pathType`  | Path matching type.                             | `ImplementationSpecific` |
+| `ingress.forwarder.configChannel.tls`                         | TLS configuration.                              | `[]`                     |
+
+See [`examples/forwarder-ingress.yaml`](../../examples/forwarder-ingress.yaml) for a worked AWS ALB
+configuration.
 
 ## MongoDB
 MongoDB Community Resource configuration.

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -18,6 +18,7 @@ Official Helm chart for Graylog.
   * [Set external access](#set-external-access)
 * [Usage](#usage)
   * [Scale Graylog](#scale-graylog)
+  * [Message Journal Lifecycle](#message-journal-lifecycle)
   * [Scale DataNode](#scale-datanode)
   * [Data Node Replicas and Data Redundancy](#data-node-replicas-and-data-redundancy)
   * [High Availability Defaults](#high-availability-defaults)
@@ -287,10 +288,121 @@ kubectl port-forward service/graylog-svc 9000:9000 -n graylog
 ```sh
 # scaling out: add more Graylog nodes to your cluster
 helm upgrade graylog graylog/graylog -n graylog --set graylog.replicas=3 --reuse-values
+```
 
+Scaling **out** is safe and needs no procedure. Scaling **in** can lose buffered
+messages — read [Message Journal Lifecycle](#message-journal-lifecycle) before you
+do it.
+
+```sh
 # scaling in: remove Graylog nodes from your cluster
+# WARNING: drain first. See "Message Journal Lifecycle" below.
 helm upgrade graylog graylog/graylog -n graylog --set graylog.replicas=1 --reuse-values
 ```
+
+## Message Journal Lifecycle
+
+Each Graylog node writes incoming messages to an on-disk **journal** on its own
+PersistentVolumeClaim, then works them off into the indexer. The journal is what
+makes Graylog durable across restarts — and it is why scaling in is not a routine
+operation.
+
+### Why upgrades are safe but scale-in is not
+
+A StatefulSet guarantees **identity**, not data migration. On a rolling upgrade,
+`graylog-app-2` is replaced by a new `graylog-app-2` that re-binds the *same* PVC,
+finds the same journal, and carries on — nothing is lost, and no procedure is
+needed.
+
+On scale-in, that ordinal stops existing. Its PVC is retained but no pod will ever
+mount it again, so anything still in that journal is unreachable. Graylog's
+graceful shutdown flushes in-memory buffers **into** the journal; it never drains
+the journal **out**. Draining is the *replacement pod's* job, and on scale-in there
+is no replacement pod.
+
+Two consequences worth knowing:
+
+- Scaling back up later re-binds the old PVC and **replays days-old messages** into
+  the pipeline. Late arrivals will hit alerts, dashboards, and index retention.
+- The data is not destroyed, just unreachable. See [Recovering an orphaned
+  journal](#recovering-an-orphaned-journal).
+
+### Automatic drain on shutdown
+
+The chart can hold pod termination while the journal is worked off:
+
+```sh
+helm upgrade graylog graylog/graylog -n graylog \
+  --set graylog.lifecycle.preStopDrain.enabled=true --reuse-values
+```
+
+This installs a `preStop` hook that polls journal depth
+(`gl_journal_entries_uncommitted`) from Graylog's Prometheus exporter on
+`localhost` and returns once the journal is empty. It needs **no credentials** —
+the exporter answers unauthenticated on the pod itself, unlike
+`GET /api/system/journal`. It does require `graylog.service.metrics.enabled`
+(the default); the chart refuses to render otherwise.
+
+It is **off by default** because it slows every rolling upgrade by the drain time.
+
+**It is best-effort, not a guarantee.** Understand these limits before relying on it:
+
+| Limit | Consequence |
+|---|---|
+| Bounded by `terminationGracePeriodSeconds` | The hook always yields in time for SIGTERM (see below). If the journal is still full, termination proceeds anyway. |
+| Only sheds *newly established* connections | Kubernetes removes the terminating pod from Service endpoints, but long-lived TCP inputs and UDP senders keep writing. Against those the journal may never reach zero, and the hook gives up after `stallPolls` samples with no decrease. |
+| Does not stop inputs | Stopping inputs requires an authenticated API call. Only the manual runbook can guarantee an empty journal. |
+
+#### The grace-period budget
+
+`terminationGracePeriodSeconds` is a hard ceiling covering the `preStop` hook **and**
+the SIGTERM that follows it. If the hook is still running when it expires, the
+container is SIGKILLed, Graylog never receives SIGTERM, and the in-memory buffers
+this feature exists to protect are lost — strictly worse than no hook at all.
+
+So the drain never uses the whole grace period:
+
+```
+drain budget = terminationGracePeriodSeconds
+             - endpointPropagationDelaySeconds   # wait for endpoint removal
+             - shutdownReserveSeconds            # left for Graylog's own shutdown
+```
+
+With the defaults that is `300 - 15 - 45 = 240s`. The chart fails to render if the
+budget is not positive, so raising the reserve means raising the grace period too.
+
+The Kubernetes default grace period is 30s, which is not enough to flush buffers
+under load. The chart sets `300` explicitly.
+
+### Recovering an orphaned journal
+
+If a node was scaled in without draining, its claim is still there:
+
+```sh
+kubectl get pvc -n graylog          # e.g. graylog-app-data-graylog-app-2
+```
+
+Two options:
+
+- **Replay it** — scale back up to the original replica count. The ordinal returns,
+  re-binds the claim, and Graylog replays the journal. Then drain properly and scale
+  in again. Note the late-arrival side effects above.
+- **Discard it** — once you have confirmed the journal is empty (or that you do not
+  want its contents), delete the claim:
+
+  ```sh
+  kubectl delete pvc graylog-app-data-graylog-app-2 -n graylog
+  ```
+
+### Inspecting journal depth manually
+
+```sh
+kubectl port-forward -n graylog pod/graylog-app-2 9833:9833
+curl -s localhost:9833/metrics | grep '^gl_journal_entries_uncommitted'
+```
+
+Port-forward the **pod**, not the Service — the Service would answer from an
+arbitrary node. `0` means that node's journal is fully worked off.
 
 ## Scale DataNode
 ```sh
@@ -838,6 +950,12 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.readinessProbe.timeoutSeconds`                               | Timeout for the readiness probe.                            | `5`                             |
 | `graylog.readinessProbe.failureThreshold`                             | Failure threshold for the readiness probe.                  | `6`                             |
 | `graylog.readinessProbe.successThreshold`                             | Success threshold for the readiness probe.                  | `1`                             |
+| `graylog.terminationGracePeriodSeconds`                               | Shutdown budget before SIGKILL. Covers the preStop hook and Graylog's own graceful shutdown. | `300`  |
+| `graylog.lifecycle.preStopDrain.enabled`                              | Hold termination while the journal drains. See [Message Journal Lifecycle](#message-journal-lifecycle). | `false` |
+| `graylog.lifecycle.preStopDrain.endpointPropagationDelaySeconds`      | Wait for EndpointSlice removal to reach kube-proxy before sampling. | `15`                     |
+| `graylog.lifecycle.preStopDrain.pollIntervalSeconds`                  | Seconds between journal-depth samples.                      | `2`                             |
+| `graylog.lifecycle.preStopDrain.shutdownReserveSeconds`               | Seconds reserved out of the grace period for Graylog's own shutdown. | `45`                   |
+| `graylog.lifecycle.preStopDrain.stallPolls`                           | Give up after this many polls with no decrease in journal depth. | `10`                       |
 | `graylog.podDisruptionBudget.enabled`                                 | Enable PodDisruptionBudget.                                 | `false`                         |
 | `graylog.podDisruptionBudget.minAvailable`                            | Minimum available pods during disruption.                   | `1`                             |
 | `graylog.podAnnotations`                                              | Additional pod annotations.                                 | `{}`                            |

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -338,12 +338,52 @@ helm upgrade graylog graylog/graylog -n graylog \
 
 This installs a `preStop` hook that polls journal depth
 (`gl_journal_entries_uncommitted`) from Graylog's Prometheus exporter on
-`localhost` and returns once the journal is empty. It needs **no credentials** —
+`localhost` and returns once the journal is empty.
+
+A single reading of zero is not treated as proof: under live ingest the depth
+oscillates and can momentarily touch zero while messages are still arriving, so the
+hook requires it to hold at zero across `confirmPolls` consecutive samples (default
+3) before declaring success. Failed metrics scrapes are retried `metricsRetries`
+times (default 5) rather than abandoning the drain on one miss. It needs **no credentials** —
 the exporter answers unauthenticated on the pod itself, unlike
 `GET /api/system/journal`. It does require `graylog.service.metrics.enabled`
 (the default); the chart refuses to render otherwise.
 
 It is **off by default** because it slows every rolling upgrade by the drain time.
+
+#### Feasibility check
+
+After `feasibilityWarmupPolls` samples (default 5) the hook measures the actual
+drain rate and projects when the journal would reach zero. If that projection does
+not fit in the remaining budget, it **aborts immediately** with a `CRIT` verdict
+rather than holding termination for a drain that cannot land:
+
+```text
+CRIT  FEASIBILITY: drain cannot finish in the time available - aborting instead of holding termination for nothing
+CRIT    journal on disk: 5.0GiB of 5.0GiB cap (100% full)
+CRIT    the journal is AT its cap - Graylog is already discarding the oldest segments, so messages are being lost right now
+CRIT    backlog:         999727 messages awaiting processing
+CRIT    drain rate:      107 msg/s measured over 2s (ingest 1200 msg/s)
+CRIT    time to clear:   ~2h35m at that rate
+CRIT    time available:  53s of the 55s drain budget
+CRIT    short by:        ~2h34m
+CRIT    999727 messages will NOT be drained by this hook - stop the inputs and drain manually to save them
+```
+
+A depth that is flat or growing reports `time to clear: never at this rate`, and
+points at the likely cause — an indexer refusing writes, typically a read-only
+index block or a disk watermark.
+
+This exists because `stallPolls` alone is not enough. It only notices a journal
+that has *stopped* falling; it cannot notice one falling far too slowly to matter,
+because every new low resets the counter. On a flooded cluster that meant the hook
+held termination for its entire 240s budget to clear ~2% of a 7.24M-message
+backlog, then stranded the rest anyway — and paid that cost on every pod in the
+rollout. Aborting early instead returns the unused grace period to Graylog's own
+shutdown, which can actually use it.
+
+Set `feasibilityWarmupPolls: 0` to disable the projection and always drain for the
+full budget.
 
 **It is best-effort, not a guarantee.** Understand these limits before relying on it:
 
@@ -353,6 +393,10 @@ It is **off by default** because it slows every rolling upgrade by the drain tim
 | Only sheds *newly established* connections | Kubernetes removes the terminating pod from Service endpoints, but that only stops new connections. Long-lived TCP inputs, UDP senders, and internally generated inputs keep writing. Against those the journal never reaches zero, and the hook gives up once journal depth stops reaching new lows for `stallPolls` samples. |
 | Does not stop inputs | Stopping inputs requires an authenticated API call. Only the manual runbook can guarantee an empty journal. |
 | Pointless on rolling upgrades | A replacement pod re-binds the same PVC and replays the journal itself, so there is nothing to protect. The hook cannot tell an upgrade from a scale-in, so it pays the cost on both. |
+| Cannot drain a blocked indexer | If the indexer refuses writes, nothing can be worked off and the journal only grows. The feasibility check detects this and aborts in a few seconds instead of stalling the rollout — but **disable the hook before rolling an already-backed-up cluster**, or it will still slow each pod by the warmup window. |
+
+See [preStop drain failure modes](../../docs/prestop-drain-failure-modes.md) for
+the incident this behaviour was derived from.
 
 > [!IMPORTANT]
 > Enable this only if you routinely scale in. On a node that is still receiving
@@ -382,20 +426,6 @@ the pod leaves Service endpoints. Then ingest to that node genuinely stops, dept
 falls to zero, and the hook exits early having saved the journal that would
 otherwise have been stranded.
 
-### Watching a drain
-
-The hook writes its progress to the container's log stream, so:
-
-```sh
-# follow BEFORE you terminate — a pod's logs are destroyed with the pod object
-kubectl logs -n graylog -l app=graylog-app -c graylog-app \
-  --follow --prefix --tail=0 --max-log-requests=20 | grep "prestop-drain"
-```
-
-A post-mortem `kubectl logs` will find nothing: the terminated pod is gone. Note
-also that Kubernetes discards `preStop` output by default — these lines are
-visible only because the hook writes to PID 1's stdout deliberately.
-
 #### The grace-period budget
 
 `terminationGracePeriodSeconds` is a hard ceiling covering the `preStop` hook **and**
@@ -417,25 +447,109 @@ budget is not positive, so raising the reserve means raising the grace period to
 The Kubernetes default grace period is 30s, which is not enough to flush buffers
 under load. The chart sets `300` explicitly.
 
-### Recovering an orphaned journal
+### Watching a drain
 
-If a node was scaled in without draining, its claim is still there:
+The hook writes its progress to the container's log stream, so:
 
 ```sh
-kubectl get pvc -n graylog          # e.g. graylog-app-data-graylog-app-2
+# follow BEFORE you terminate — a pod's logs are destroyed with the pod object
+kubectl logs -n graylog -l app=graylog-app -c graylog-app \
+  --follow --prefix --tail=0 --max-log-requests=20 | grep "prestop-drain"
 ```
 
-Two options:
+A post-mortem `kubectl logs` will find nothing: the terminated pod is gone. Note
+also that Kubernetes discards `preStop` output by default — these lines are
+visible only because the hook writes to PID 1's stdout deliberately.
 
-- **Replay it** — scale back up to the original replica count. The ordinal returns,
-  re-binds the claim, and Graylog replays the journal. Then drain properly and scale
-  in again. Note the late-arrival side effects above.
-- **Discard it** — once you have confirmed the journal is empty (or that you do not
-  want its contents), delete the claim:
+### Scaling in: is it safe to delete the leftover PVC?
 
-  ```sh
-  kubectl delete pvc graylog-app-data-graylog-app-2 -n graylog
-  ```
+Scaling in removes the highest ordinal and leaves its claim behind. The chart pins
+`persistentVolumeClaimRetentionPolicy` to `Retain` on both `whenScaled` and
+`whenDeleted`, and **refuses to render `whenScaled: Delete`** — so the volume is
+never destroyed automatically, and the decision to delete it is always yours.
+
+```sh
+kubectl get pvc -n graylog          # e.g. graylog-data-graylog-3
+```
+
+#### Disk size is not the signal
+
+This is the part that surprises people. **A fully drained journal still occupies
+hundreds of megabytes**, and that is correct.
+
+Two different things get measured:
+
+| | Means |
+|---|---|
+| `gl_journal_entries_uncommitted` | messages **left to process** — this is what "drained" means |
+| journal size on disk | messages **still stored** |
+
+Graylog never deletes a segment merely because it has been processed. Segments are
+retained for `graylog.config.messageJournal.maxAge` (default **12h**) and reaped only
+once a segment is both fully committed *and* past retention. So a drained node keeps
+up to 12 hours of already-delivered messages on disk.
+
+A real example, sampled at one instant on a node whose drain had just reported
+`0 messages remaining`:
+
+```
+du(journal dir)      =    127.9 MiB
+gl_journal_size      =    127.5 MiB
+uncommitted          =        669
+segments:
+  00000000000003928790.log   100.0 MiB   <- rolled at segmentSize, fully processed
+  00000000000004074253.log    27.9 MiB   <- active segment, being appended to
+```
+
+That 100 MiB segment sits entirely below the committed offset: every message in it is
+already in OpenSearch. Deleting it loses nothing. Judge the claim by
+`uncommitted`, never by `du`.
+
+You will also see the on-disk figure **sawtooth** — climbing steadily, then dropping
+by ~100 MiB at once. That is a fully-committed segment being reaped, not data loss.
+
+#### Verifying before you delete
+
+The drain hook's verdict is good evidence but it is a point-in-time measurement, and
+"committed" means *read out of the journal into the processing pipeline* — the final
+hop into OpenSearch happens from an in-memory buffer during graceful shutdown. So
+confirm rather than assume. Two ways, strongest first:
+
+1. **Re-attach the volume.** Scale back up by one. The ordinal returns, re-binds the
+   same claim, and Graylog replays anything unprocessed. Watch `uncommitted` on that
+   pod settle at `0` with inputs quiesced, then scale in again and delete the claim.
+   This is both the test and the fix: if something *was* stranded, replaying it is
+   what you wanted.
+
+2. **Inspect it offline.** `examples/inspect-orphaned-journal.yaml` mounts the claim
+   read-only and compares the committed offset against the segments:
+
+   ```sh
+   kubectl apply -n graylog -f examples/inspect-orphaned-journal.yaml
+   kubectl logs -n graylog journal-inspector -f
+   kubectl delete -n graylog pod/journal-inspector
+   ```
+
+   > [!IMPORTANT]
+   > It can prove that messages **were** stranded, but it cannot prove the opposite.
+   > Graylog's offset index is sparse, so records past the last index entry are
+   > invisible to any offline reader. Measured on a live node: the index looked clean
+   > while the node genuinely had 537 unprocessed messages. Treat
+   > `NO EVIDENCE OF STRANDED DATA` as "no evidence", not as proof — use option 1 when
+   > you need certainty.
+
+Then delete it:
+
+```sh
+kubectl delete pvc graylog-data-graylog-3 -n graylog
+```
+
+#### If you scaled in without draining
+
+The data is not lost, just unreachable — nothing will ever mount that claim again.
+Scale back up to the original replica count: the ordinal returns, re-binds the claim,
+and Graylog replays the journal. Expect the late-arrival side effects described above
+(alerts, dashboards, index retention). Then drain properly and scale in again.
 
 ### Inspecting journal depth manually
 
@@ -1002,6 +1116,11 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.lifecycle.preStopDrain.pollIntervalSeconds`                  | Seconds between journal-depth samples.                      | `2`                             |
 | `graylog.lifecycle.preStopDrain.shutdownReserveSeconds`               | Seconds reserved out of the grace period for Graylog's own shutdown. | `45`                   |
 | `graylog.lifecycle.preStopDrain.stallPolls`                           | Give up after this many polls with no decrease in journal depth. | `10`                       |
+| `graylog.lifecycle.preStopDrain.statusIntervalSeconds`                | How often to log a progress line during the drain.          | `10`                            |
+| `graylog.lifecycle.preStopDrain.confirmPolls`                          | Consecutive zero readings required before declaring the journal drained. | `3`                |
+| `graylog.lifecycle.preStopDrain.metricsRetries`                        | Retries for the metrics probe before giving up.              | `5`                             |
+| `graylog.persistence.retentionPolicy.whenDeleted`                      | PVC fate when the StatefulSet is deleted.                   | `Retain`                        |
+| `graylog.persistence.retentionPolicy.whenScaled`                       | PVC fate when scaled in. `Delete` is refused — it destroys a scaled-in node's journal. | `Retain` |
 | `graylog.podDisruptionBudget.enabled`                                 | Enable PodDisruptionBudget.                                 | `false`                         |
 | `graylog.podDisruptionBudget.minAvailable`                            | Minimum available pods during disruption.                   | `1`                             |
 | `graylog.podAnnotations`                                              | Additional pod annotations.                                 | `{}`                            |
@@ -1164,20 +1283,30 @@ resource — `<release>-forwarder-message-channel` and `<release>-forwarder-conf
 Setting `ingress.forwarder.enabled: true` enables both channels; disable one with
 `ingress.forwarder.<channel>.enabled: false`.
 
-The Forwarder is an enterprise feature and requires a valid license. Enabling the ingress also sets
-`GRAYLOG_FORWARDER_BIND_ADDRESS` (see `graylog.config.forwarder` below) — without it Graylog never listens on
-`13301`/`13302` and forwarders fail with `Code=<UNAVAILABLE>` no matter how the endpoint is exposed.
+The Forwarder is an enterprise feature and requires a valid license.
 
-In addition, a **Forwarder input** must exist. Graylog Cloud provisions it automatically; self-managed
-deployments must create it manually under **System > Inputs**. Creating a forwarder token under
-**System > Forwarders** is not sufficient — until the input exists, the ports stay closed and load balancer
-targets remain unhealthy.
+The Ingress only exposes the ports — it cannot make Graylog listen on them. A **Forwarder input** must
+exist for that: an input of type **Forwarder**
+(`org.graylog.plugins.forwarder.input.ForwarderServiceInput`) created under **System > Inputs**. Graylog
+Cloud provisions it automatically; self-managed deployments must create it. Registering a forwarder
+under **System > Forwarders** is *not* sufficient — and neither is any chart setting. Until the input
+exists, `13301`/`13302` stay closed, forwarders fail with `Code=<UNAVAILABLE>`, and load balancer
+targets remain unhealthy. Once it exists, Graylog binds the ports on every node.
 
-| Key Path                                  | Description                                                                                    | Default     |
-|-------------------------------------------|------------------------------------------------------------------------------------------------|-------------|
-| `graylog.config.forwarder.enabled`        | Listen for forwarder connections. Unset defaults to `ingress.forwarder.enabled`.                | `null`      |
-| `graylog.config.forwarder.bindAddress`    | `GRAYLOG_FORWARDER_BIND_ADDRESS`.                                                              | `0.0.0.0`   |
-| `graylog.config.forwarder.grpcEnableTls`  | Encrypt forwarder&nbsp;→&nbsp;Graylog transport. Leave `false` when a load balancer terminates TLS. | `false` |
+The listener is configured by attributes **on that input**, not through `server.conf` or this chart:
+
+| Input attribute | Default |
+|---|---|
+| `forwarder_bind_address` | `0.0.0.0` |
+| `forwarder_message_transmission_port` | `13301` |
+| `forwarder_configuration_port` | `13302` |
+| `forwarder_grpc_enable_tls` | `true` |
+
+> [!IMPORTANT]
+> `forwarder_grpc_enable_tls` defaults to **true** on the input. When a load balancer terminates TLS and
+> speaks cleartext HTTP/2 to Graylog — as in the ALB example above — it must be set to **false**, or the
+> targets never become healthy. Set TLS on the *forwarder agent* instead, since it connects to the load
+> balancer's certificate.
 
 | Key Path                                                      | Description                                     | Default                  |
 |---------------------------------------------------------------|-------------------------------------------------|--------------------------|

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -302,264 +302,70 @@ helm upgrade graylog graylog/graylog -n graylog --set graylog.replicas=1 --reuse
 
 ## Message Journal Lifecycle
 
-Each Graylog node writes incoming messages to an on-disk **journal** on its own
-PersistentVolumeClaim, then works them off into the indexer. The journal is what
-makes Graylog durable across restarts — and it is why scaling in is not a routine
-operation.
+Each Graylog node buffers incoming messages in an on-disk journal on its own PVC,
+then works them off into the indexer.
 
-### Why upgrades are safe but scale-in is not
+Rolling upgrades are safe with no procedure: the replacement pod keeps the ordinal,
+re-binds the same PVC, and replays the journal. **Scale-in is not.** The ordinal
+stops existing, so its PVC is retained but never mounted again, and anything left
+unprocessed in that journal is unreachable. Graceful shutdown flushes memory buffers
+*into* the journal; it never drains the journal *out*.
 
-A StatefulSet guarantees **identity**, not data migration. On a rolling upgrade,
-`graylog-app-2` is replaced by a new `graylog-app-2` that re-binds the *same* PVC,
-finds the same journal, and carries on — nothing is lost, and no procedure is
-needed.
+Before scaling in, drain the node. See
+[Graylog Message Handling](../../docs/graylog-message-handling.md) for the runbook,
+how to read a drain's logs, and what to do with the leftover PVC.
 
-On scale-in, that ordinal stops existing. Its PVC is retained but no pod will ever
-mount it again, so anything still in that journal is unreachable. Graylog's
-graceful shutdown flushes in-memory buffers **into** the journal; it never drains
-the journal **out**. Draining is the *replacement pod's* job, and on scale-in there
-is no replacement pod.
+### Shutdown budget
 
-Two consequences worth knowing:
+`graylog.terminationGracePeriodSeconds` (default `300`) covers the preStop hook
+**and** the SIGTERM after it. The Kubernetes default of 30s is not enough to flush
+buffers under load.
 
-- Scaling back up later re-binds the old PVC and **replays days-old messages** into
-  the pipeline. Late arrivals will hit alerts, dashboards, and index retention.
-- The data is not destroyed, just unreachable. See [Recovering an orphaned
-  journal](#recovering-an-orphaned-journal).
+### Automatic drain
 
-### Automatic drain on shutdown
-
-The chart can hold pod termination while the journal is worked off:
+Off by default. Holds pod termination while the journal is worked off, so a
+scale-in has a chance to finish processing:
 
 ```sh
 helm upgrade graylog graylog/graylog -n graylog \
   --set graylog.lifecycle.preStopDrain.enabled=true --reuse-values
 ```
 
-This installs a `preStop` hook that polls journal depth
-(`gl_journal_entries_uncommitted`) from Graylog's Prometheus exporter on
-`localhost` and returns once the journal is empty.
+It reads journal depth from the Prometheus exporter on localhost, so it needs no
+credentials, but it does require `graylog.service.metrics.enabled` (the default).
 
-A single reading of zero is not treated as proof: under live ingest the depth
-oscillates and can momentarily touch zero while messages are still arriving, so the
-hook requires it to hold at zero across `confirmPolls` consecutive samples (default
-3) before declaring success. Failed metrics scrapes are retried `metricsRetries`
-times (default 5) rather than abandoning the drain on one miss. It needs **no credentials** —
-the exporter answers unauthenticated on the pod itself, unlike
-`GET /api/system/journal`. It does require `graylog.service.metrics.enabled`
-(the default); the chart refuses to render otherwise.
+It is best-effort. It cannot stop inputs, so on a node still receiving traffic the
+journal never reaches zero and the hook gives up. It also cannot tell an upgrade
+from a scale-in, so it slows both. Enable it if you routinely scale in.
 
-It is **off by default** because it slows every rolling upgrade by the drain time.
+| Key | Description | Default |
+|---|---|---|
+| `enabled` | Hold termination while the journal drains. | `false` |
+| `endpointPropagationDelaySeconds` | Sleep before the first sample, waiting for endpoint removal to propagate. Raise it if a load balancer targets pod IPs directly. | `15` |
+| `shutdownReserveSeconds` | Held back out of the grace period for Graylog's own shutdown. | `45` |
+| `pollIntervalSeconds` | Seconds between journal-depth samples. | `2` |
+| `stallPolls` | Give up after this many polls with no new low. | `10` |
+| `confirmPolls` | Consecutive zero readings required before declaring success. | `3` |
+| `metricsRetries` | Metrics probe retries before giving up. | `5` |
+| `statusIntervalSeconds` | How often to log a progress line. | `10` |
+| `feasibilityWarmupPolls` | Polls to observe before projecting whether the drain can finish at all; aborts early if it cannot. `0` disables. | `5` |
 
-#### Feasibility check
+All under `graylog.lifecycle.preStopDrain`. The drain budget is
+`terminationGracePeriodSeconds - endpointPropagationDelaySeconds - shutdownReserveSeconds`
+(240s at defaults); the chart refuses to render if that is not positive.
 
-After `feasibilityWarmupPolls` samples (default 5) the hook measures the actual
-drain rate and projects when the journal would reach zero. If that projection does
-not fit in the remaining budget, it **aborts immediately** with a `CRIT` verdict
-rather than holding termination for a drain that cannot land:
+### PVC retention
 
-```text
-CRIT  FEASIBILITY: drain cannot finish in the time available - aborting instead of holding termination for nothing
-CRIT    journal on disk: 5.0GiB of 5.0GiB cap (100% full)
-CRIT    the journal is AT its cap - Graylog is already discarding the oldest segments, so messages are being lost right now
-CRIT    backlog:         999727 messages awaiting processing
-CRIT    drain rate:      107 msg/s measured over 2s (ingest 1200 msg/s)
-CRIT    time to clear:   ~2h35m at that rate
-CRIT    time available:  53s of the 55s drain budget
-CRIT    short by:        ~2h34m
-CRIT    999727 messages will NOT be drained by this hook - stop the inputs and drain manually to save them
-```
+Both StatefulSets pin `persistentVolumeClaimRetentionPolicy` to `Retain`, so no
+claim is deleted automatically. `graylog.persistence.retentionPolicy.whenScaled: Delete`
+is **refused** — it would destroy a scaled-in node's journal. The Data Node permits
+it, since shard data rebuilds from replicas.
 
-A depth that is flat or growing reports `time to clear: never at this rate`, and
-points at the likely cause — an indexer refusing writes, typically a read-only
-index block or a disk watermark.
-
-This exists because `stallPolls` alone is not enough. It only notices a journal
-that has *stopped* falling; it cannot notice one falling far too slowly to matter,
-because every new low resets the counter. On a flooded cluster that meant the hook
-held termination for its entire 240s budget to clear ~2% of a 7.24M-message
-backlog, then stranded the rest anyway — and paid that cost on every pod in the
-rollout. Aborting early instead returns the unused grace period to Graylog's own
-shutdown, which can actually use it.
-
-Set `feasibilityWarmupPolls: 0` to disable the projection and always drain for the
-full budget.
-
-**It is best-effort, not a guarantee.** Understand these limits before relying on it:
-
-| Limit | Consequence |
-|---|---|
-| Bounded by `terminationGracePeriodSeconds` | The hook always yields in time for SIGTERM (see below). If the journal is still full, termination proceeds anyway. |
-| Only sheds *newly established* connections | Kubernetes removes the terminating pod from Service endpoints, but that only stops new connections. Long-lived TCP inputs, UDP senders, and internally generated inputs keep writing. Against those the journal never reaches zero, and the hook gives up once journal depth stops reaching new lows for `stallPolls` samples. |
-| Does not stop inputs | Stopping inputs requires an authenticated API call. Only the manual runbook can guarantee an empty journal. |
-| Pointless on rolling upgrades | A replacement pod re-binds the same PVC and replays the journal itself, so there is nothing to protect. The hook cannot tell an upgrade from a scale-in, so it pays the cost on both. |
-| Cannot drain a blocked indexer | If the indexer refuses writes, nothing can be worked off and the journal only grows. The feasibility check detects this and aborts in a few seconds instead of stalling the rollout — but **disable the hook before rolling an already-backed-up cluster**, or it will still slow each pod by the warmup window. |
-
-See [preStop drain failure modes](../../docs/prestop-drain-failure-modes.md) for
-the incident this behaviour was derived from.
-
-> [!IMPORTANT]
-> Enable this only if you routinely scale in. On a node that is still receiving
-> traffic the drain cannot finish, and it adds its give-up time to *every* pod
-> termination — including every rolling upgrade, where it buys nothing.
-
-Measured on a 3-node cluster ingesting ~115 msg/s per node from inputs that keep
-producing throughout termination — in this case internally generated traffic, which
-endpoint removal cannot shed at all. Network inputs holding long-lived TCP
-connections behave the same way, because removing a pod from Service endpoints only
-stops *new* connections:
-
-```
-[prestop-drain] waiting 15s for endpoint removal to propagate
-[prestop-drain] no progress in 10 polls (63s): depth 163, best 4, still ingesting
-                113 msg/s. A true drain needs inputs stopped; handing over to
-                graceful shutdown
-```
-
-Pod termination took **89s** instead of ~10s, and the journal never emptied — it
-got as low as 4 entries but new messages kept arriving. That is the expected
-outcome for a node under live load, and it is why the message names the ingest
-rate: the fix is to stop the inputs, not to wait longer.
-
-Where the hook *does* pay off is a scale-in whose senders reconnect elsewhere once
-the pod leaves Service endpoints. Then ingest to that node genuinely stops, depth
-falls to zero, and the hook exits early having saved the journal that would
-otherwise have been stranded.
-
-#### The grace-period budget
-
-`terminationGracePeriodSeconds` is a hard ceiling covering the `preStop` hook **and**
-the SIGTERM that follows it. If the hook is still running when it expires, the
-container is SIGKILLed, Graylog never receives SIGTERM, and the in-memory buffers
-this feature exists to protect are lost — strictly worse than no hook at all.
-
-So the drain never uses the whole grace period:
-
-```
-drain budget = terminationGracePeriodSeconds
-             - endpointPropagationDelaySeconds   # wait for endpoint removal
-             - shutdownReserveSeconds            # left for Graylog's own shutdown
-```
-
-With the defaults that is `300 - 15 - 45 = 240s`. The chart fails to render if the
-budget is not positive, so raising the reserve means raising the grace period too.
-
-The Kubernetes default grace period is 30s, which is not enough to flush buffers
-under load. The chart sets `300` explicitly.
-
-### Watching a drain
-
-The hook writes its progress to the container's log stream, so:
-
-```sh
-# follow BEFORE you terminate — a pod's logs are destroyed with the pod object
-kubectl logs -n graylog -l app=graylog-app -c graylog-app \
-  --follow --prefix --tail=0 --max-log-requests=20 | grep "prestop-drain"
-```
-
-A post-mortem `kubectl logs` will find nothing: the terminated pod is gone. Note
-also that Kubernetes discards `preStop` output by default — these lines are
-visible only because the hook writes to PID 1's stdout deliberately.
-
-### Scaling in: is it safe to delete the leftover PVC?
-
-Scaling in removes the highest ordinal and leaves its claim behind. The chart pins
-`persistentVolumeClaimRetentionPolicy` to `Retain` on both `whenScaled` and
-`whenDeleted`, and **refuses to render `whenScaled: Delete`** — so the volume is
-never destroyed automatically, and the decision to delete it is always yours.
-
-```sh
-kubectl get pvc -n graylog          # e.g. graylog-data-graylog-3
-```
-
-#### Disk size is not the signal
-
-This is the part that surprises people. **A fully drained journal still occupies
-hundreds of megabytes**, and that is correct.
-
-Two different things get measured:
-
-| | Means |
-|---|---|
-| `gl_journal_entries_uncommitted` | messages **left to process** — this is what "drained" means |
-| journal size on disk | messages **still stored** |
-
-Graylog never deletes a segment merely because it has been processed. Segments are
-retained for `graylog.config.messageJournal.maxAge` (default **12h**) and reaped only
-once a segment is both fully committed *and* past retention. So a drained node keeps
-up to 12 hours of already-delivered messages on disk.
-
-A real example, sampled at one instant on a node whose drain had just reported
-`0 messages remaining`:
-
-```
-du(journal dir)      =    127.9 MiB
-gl_journal_size      =    127.5 MiB
-uncommitted          =        669
-segments:
-  00000000000003928790.log   100.0 MiB   <- rolled at segmentSize, fully processed
-  00000000000004074253.log    27.9 MiB   <- active segment, being appended to
-```
-
-That 100 MiB segment sits entirely below the committed offset: every message in it is
-already in OpenSearch. Deleting it loses nothing. Judge the claim by
-`uncommitted`, never by `du`.
-
-You will also see the on-disk figure **sawtooth** — climbing steadily, then dropping
-by ~100 MiB at once. That is a fully-committed segment being reaped, not data loss.
-
-#### Verifying before you delete
-
-The drain hook's verdict is good evidence but it is a point-in-time measurement, and
-"committed" means *read out of the journal into the processing pipeline* — the final
-hop into OpenSearch happens from an in-memory buffer during graceful shutdown. So
-confirm rather than assume. Two ways, strongest first:
-
-1. **Re-attach the volume.** Scale back up by one. The ordinal returns, re-binds the
-   same claim, and Graylog replays anything unprocessed. Watch `uncommitted` on that
-   pod settle at `0` with inputs quiesced, then scale in again and delete the claim.
-   This is both the test and the fix: if something *was* stranded, replaying it is
-   what you wanted.
-
-2. **Inspect it offline.** `examples/inspect-orphaned-journal.yaml` mounts the claim
-   read-only and compares the committed offset against the segments:
-
-   ```sh
-   kubectl apply -n graylog -f examples/inspect-orphaned-journal.yaml
-   kubectl logs -n graylog journal-inspector -f
-   kubectl delete -n graylog pod/journal-inspector
-   ```
-
-   > [!IMPORTANT]
-   > It can prove that messages **were** stranded, but it cannot prove the opposite.
-   > Graylog's offset index is sparse, so records past the last index entry are
-   > invisible to any offline reader. Measured on a live node: the index looked clean
-   > while the node genuinely had 537 unprocessed messages. Treat
-   > `NO EVIDENCE OF STRANDED DATA` as "no evidence", not as proof — use option 1 when
-   > you need certainty.
-
-Then delete it:
-
-```sh
-kubectl delete pvc graylog-data-graylog-3 -n graylog
-```
-
-#### If you scaled in without draining
-
-The data is not lost, just unreachable — nothing will ever mount that claim again.
-Scale back up to the original replica count: the ordinal returns, re-binds the claim,
-and Graylog replays the journal. Expect the late-arrival side effects described above
-(alerts, dashboards, index retention). Then drain properly and scale in again.
-
-### Inspecting journal depth manually
-
-```sh
-kubectl port-forward -n graylog pod/graylog-app-2 9833:9833
-curl -s localhost:9833/metrics | grep '^gl_journal_entries_uncommitted'
-```
-
-Port-forward the **pod**, not the Service — the Service would answer from an
-arbitrary node. `0` means that node's journal is fully worked off.
+> [!WARNING]
+> Retention protects the claim from the StatefulSet controller, not from you.
+> Deleting a retained PVC destroys the disk under most StorageClasses, including this
+> chart's gp3 class. See
+> [Deleting a leftover PVC](../../docs/graylog-message-handling.md#deleting-a-leftover-pvc).
 
 ## Scale DataNode
 ```sh
@@ -1025,7 +831,8 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.config.mongodb.customUri`                                    | Custom MongoDB connection URI.                              | `""`                            |
 | `graylog.config.mongodb.maxConnections`                               | Max MongoDB connections.                                    | `"1000"`                        |
 | `graylog.config.mongodb.versionProbeAttempts`                         | MongoDB version probe attempts.                             | `"0"`                           |
-| `graylog.config.messageJournal.enabled`                               | Enable message journal.                                     | `"true"`                        |
+| `graylog.config.messageJournal.enabled`                               | Enable message journal. Requires durable storage — the chart refuses to render this with `persistence.enabled=false` and no `existingClaim`, since the journal would be an `emptyDir`. A string, so disabling needs `--set-string`. | `"true"` |
+| `graylog.config.messageJournal.maxSize`                                | On-disk journal cap. Must stay under 90% of `graylog.persistence.size`; the chart refuses to render otherwise. Binary suffixes — `5gb` is 5×1024³. | `"5gb"` |
 | `graylog.config.messageJournal.flushAge`                              | Journal flush age.                                          | `"1m"`                          |
 | `graylog.config.messageJournal.flushInterval`                         | Journal flush interval.                                     | `"1000000"`                     |
 | `graylog.config.messageJournal.maxAge`                                | Max journal age.                                            | `"12h"`                         |
@@ -1119,6 +926,7 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.lifecycle.preStopDrain.statusIntervalSeconds`                | How often to log a progress line during the drain.          | `10`                            |
 | `graylog.lifecycle.preStopDrain.confirmPolls`                          | Consecutive zero readings required before declaring the journal drained. | `3`                |
 | `graylog.lifecycle.preStopDrain.metricsRetries`                        | Retries for the metrics probe before giving up.              | `5`                             |
+| `graylog.lifecycle.preStopDrain.feasibilityWarmupPolls`                | Polls observed before projecting whether the drain can finish; aborts early if it cannot. `0` disables. | `5` |
 | `graylog.persistence.retentionPolicy.whenDeleted`                      | PVC fate when the StatefulSet is deleted.                   | `Retain`                        |
 | `graylog.persistence.retentionPolicy.whenScaled`                       | PVC fate when scaled in. `Delete` is refused — it destroys a scaled-in node's journal. | `Retain` |
 | `graylog.podDisruptionBudget.enabled`                                 | Enable PodDisruptionBudget.                                 | `false`                         |
@@ -1188,6 +996,8 @@ These values affect Graylog, DataNode, and MongoDB.
 | `datanode.resources.limits.memory`                     | Memory limit for the datanode pod.              | `"5Gi"`           |
 | `datanode.resources.requests.cpu`                      | CPU request for the datanode pod.               | `"500m"`          |
 | `datanode.resources.requests.memory`                   | Memory request for the datanode pod.            | `"3.5Gi"`         |
+| `datanode.persistence.retentionPolicy.whenDeleted`     | PVC fate when the StatefulSet is deleted.       | `Retain`          |
+| `datanode.persistence.retentionPolicy.whenScaled`      | PVC fate when scaled in. `Delete` is permitted here (shard data rebuilds from replicas), unlike on the Graylog StatefulSet. | `Retain` |
 | `datanode.persistence.data.enabled`                    | Enable persistent volume for data.              | `true`            |
 | `datanode.persistence.data.storageClass`               | Storage class for data PVC.                     | `""`              |
 | `datanode.persistence.data.mountPath`                  | Mount path for data volume.                     | `""`              |

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -350,8 +350,51 @@ It is **off by default** because it slows every rolling upgrade by the drain tim
 | Limit | Consequence |
 |---|---|
 | Bounded by `terminationGracePeriodSeconds` | The hook always yields in time for SIGTERM (see below). If the journal is still full, termination proceeds anyway. |
-| Only sheds *newly established* connections | Kubernetes removes the terminating pod from Service endpoints, but long-lived TCP inputs and UDP senders keep writing. Against those the journal may never reach zero, and the hook gives up after `stallPolls` samples with no decrease. |
+| Only sheds *newly established* connections | Kubernetes removes the terminating pod from Service endpoints, but that only stops new connections. Long-lived TCP inputs, UDP senders, and internally generated inputs keep writing. Against those the journal never reaches zero, and the hook gives up once journal depth stops reaching new lows for `stallPolls` samples. |
 | Does not stop inputs | Stopping inputs requires an authenticated API call. Only the manual runbook can guarantee an empty journal. |
+| Pointless on rolling upgrades | A replacement pod re-binds the same PVC and replays the journal itself, so there is nothing to protect. The hook cannot tell an upgrade from a scale-in, so it pays the cost on both. |
+
+> [!IMPORTANT]
+> Enable this only if you routinely scale in. On a node that is still receiving
+> traffic the drain cannot finish, and it adds its give-up time to *every* pod
+> termination — including every rolling upgrade, where it buys nothing.
+
+Measured on a 3-node cluster ingesting ~115 msg/s per node from inputs that keep
+producing throughout termination — in this case internally generated traffic, which
+endpoint removal cannot shed at all. Network inputs holding long-lived TCP
+connections behave the same way, because removing a pod from Service endpoints only
+stops *new* connections:
+
+```
+[prestop-drain] waiting 15s for endpoint removal to propagate
+[prestop-drain] no progress in 10 polls (63s): depth 163, best 4, still ingesting
+                113 msg/s. A true drain needs inputs stopped; handing over to
+                graceful shutdown
+```
+
+Pod termination took **89s** instead of ~10s, and the journal never emptied — it
+got as low as 4 entries but new messages kept arriving. That is the expected
+outcome for a node under live load, and it is why the message names the ingest
+rate: the fix is to stop the inputs, not to wait longer.
+
+Where the hook *does* pay off is a scale-in whose senders reconnect elsewhere once
+the pod leaves Service endpoints. Then ingest to that node genuinely stops, depth
+falls to zero, and the hook exits early having saved the journal that would
+otherwise have been stranded.
+
+### Watching a drain
+
+The hook writes its progress to the container's log stream, so:
+
+```sh
+# follow BEFORE you terminate — a pod's logs are destroyed with the pod object
+kubectl logs -n graylog -l app=graylog-app -c graylog-app \
+  --follow --prefix --tail=0 --max-log-requests=20 | grep "prestop-drain"
+```
+
+A post-mortem `kubectl logs` will find nothing: the terminated pod is gone. Note
+also that Kubernetes discards `preStop` output by default — these lines are
+visible only because the hook writes to PID 1's stdout deliberately.
 
 #### The grace-period budget
 
@@ -686,6 +729,9 @@ helm upgrade -i graylog graylog/graylog -n graylog --reuse-values --set global.e
 > - `graylog.config.rootUsername`
 > - `graylog.config.customSecretPepper`
 > - `graylog.config.tls.keyPassword`
+
+The required keys, and how to build the secret, are documented in
+[Graylog Secrets](../../docs/graylog-secrets.md).
 
 ## Bring Your Own MongoDB
 

--- a/charts/graylog/files/scripts/prestop-drain.sh
+++ b/charts/graylog/files/scripts/prestop-drain.sh
@@ -119,10 +119,10 @@ sample() {
   curl -fsS --max-time 5 "${URL}" 2>/dev/null \
     | awk -v d="${DEPTH_GAUGE}" -v r="${RATE_GAUGE}" \
           -v s="${SIZE_GAUGE}" -v l="${LIMIT_GAUGE}" '
-        $1 ~ "^"d"[{ ]" || index($1, d"{") == 1 { v = $NF }
-        $1 ~ "^"r"[{ ]" || index($1, r"{") == 1 { a = $NF }
-        $1 ~ "^"s"[{ ]" || index($1, s"{") == 1 { z = $NF }
-        $1 ~ "^"l"[{ ]" || index($1, l"{") == 1 { m = $NF }
+        $1 == d || $1 ~ "^"d"[{ ]" || index($1, d"{") == 1 { v = $NF }
+        $1 == r || $1 ~ "^"r"[{ ]" || index($1, r"{") == 1 { a = $NF }
+        $1 == s || $1 ~ "^"s"[{ ]" || index($1, s"{") == 1 { z = $NF }
+        $1 == l || $1 ~ "^"l"[{ ]" || index($1, l"{") == 1 { m = $NF }
         END {
           if (v == "") exit 1
           if (z == "") z = 0
@@ -378,7 +378,11 @@ while [ "$(date +%s)" -lt "${deadline}" ]; do
     # Restart the progress baseline. Leaving best at 0 would make every
     # subsequent reading "no new low", so the stall counter would climb every
     # poll and report INCOMPLETE while the drain was in fact still working.
+    # The accumulated count has to go with it: a drain that blips to zero late,
+    # having already banked polls without a new low, would otherwise trip
+    # STALL_LIMIT within a poll or two of genuinely resuming.
     best="${n}"
+    stall=0
   fi
   first_poll=0
 

--- a/charts/graylog/files/scripts/prestop-drain.sh
+++ b/charts/graylog/files/scripts/prestop-drain.sh
@@ -1,0 +1,466 @@
+#!/bin/sh
+# Graylog preStop journal drain.
+#
+# Inlined into the graylog-app container's preStop hook by
+# templates/workload/containers/_prestop-drain.tpl via .Files.Get. It lives here
+# rather than under templates/ for two reasons: helm lint rejects a .sh extension
+# in templates/ ("Valid extensions are .yaml, .yml, .tpl, or .txt"), and keeping
+# it out of there means no Helm syntax, so editors and shellcheck can read it.
+#
+# Everything Helm supplies arrives as environment variables, rendered onto the
+# container by "graylog.prestopDrain.env" in that same file. Run it by hand
+# inside a pod to test:
+#
+#   GL_DRAIN_METRICS_URL=http://127.0.0.1:9833/metrics \
+#   GL_DRAIN_BUDGET_SECONDS=60 GL_DRAIN_POLL_SECONDS=2 \
+#   GL_DRAIN_SETTLE_SECONDS=0 GL_DRAIN_STALL_POLLS=5 \
+#   GL_DRAIN_STATUS_INTERVAL_SECONDS=5 GL_DRAIN_GRACE_SECONDS=300 \
+#   GL_DRAIN_RESERVE_SECONDS=45 GL_DRAIN_CONFIRM_POLLS=3 \
+#   GL_DRAIN_METRICS_RETRIES=5 GL_DRAIN_FEASIBILITY_WARMUP_POLLS=5 \
+#   sh prestop-drain.sh
+#
+# Every variable is required via ${VAR:?}: a missing one fails loudly at the top
+# rather than defaulting to empty and producing nonsense arithmetic further down.
+
+# Token-free journal drain. Always exits 0: a failing preStop hook
+# would stall termination for the whole grace period and then get the
+# container SIGKILLed, so every give-up path here hands over to
+# Graylog's own graceful shutdown instead of erroring.
+set -u
+
+URL="${GL_DRAIN_METRICS_URL:?GL_DRAIN_METRICS_URL is not set}"
+BUDGET="${GL_DRAIN_BUDGET_SECONDS:?GL_DRAIN_BUDGET_SECONDS is not set}"
+POLL="${GL_DRAIN_POLL_SECONDS:?GL_DRAIN_POLL_SECONDS is not set}"
+SETTLE="${GL_DRAIN_SETTLE_SECONDS:?GL_DRAIN_SETTLE_SECONDS is not set}"
+STALL_LIMIT="${GL_DRAIN_STALL_POLLS:?GL_DRAIN_STALL_POLLS is not set}"
+STATUS_EVERY="${GL_DRAIN_STATUS_INTERVAL_SECONDS:?GL_DRAIN_STATUS_INTERVAL_SECONDS is not set}"
+CONFIRM_POLLS="${GL_DRAIN_CONFIRM_POLLS:?GL_DRAIN_CONFIRM_POLLS is not set}"
+METRICS_RETRIES="${GL_DRAIN_METRICS_RETRIES:?GL_DRAIN_METRICS_RETRIES is not set}"
+GRACE="${GL_DRAIN_GRACE_SECONDS:?GL_DRAIN_GRACE_SECONDS is not set}"
+RESERVE="${GL_DRAIN_RESERVE_SECONDS:?GL_DRAIN_RESERVE_SECONDS is not set}"
+WARMUP="${GL_DRAIN_FEASIBILITY_WARMUP_POLLS:?GL_DRAIN_FEASIBILITY_WARMUP_POLLS is not set}"
+
+DEPTH_GAUGE="gl_journal_entries_uncommitted"
+RATE_GAUGE="gl_journal_append_1_sec_rate"
+# Reported in the feasibility verdict so an operator sees how much is actually on
+# disk, not just a message count. The anchored matching in sample() is what keeps
+# SIZE_GAUGE from also matching LIMIT_GAUGE, which is a prefix extension of it.
+SIZE_GAUGE="gl_journal_size"
+LIMIT_GAUGE="gl_journal_size_limit"
+
+# kubelet discards preStop stdout — it only ever surfaces (truncated) in
+# a FailedPreStopHook event, and only when the hook fails. Writing to
+# PID 1's stdout puts these lines in the container's real log stream so
+# `kubectl logs` can see a drain happen. Keep the plain echo too: it is
+# what lands in the event if this hook ever does fail.
+# Probed once with a stat, not by opening it: if PID 1's stdout happens to
+# be a regular file rather than the usual pipe, an open-for-write would
+# truncate the container log. Appending for the same reason.
+PID1_LOG=0
+[ -w /proc/1/fd/1 ] 2>/dev/null && PID1_LOG=1
+log() {
+  lvl="$1"; shift
+  line="[prestop-drain] $(date -u '+%Y-%m-%dT%H:%M:%SZ') ${lvl} $*"
+  echo "${line}"
+  # A bare `echo > /proc/1/fd/1 2>/dev/null` does NOT stay quiet when the
+  # path is missing: the failure comes from the shell performing the
+  # redirection, not from echo, so its stderr is not what gets silenced.
+  if [ "${PID1_LOG}" = "1" ]; then
+    echo "${line}" >> /proc/1/fd/1 2>/dev/null
+  fi
+  return 0
+}
+info()  { log "INFO " "$@"; }
+warn()  { log "WARN " "$@"; }
+error() { log "ERROR" "$@"; }
+crit()  { log "CRIT " "$@"; }
+
+# Byte counts for humans. The gauges are in bytes and reach the low gigabytes, so
+# a raw number is unreadable in a verdict an operator has seconds to act on.
+# One decimal place, worked out with integer arithmetic because POSIX sh has no
+# floating point: the remainder is scaled by 10 before dividing, not after.
+fmt_bytes() {
+  _b="$1"
+  if [ "${_b}" -ge 1073741824 ]; then
+    printf '%d.%01dGiB' $(( _b / 1073741824 )) $(( _b % 1073741824 * 10 / 1073741824 ))
+  elif [ "${_b}" -ge 1048576 ]; then
+    printf '%d.%01dMiB' $(( _b / 1048576 )) $(( _b % 1048576 * 10 / 1048576 ))
+  else
+    printf '%dB' "${_b}"
+  fi
+}
+
+# Same reasoning for durations: the whole point of the feasibility verdict is that
+# the projection is wildly larger than the budget, and "7452s" does not land that
+# way "2h4m" does.
+fmt_duration() {
+  _s="$1"
+  if [ "${_s}" -ge 3600 ]; then
+    printf '%dh%dm' $(( _s / 3600 )) $(( _s % 3600 / 60 ))
+  elif [ "${_s}" -ge 60 ]; then
+    printf '%dm%ds' $(( _s / 60 )) $(( _s % 60 ))
+  else
+    printf '%ds' "${_s}"
+  fi
+}
+
+# Reads every gauge in one scrape. $NF is the value; ^gl_ skips the
+# "# HELP"/"# TYPE" lines, and the anchored names avoid the
+# similarly-spelled data-lake and kafka gauges. Exits non-zero when the
+# depth gauge is absent, so callers can distinguish "no data" from zero.
+#
+# The anchoring matters more now that SIZE_GAUGE (gl_journal_size) is a strict
+# prefix of LIMIT_GAUGE (gl_journal_size_limit): requiring "{" or a space
+# immediately after the name is what stops the limit line from also matching the
+# size gauge. Only the depth gauge is mandatory - size and limit default to 0 so
+# a Graylog version that stops publishing them degrades the verdict's detail
+# rather than aborting the drain.
+sample() {
+  curl -fsS --max-time 5 "${URL}" 2>/dev/null \
+    | awk -v d="${DEPTH_GAUGE}" -v r="${RATE_GAUGE}" \
+          -v s="${SIZE_GAUGE}" -v l="${LIMIT_GAUGE}" '
+        $1 ~ "^"d"[{ ]" || index($1, d"{") == 1 { v = $NF }
+        $1 ~ "^"r"[{ ]" || index($1, r"{") == 1 { a = $NF }
+        $1 ~ "^"s"[{ ]" || index($1, s"{") == 1 { z = $NF }
+        $1 ~ "^"l"[{ ]" || index($1, l"{") == 1 { m = $NF }
+        END {
+          if (v == "") exit 1
+          if (z == "") z = 0
+          if (m == "") m = 0
+          printf "%d %d %d %d\n", v, a, z, m
+        }'
+}
+
+# Splits a sample into globals. Four fields no longer fit the ${x% *}/${x#* }
+# pair the two-field version used, and doing it in pure parameter expansion
+# keeps this off the process-spawn path - it runs on every poll.
+S_DEPTH=0; S_RATE=0; S_SIZE=0; S_LIMIT=0
+parse_sample() {
+  _rest="$1"
+  S_DEPTH="${_rest%% *}"; _rest="${_rest#* }"
+  S_RATE="${_rest%% *}";  _rest="${_rest#* }"
+  S_SIZE="${_rest%% *}";  _rest="${_rest#* }"
+  S_LIMIT="${_rest}"
+}
+
+# The disk half of the feasibility verdict. Split out because both infeasible
+# paths report it identically, and because the percentage needs a guard: an
+# absent limit gauge would divide by zero.
+report_journal_state() {
+  if [ "${S_LIMIT}" -gt 0 ]; then
+    crit "  journal on disk: $(fmt_bytes "${S_SIZE}") of $(fmt_bytes "${S_LIMIT}") cap ($(( S_SIZE * 100 / S_LIMIT ))% full)"
+    if [ "${S_SIZE}" -ge "${S_LIMIT}" ]; then
+      crit "  the journal is AT its cap - Graylog is already discarding the oldest segments, so messages are being lost right now"
+    fi
+  else
+    crit "  journal on disk: $(fmt_bytes "${S_SIZE}") (cap not published by this Graylog version)"
+  fi
+}
+
+# Retrying wrapper around sample(). A single failed scrape is usually a blip -
+# the exporter briefly busy, a dropped connection - and abandoning the drain on
+# one miss throws away the whole point of the hook.
+#
+# Sets SAMPLE rather than echoing: callers use $( ) around sample(), and any
+# warn() emitted during a retry would be captured into that output instead of
+# reaching the log.
+SAMPLE=""
+sample_retry() {
+  attempt=1
+  while :; do
+    if SAMPLE=$(sample); then
+      [ "${attempt}" -gt 1 ] && info "metrics probe recovered on attempt ${attempt}"
+      return 0
+    fi
+    if [ "${attempt}" -ge "${METRICS_RETRIES}" ]; then
+      SAMPLE=""
+      return 1
+    fi
+    warn "metrics probe failed (attempt ${attempt}/${METRICS_RETRIES}) - retrying in ${POLL}s"
+    attempt=$(( attempt + 1 ))
+    sleep "${POLL}"
+  done
+}
+
+# Single exit point so every path reports a verdict in the same shape.
+# Always exit 0 (see the header comment).
+finish() {
+  outcome="$1"; depth="$2"
+  # Timings are derived here rather than passed in. The poll loop's own clock
+  # starts after the settle wait, so quoting it alone reports "0s" for a journal
+  # that actually took settle+poll to clear - accurate for the loop, misleading
+  # about the hook. Report the total, and break it down.
+  now=$(date +%s)
+  total=$(( now - hook_started ))
+  # Report the phases that actually ran. Quoting the configured SETTLE
+  # unconditionally produced nonsense on the preflight path - "0s total (15s
+  # settle + 0s draining)" - because that exit happens before the wait starts.
+  if [ -z "${settle_started:-}" ]; then
+    phase="preflight"
+    spent="${total}s total, before the settle wait began"
+  elif [ -z "${loop_started:-}" ]; then
+    phase="settle"
+    spent="${total}s total, during the settle wait"
+  else
+    phase="draining"
+    # Measured, not assumed: the sleep can overrun under load, and metrics retries
+    # can make preflight take real time. The three parts must sum to the total, or
+    # the line invites exactly the "where did the rest go?" question.
+    spent="${total}s total ($(( settle_started - hook_started ))s preflight + $(( loop_started - settle_started ))s settle + $(( now - loop_started ))s draining)"
+  fi
+  case "${outcome}" in
+    drained)
+      info "RESULT: SUCCESS - journal fully drained (0 messages remaining) in ${spent}, within the ${BUDGET}s budget" ;;
+    stalled)
+      warn "RESULT: INCOMPLETE - ${depth} messages still queued and no longer decreasing after ${spent} (budget ${BUDGET}s)"
+      warn "the write side never stopped, so the journal cannot reach zero; only stopping the inputs can finish this drain" ;;
+    timeout)
+      warn "RESULT: INCOMPLETE - ${BUDGET}s timeout cutoff reached with ${depth} messages still undrained (${spent})" ;;
+    infeasible)
+      # Deliberately not a warn: this is the one outcome where the hook is telling
+      # the operator that data loss is already committed and only manual action can
+      # prevent it. The detail lines were emitted at the detection site.
+      crit "RESULT: ABORTED - drain is not feasible; giving up immediately with ${depth} messages undrained (${spent})"
+      crit "holding termination any longer would not have cleared them - returning the rest of the grace period to Graylog's own shutdown" ;;
+    unavailable)
+      if [ "${phase}" = "preflight" ]; then
+        error "RESULT: UNKNOWN - no drain attempted; journal depth was never measurable (${spent})"
+      else
+        error "RESULT: UNKNOWN - drain abandoned; journal depth stopped being measurable (${spent})"
+      fi ;;
+  esac
+  # How much of the backlog that existed when the hook started is now gone.
+  # The baseline is the preflight sample, taken before the settle wait, because
+  # that is "what was on disk when termination began" - the figure an operator
+  # means by "did it drain". Integer arithmetic only; there is no floating point
+  # in POSIX sh.
+  if [ "${depth}" != "unknown" ]; then
+    base="${start_depth:-0}"
+    if [ "${base}" -le 0 ]; then
+      info "drained n/a - the journal was already empty when the hook began"
+    elif [ "${depth}" -ge "${base}" ]; then
+      # Ingest outran processing, so nothing was net-drained. Reporting a negative
+      # percentage would be noise; the two absolute numbers say it better.
+      warn "drained 0% of the starting backlog - it grew from ${base} to ${depth} messages while ingest continued"
+    else
+      info "drained $(( (base - depth) * 100 / base ))% of the starting backlog (${base} -> ${depth} messages)"
+    fi
+  fi
+  if [ "${outcome}" != "drained" ] && [ "${depth}" != "unknown" ] && [ "${depth}" -gt 0 ] 2>/dev/null; then
+    warn "if this pod is being removed by a scale-in, those ${depth} messages will be stranded in its PVC - nothing replays an orphaned journal"
+  fi
+  # RESERVE is only the guaranteed FLOOR - the deadline is set so at least that
+  # much is left in the worst case. A drain that finishes early leaves far more,
+  # and quoting the floor understated it badly (45s reported when 280s remained).
+  # Report what is actually left of the grace period.
+  left=$(( GRACE - total ))
+  [ "${left}" -lt 0 ] && left=0
+  info "handing over to SIGTERM with ~${left}s of the ${GRACE}s grace period left for Graylog to shut down cleanly (guaranteed floor was ${RESERVE}s)"
+  exit 0
+}
+
+# ---- configuration -----------------------------------------------------
+hook_started=$(date +%s)
+info "journal drain starting on ${HOSTNAME:-unknown}"
+info "config: budget=${BUDGET}s retries=${METRICS_RETRIES} poll=${POLL}s settle=${SETTLE}s stallPolls=${STALL_LIMIT} confirmPolls=${CONFIRM_POLLS} statusEvery=${STATUS_EVERY}s"
+info "config: budget = terminationGracePeriodSeconds(${GRACE}s) - settle(${SETTLE}s) - shutdownReserve(${RESERVE}s)"
+info "config: metrics=${URL} depthGauge=${DEPTH_GAUGE}"
+
+# ---- preflight: is the endpoint there, and how much is queued? ---------
+sample_retry || true
+start_sample="${SAMPLE}"
+if [ -z "${start_sample}" ]; then
+  error "metrics endpoint ${URL} did not answer after ${METRICS_RETRIES} attempts, or ${DEPTH_GAUGE} is absent"
+  error "the exporter only serves once Graylog has started; if this pod was still"
+  error "starting up or already unhealthy, it had no journal activity to drain"
+  finish unavailable unknown
+fi
+parse_sample "${start_sample}"
+start_depth="${S_DEPTH}"
+start_rate="${S_RATE}"
+info "metrics endpoint reachable"
+info "journal at start: ${start_depth} messages on disk awaiting processing, ingest ${start_rate} msg/s"
+if [ "${S_LIMIT}" -gt 0 ]; then
+  info "journal on disk: $(fmt_bytes "${S_SIZE}") of $(fmt_bytes "${S_LIMIT}") cap ($(( S_SIZE * 100 / S_LIMIT ))% full)"
+fi
+if [ "${start_depth}" -le 0 ]; then
+  info "journal already empty before the settle wait"
+fi
+
+# Kubernetes removes a Terminating pod from every Service EndpointSlice,
+# but kube-proxy convergence is not instant. Measuring before it lands
+# reads traffic that is already going away.
+settle_started=$(date +%s)
+info "waiting ${SETTLE}s for EndpointSlice removal to propagate"
+sleep "${SETTLE}"
+
+# ---- drain loop --------------------------------------------------------
+# Wall clock, not a tick count. Each iteration can block for up to the
+# curl timeout, so counting polls would let the hook overrun BUDGET by
+# a wide margin and get the container SIGKILLed mid-shutdown.
+loop_started=$(date +%s)
+# Anchored to the hook's own start, not the loop's. Preflight retries and an
+# overrunning settle both eat wall clock before we get here; deriving the
+# deadline from BUDGET alone would push the total past the grace period and get
+# the container SIGKILLed with its buffers unflushed. This guarantees RESERVE
+# seconds are left for SIGTERM no matter what happened earlier.
+deadline=$(( hook_started + GRACE - RESERVE ))
+remaining_budget=$(( deadline - loop_started ))
+# A second or two goes on the preflight scrape itself; that is not worth a warning.
+# Only flag a shortfall big enough to change the outcome.
+if [ "${remaining_budget}" -lt $(( BUDGET - 10 )) ]; then
+  warn "only ${remaining_budget}s of the ${BUDGET}s budget remain - preflight and settle took $(( BUDGET - remaining_budget ))s longer than planned"
+fi
+# Progress is measured against the best (lowest) depth seen so far, not
+# against the previous sample. Under live ingest the gauge oscillates
+# continuously — two consecutive samples are essentially never equal —
+# so an equality test never fires and the hook burns the whole budget
+# for nothing. Requiring a new low means "no improvement" is detected
+# even while the raw number jitters.
+stall=0
+best=""
+zero_streak=0
+n="${start_depth}"
+rate="${start_rate}"
+last_status=-999
+first_poll=1
+# Feasibility gate state. polls counts iterations that actually sampled a
+# non-zero depth, so the WARMUP window measures real draining rather than being
+# consumed by zero-confirmation polls.
+polls=0
+feas_checked=0
+feas_depth0=""
+feas_t0=0
+info "draining: up to ${BUDGET}s, giving up early after ${STALL_LIMIT} polls without a new low"
+if [ "${WARMUP}" -gt 0 ]; then
+  info "feasibility: projecting completion after ${WARMUP} polls; aborting immediately if it cannot finish in the budget"
+else
+  info "feasibility: projection disabled (feasibilityWarmupPolls=0)"
+fi
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  elapsed=$(( $(date +%s) - loop_started ))
+  remaining=$(( deadline - $(date +%s) ))
+  sample_retry || true
+  sample="${SAMPLE}"
+  if [ -z "${sample}" ]; then
+    error "metrics endpoint stopped answering after ${elapsed}s and did not recover in ${METRICS_RETRIES} attempts (it responded during preflight)"
+    finish unavailable unknown
+  fi
+  parse_sample "${sample}"
+  n="${S_DEPTH}"
+  rate="${S_RATE}"
+  [ -z "${best}" ] && best="${n}"
+
+  # A SINGLE zero is not proof the journal is drained. Under live ingest the depth
+  # oscillates and momentarily touches zero while messages are still arriving;
+  # exiting on that would declare success, hand over to SIGTERM, and let whatever
+  # arrives next be journaled and then orphaned on the PVC. Require the depth to
+  # stay at zero across CONFIRM_POLLS consecutive samples - if anything is still
+  # writing, it pops back above zero and the streak resets.
+  if [ "${n}" -le 0 ]; then
+    zero_streak=$(( zero_streak + 1 ))
+    if [ "${zero_streak}" -ge "${CONFIRM_POLLS}" ]; then
+      if [ "${first_poll}" = "1" ] && [ "${CONFIRM_POLLS}" -le 1 ]; then
+        info "journal was already empty at the first poll - it cleared during the ${SETTLE}s settle wait"
+      else
+        info "depth held at 0 across ${zero_streak} consecutive polls - nothing is still writing"
+      fi
+      finish drained 0
+    fi
+    info "depth is 0 (confirmation ${zero_streak}/${CONFIRM_POLLS}) - re-checking that nothing is still arriving"
+    first_poll=0
+    sleep "${POLL}"
+    continue
+  fi
+  if [ "${zero_streak}" -gt 0 ]; then
+    warn "depth rose back to ${n} after ${zero_streak} zero reading(s): messages are still arriving, so the journal is NOT drained"
+    zero_streak=0
+    # Restart the progress baseline. Leaving best at 0 would make every
+    # subsequent reading "no new low", so the stall counter would climb every
+    # poll and report INCOMPLETE while the drain was in fact still working.
+    best="${n}"
+  fi
+  first_poll=0
+
+  if [ "${n}" -lt "${best}" ]; then
+    best="${n}"
+    stall=0
+  else
+    stall=$((stall + 1))
+  fi
+
+  # Throttled so a long drain does not bury the log, but always report
+  # the first sample so there is a datapoint even on a short run.
+  if [ $(( elapsed - last_status )) -ge "${STATUS_EVERY}" ]; then
+    info "draining: ${n} messages queued (best ${best}), ingest ${rate} msg/s, ${elapsed}s elapsed, ${remaining}s left, ${stall}/${STALL_LIMIT} polls without progress"
+    last_status="${elapsed}"
+  fi
+
+  # ---- feasibility gate ------------------------------------------------
+  # The stall detector answers "is depth still falling?" It never asks "can this
+  # finish in the time left?", and the two diverge badly. A terminating pod is
+  # pulled from the EndpointSlice, ingest tapers, and depth genuinely does keep
+  # reaching new lows - so the stall counter keeps resetting and the hook runs
+  # its entire budget. Observed on a flooded cluster: 7.24M queued messages
+  # draining at ~1k msg/s needed ~2h, had 240s, cleared ~2%, and stranded the
+  # rest. The budget bought nothing and delayed every pod in the rollout.
+  #
+  # So project it. One evaluation, once WARMUP polls have produced a measured
+  # rate; if the projection does not fit, abort now and hand the remaining grace
+  # period back to Graylog's shutdown, which can at least use it. A drain that
+  # passes the gate but degrades afterwards is still caught by the stall
+  # detector, so this does not need to re-arm.
+  polls=$(( polls + 1 ))
+  if [ -z "${feas_depth0}" ]; then
+    feas_depth0="${n}"
+    feas_t0=$(date +%s)
+  elif [ "${WARMUP}" -gt 0 ] && [ "${feas_checked}" = "0" ] && [ "${polls}" -ge "${WARMUP}" ]; then
+    feas_checked=1
+    observed=$(( $(date +%s) - feas_t0 ))
+    # Guard the divisor: a fast loop can measure the window as 0s.
+    [ "${observed}" -lt 1 ] && observed=1
+    cleared=$(( feas_depth0 - n ))
+    budget_left=$(( deadline - $(date +%s) ))
+    [ "${budget_left}" -lt 0 ] && budget_left=0
+    if [ "${cleared}" -le 0 ]; then
+      crit "FEASIBILITY: journal is NOT draining - depth went ${feas_depth0} -> ${n} messages over ${observed}s"
+      report_journal_state
+      crit "  backlog:         ${n} messages awaiting processing"
+      crit "  drain rate:      0 msg/s - nothing is being worked off (ingest ${rate} msg/s)"
+      crit "  time to clear:   never at this rate"
+      crit "  time available:  ${budget_left}s of the ${BUDGET}s drain budget"
+      crit "  the indexer is refusing writes or cannot keep up; check for a read-only index block or a disk watermark on the indexer"
+      crit "  ${n} messages will NOT be drained by this hook - stop the inputs and drain manually to save them"
+      finish infeasible "${n}"
+    fi
+    drain_rate=$(( cleared / observed ))
+    # Projected as n * observed / cleared rather than n / drain_rate: integer
+    # division floors a slow-but-real drain to 0 msg/s, and dividing by that
+    # would abort the script outright. This form has no such hole, and it keeps
+    # the sub-1-msg/s precision that the floored rate throws away.
+    eta=$(( n * observed / cleared ))
+    if [ "${eta}" -gt "${budget_left}" ]; then
+      crit "FEASIBILITY: drain cannot finish in the time available - aborting instead of holding termination for nothing"
+      report_journal_state
+      crit "  backlog:         ${n} messages awaiting processing"
+      crit "  drain rate:      ${drain_rate} msg/s measured over ${observed}s (ingest ${rate} msg/s)"
+      crit "  time to clear:   ~$(fmt_duration "${eta}") at that rate"
+      crit "  time available:  ${budget_left}s of the ${BUDGET}s drain budget"
+      crit "  short by:        ~$(fmt_duration $(( eta - budget_left )))"
+      crit "  ${n} messages will NOT be drained by this hook - stop the inputs and drain manually to save them"
+      finish infeasible "${n}"
+    fi
+    info "feasibility OK: ${n} messages at ${drain_rate} msg/s projects ~$(fmt_duration "${eta}"), inside the ${budget_left}s remaining"
+  fi
+
+  if [ "${stall}" -ge "${STALL_LIMIT}" ]; then
+    # Endpoint removal only sheds newly-established connections.
+    # Long-lived TCP inputs, UDP senders and internally generated inputs
+    # keep writing, so the journal will not reach zero however long we
+    # wait.
+    warn "no new low in ${stall} polls: depth ${n}, best ${best}, still ingesting ${rate} msg/s"
+    finish stalled "${n}"
+  fi
+  sleep "${POLL}"
+done
+finish timeout "${n}"

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -286,14 +286,17 @@ Graylog service app port
 {{- end }}
 
 {{/*
-Whether the Graylog server should listen for forwarder connections.
+DISABLED 2026-07-30 -- graylog.config.forwarder is commented out in values.yaml
+because the settings are inert: the forwarder listener is configured as attributes
+on a Graylog input of type "Forwarder", not through server.conf, and unrecognised
+GRAYLOG_* env vars are silently dropped. This helper reads values that no longer
+exist. Restore it together with that block.
 
+Whether the Graylog server should listen for forwarder connections.
 Defaults to ingress.forwarder.enabled so that exposing the ingest endpoint also
 binds the ports behind it; set graylog.config.forwarder.enabled explicitly to
 override (e.g. to bind the ports without creating an Ingress).
-Returns the string "true" or "false".
-Usage: if include "graylog.forwarder.enabled" . | eq "true" ...
-*/}}
+
 {{- define "graylog.forwarder.enabled" -}}
 {{- $configured := .Values.graylog.config.forwarder.enabled -}}
 {{- if kindIs "bool" $configured -}}
@@ -302,6 +305,7 @@ Usage: if include "graylog.forwarder.enabled" . | eq "true" ...
 {{- .Values.ingress.forwarder.enabled | ternary true false -}}
 {{- end -}}
 {{- end }}
+*/}}
 
 {{/*
 Graylog service port name for the forwarder message channel (default 13301).

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -286,6 +286,40 @@ Graylog service app port
 {{- end }}
 
 {{/*
+Whether the Graylog server should listen for forwarder connections.
+
+Defaults to ingress.forwarder.enabled so that exposing the ingest endpoint also
+binds the ports behind it; set graylog.config.forwarder.enabled explicitly to
+override (e.g. to bind the ports without creating an Ingress).
+Returns the string "true" or "false".
+Usage: if include "graylog.forwarder.enabled" . | eq "true" ...
+*/}}
+{{- define "graylog.forwarder.enabled" -}}
+{{- $configured := .Values.graylog.config.forwarder.enabled -}}
+{{- if kindIs "bool" $configured -}}
+{{- $configured -}}
+{{- else -}}
+{{- .Values.ingress.forwarder.enabled | ternary true false -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Graylog service port name for the forwarder message channel (default 13301).
+Sourced from graylog.inputs, so it must stay in sync with that entry's name.
+*/}}
+{{- define "graylog.service.port.forwarder.message" -}}
+{{- print "input-forwarder" }}
+{{- end }}
+
+{{/*
+Graylog service port name for the forwarder configuration channel (13302).
+Always exposed by the service; the forwarder polls it for configuration updates.
+*/}}
+{{- define "graylog.service.port.forwarder.config" -}}
+{{- print "input-fwd-conf" }}
+{{- end }}
+
+{{/*
 Graylog configmap name
 */}}
 {{- define "graylog.configmap.name" -}}
@@ -602,6 +636,20 @@ Ingress name
 */}}
 {{- define "graylog.ingress.web.name" }}
 {{- include "graylog.fullname" . | printf "%s-web" }}
+{{- end }}
+
+{{/*
+Forwarder message channel ingress name
+*/}}
+{{- define "graylog.ingress.forwarder.message.name" }}
+{{- include "graylog.fullname" . | printf "%s-forwarder-message-channel" }}
+{{- end }}
+
+{{/*
+Forwarder configuration channel ingress name
+*/}}
+{{- define "graylog.ingress.forwarder.config.name" }}
+{{- include "graylog.fullname" . | printf "%s-forwarder-config-channel" }}
 {{- end }}
 
 {{/*

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -286,11 +286,11 @@ Graylog service app port
 {{- end }}
 
 {{/*
-DISABLED 2026-07-30 -- graylog.config.forwarder is commented out in values.yaml
-because the settings are inert: the forwarder listener is configured as attributes
-on a Graylog input of type "Forwarder", not through server.conf, and unrecognised
-GRAYLOG_* env vars are silently dropped. This helper reads values that no longer
-exist. Restore it together with that block.
+DISABLED 2026-07-30 -- the settings are inert: the forwarder listener is
+configured as attributes on a Graylog input of type "Forwarder", not through
+server.conf, and unrecognised GRAYLOG_* env vars are silently dropped.
+graylog.config.forwarder was removed from values.yaml, so this helper reads a
+path that no longer exists -- re-add those values before restoring it.
 
 Whether the Graylog server should listen for forwarder connections.
 Defaults to ingress.forwarder.enabled so that exposing the ingest endpoint also
@@ -387,6 +387,124 @@ Exactly one indexer source must be selected.
 {{- end }}
 {{- if and .Values.opensearch.tls.enabled (not .Values.opensearch.tls.caSecret) (not .Values.global.existingSecretName) }}
 {{- /* CA may legitimately be a public/known CA; warn-by-convention only, no fail */ -}}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Size string to bytes, or "" when the format is not recognised.
+
+Two conventions meet here: Kubernetes resource quantities on persistence.size and
+Graylog's own size strings on the journal settings. They disagree - Kubernetes G is
+10^9 and Gi is 2^30, while Graylog's gb is 2^30 (verified against the exporter:
+maxSize 5gb reports gl_journal_size_limit 5368709120, exactly 5 x 1024^3). So
+suffixes are matched exactly, never case-folded: lowercasing would collapse
+Kubernetes M (10^6) onto m (milli).
+
+Returns "" rather than guessing on anything unrecognised, fractional quantities like
+1.5Gi included. Callers must treat "" as "cannot validate" and skip - a size this
+cannot parse is not grounds for refusing to render.
+
+Usage: {{ include "graylog.sizeToBytes" "8Gi" }}
+*/}}
+{{- define "graylog.sizeToBytes" -}}
+{{- $s := . | toString | trim -}}
+{{- $digits := regexFind "^[0-9]+" $s -}}
+{{- if $digits -}}
+{{- $suffix := substr (len $digits) (len $s) $s -}}
+{{- $units := dict
+    "" 1 "b" 1 "B" 1
+    "k" 1000 "K" 1000 "M" 1000000 "G" 1000000000 "T" 1000000000000
+    "Ki" 1024 "Mi" 1048576 "Gi" 1073741824 "Ti" 1099511627776
+    "kb" 1024 "KB" 1024 "mb" 1048576 "MB" 1048576
+    "gb" 1073741824 "GB" 1073741824 "tb" 1099511627776 "TB" 1099511627776 -}}
+{{- if hasKey $units $suffix -}}
+{{- mul (atoi $digits) (get $units $suffix) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Message journal durability validation (J-03).
+
+An enabled journal on a non-persistent data dir is a data-loss configuration
+wearing a durability costume: the volume renders as emptyDir while
+GRAYLOG_MESSAGE_JOURNAL_ENABLED=true tells Graylog its write-ahead log survives
+restarts. Every pod replacement then silently discards whatever had not been
+processed yet.
+
+Three things this deliberately does NOT treat as the broken combination:
+
+  - existingClaim. `persistence.enabled=false` with an existingClaim still mounts
+    a real PVC (see the volumes block in the Graylog StatefulSet), so the journal
+    is durable and the config is legitimate.
+  - graylog.enabled=false. No StatefulSet is rendered, so there is no pod and no
+    journal to lose.
+  - A journal that is genuinely turned off. messageJournal.enabled is
+    schema-typed as a *string*, so `if .Values.graylog.config.messageJournal.enabled`
+    is truthy even for "false" - a non-empty string. The comparison below has to
+    be against the value, not its truthiness, or the guard fires on the very
+    configuration it tells people to use.
+*/}}
+{{- define "graylog.journal.validate" -}}
+{{- if .Values.graylog.enabled }}
+{{/* Mirrors how config/graylog.yaml renders the env var: `default true` covers
+     nil/empty, toString covers a bool from a values file, lower covers "False". */}}
+{{- $journal := .Values.graylog.config.messageJournal.enabled | default true | toString | lower }}
+{{- if ne $journal "false" }}
+{{- if and (not .Values.graylog.persistence.enabled) (not .Values.graylog.persistence.existingClaim) }}
+{{/* The first line is deliberately short and everything substantive follows a
+     break: helm-unittest only matches a fail message from the first line break
+     onward, so anything asserted in the test suite has to live below it. */}}
+{{- $msg := "Cannot enable the message journal without persistent storage." }}
+{{- $msg = cat $msg "\n\ngraylog.config.messageJournal.enabled is on while graylog.persistence.enabled=false, so the journal would be backed by an emptyDir volume: every unprocessed message is lost on any pod restart, eviction, or upgrade - while GRAYLOG_MESSAGE_JOURNAL_ENABLED=true tells Graylog its write-ahead log is durable." }}
+{{- $msg = cat $msg "\n\nChoose one of the following instead:" }}
+{{- $msg = cat $msg "\n\nOption A: Durable journal on chart-managed storage (recommended)" }}
+{{- $msg = cat $msg "\n  --set graylog.persistence.enabled=true" }}
+{{- $msg = cat $msg "\n\nOption B: Durable journal on a pre-provisioned claim" }}
+{{- $msg = cat $msg "\n  --set graylog.persistence.existingClaim=my-graylog-data" }}
+{{- $msg = cat $msg "\n\nOption C: No journal at all (ephemeral or test deployments only)" }}
+{{- $msg = cat $msg "\n  --set-string graylog.config.messageJournal.enabled=false" }}
+{{- $msg = cat $msg "\n  --set graylog.persistence.enabled=false" }}
+{{- $msg = cat $msg "\n\nNote: messageJournal.enabled is a string in values.schema.json, so Option C needs --set-string. A bare `--set ...enabled=false` is rejected as a boolean." }}
+{{- $msg = cat $msg "\n\nSee docs/graylog-message-handling.md for what the journal protects and how to drain it." }}
+{{- fail $msg }}
+{{- end }}
+{{/*
+  Journal cap vs volume size (J-06). Only checkable when the chart provisions the
+  volume: an existingClaim's capacity is not knowable at render time, and a
+  disabled persistence has no declared size (and is already rejected above).
+
+  The cap is compared at 90% of the volume rather than 100%. The journal shares the
+  data volume with the node-id, the truststore, content packs and GeoIP databases,
+  and it can overshoot its cap briefly because reaping happens per segment. A full
+  journal throttles inputs by design; a full data volume is a much worse failure.
+*/}}
+{{- if and .Values.graylog.persistence.enabled (not .Values.graylog.persistence.existingClaim) }}
+{{- $capStr := .Values.graylog.config.messageJournal.maxSize | default "5gb" }}
+{{- $volStr := .Values.graylog.persistence.size | default "8Gi" }}
+{{- $cap := include "graylog.sizeToBytes" $capStr }}
+{{- $vol := include "graylog.sizeToBytes" $volStr }}
+{{- if and $cap $vol }}
+{{- $capB := atoi $cap }}
+{{- $volB := atoi $vol }}
+{{- if gt (mul $capB 10) (mul $volB 9) }}
+{{/* Suggestions in MiB: Graylog accepts mb, Kubernetes accepts Mi, and integer
+     division keeps both on the safe side of the 90% line. */}}
+{{- $maxCapMiB := div (mul $volB 9) 10485760 }}
+{{- $minVolMiB := div (add (mul $capB 10) 9437183) 9437184 }}
+{{- $msg := "The message journal cap does not fit the data volume." }}
+{{- $msg = cat $msg (printf "\n\ngraylog.config.messageJournal.maxSize (%s) claims more than 90%% of graylog.persistence.size (%s). The journal shares that volume with the node-id, truststore, content packs and GeoIP databases, so it cannot have all of it." $capStr $volStr) }}
+{{- $msg = cat $msg "\n\nA full journal throttles inputs by design. A full data volume does not - it takes the node down." }}
+{{- $msg = cat $msg "\n\nEither:" }}
+{{- $msg = cat $msg (printf "\n  Lower the cap:      --set-string graylog.config.messageJournal.maxSize=%dmb" $maxCapMiB) }}
+{{- $msg = cat $msg (printf "\n  Or grow the volume: --set graylog.persistence.size=%dMi" $minVolMiB) }}
+{{- $msg = cat $msg "\n\nNote that growing an existing volume needs a StorageClass with allowVolumeExpansion, and shrinking one is not supported at all." }}
+{{- $msg = cat $msg "\n\nSee docs/graylog-message-handling.md for journal sizing." }}
+{{- fail $msg }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/config/graylog.yaml
+++ b/charts/graylog/templates/config/graylog.yaml
@@ -60,6 +60,14 @@ data:
   {{/* http_publish_uri is rendered directly on the PodSpec for each Graylog node based on $POD_NAME */}}
   # GRAYLOG_HTTP_PUBLISH_URI: ""
 
+  {{- if include "graylog.forwarder.enabled" . | eq "true" }}
+  # Forwarder
+  {{/* Without a bind address Graylog never listens on 13301/13302, so forwarders
+       cannot connect no matter how the ingest endpoint is exposed. */}}
+  GRAYLOG_FORWARDER_BIND_ADDRESS: {{ .Values.graylog.config.forwarder.bindAddress | quote }}
+  GRAYLOG_FORWARDER_GRPC_ENABLE_TLS: {{ .Values.graylog.config.forwarder.grpcEnableTls | quote }}
+  {{- end }}
+
   # Performance Tuning
   GRAYLOG_ASYNC_EVENTBUS_PROCESSORS: {{ .Values.graylog.config.performance.asyncEventbusProcessors | int | quote }}
   GRAYLOG_AUTO_RESTART_INPUTS: {{ .Values.graylog.config.performance.autoRestartInputs | quote }}

--- a/charts/graylog/templates/config/graylog.yaml
+++ b/charts/graylog/templates/config/graylog.yaml
@@ -41,6 +41,7 @@ data:
   GRAYLOG_MESSAGE_JOURNAL_FLUSH_AGE: {{ .Values.graylog.config.messageJournal.flushAge | quote }} 
   GRAYLOG_MESSAGE_JOURNAL_FLUSH_INTERVAL: {{ .Values.graylog.config.messageJournal.flushInterval | int | quote }}
   GRAYLOG_MESSAGE_JOURNAL_MAX_AGE: {{ .Values.graylog.config.messageJournal.maxAge | quote }}
+  GRAYLOG_MESSAGE_JOURNAL_MAX_SIZE: {{ .Values.graylog.config.messageJournal.maxSize | default "5gb" | quote }}
   GRAYLOG_MESSAGE_JOURNAL_SEGMENT_AGE: {{ .Values.graylog.config.messageJournal.segmentAge | quote }}
   GRAYLOG_MESSAGE_JOURNAL_SEGMENT_SIZE: {{ .Values.graylog.config.messageJournal.segmentSize | quote }}
 
@@ -72,6 +73,8 @@ data:
      Unrecognised GRAYLOG_* env vars are silently dropped, so rendering
      GRAYLOG_FORWARDER_BIND_ADDRESS did nothing -- 13301/13302 stayed closed until
      the input was created, after which Graylog bound them on every node.
+     graylog.config.forwarder has since been removed from values.yaml, so the
+     block below reads paths that no longer exist; re-add them to restore it.
      NOTE: grpc TLS defaults to TRUE on the input; behind a TLS-terminating load
      balancer it must be set false or targets stay unhealthy.
 

--- a/charts/graylog/templates/config/graylog.yaml
+++ b/charts/graylog/templates/config/graylog.yaml
@@ -60,13 +60,27 @@ data:
   {{/* http_publish_uri is rendered directly on the PodSpec for each Graylog node based on $POD_NAME */}}
   # GRAYLOG_HTTP_PUBLISH_URI: ""
 
+  {{/* DISABLED 2026-07-30 -- these settings are INERT. Verified against Graylog
+     Enterprise 7.1.6: the forwarder listener is configured as attributes on a
+     Graylog input of type "Forwarder"
+     (org.graylog.plugins.forwarder.input.ForwarderServiceInput), NOT via
+     server.conf:
+         forwarder_bind_address                default 0.0.0.0
+         forwarder_message_transmission_port   default 13301
+         forwarder_configuration_port          default 13302
+         forwarder_grpc_enable_tls             default TRUE
+     Unrecognised GRAYLOG_* env vars are silently dropped, so rendering
+     GRAYLOG_FORWARDER_BIND_ADDRESS did nothing -- 13301/13302 stayed closed until
+     the input was created, after which Graylog bound them on every node.
+     NOTE: grpc TLS defaults to TRUE on the input; behind a TLS-terminating load
+     balancer it must be set false or targets stay unhealthy.
+
   {{- if include "graylog.forwarder.enabled" . | eq "true" }}
   # Forwarder
-  {{/* Without a bind address Graylog never listens on 13301/13302, so forwarders
-       cannot connect no matter how the ingest endpoint is exposed. */}}
   GRAYLOG_FORWARDER_BIND_ADDRESS: {{ .Values.graylog.config.forwarder.bindAddress | quote }}
   GRAYLOG_FORWARDER_GRPC_ENABLE_TLS: {{ .Values.graylog.config.forwarder.grpcEnableTls | quote }}
   {{- end }}
+  */}}
 
   # Performance Tuning
   GRAYLOG_ASYNC_EVENTBUS_PROCESSORS: {{ .Values.graylog.config.performance.asyncEventbusProcessors | int | quote }}

--- a/charts/graylog/templates/config/init-graylog.yaml
+++ b/charts/graylog/templates/config/init-graylog.yaml
@@ -9,12 +9,37 @@ metadata:
 data:
   init-script.sh: |
     #!/bin/sh
-    # initialize data dir
-    if [ -f /mnt/data/journal/.lock ]; then
-      echo "Data already initialized, skipping copy."
+    # Initialize the data dir.
+    #
+    # The sentinel is a dedicated marker, not the journal lock file. Volume
+    # initialization and journal presence are independent concerns: the lock only
+    # exists while a journal does, so disabling the journal - or anything else that
+    # removes that lock - made every restart re-run the copy below and overwrite
+    # volume contents with the image defaults.
+    if [ -f /mnt/data/.initialized ]; then
+      echo "Data volume already initialized, skipping copy."
+    elif [ -f /mnt/data/journal/.lock ]; then
+      # Migration path for volumes initialized by an earlier chart version: they
+      # carry the journal lock but no marker. The lock is proof enough that the
+      # copy already happened, so adopt the volume and stamp the marker. Running
+      # the copy here would clobber a live volume - the exact failure this change
+      # exists to prevent, triggered by the fix itself.
+      echo "Data volume was initialized by an earlier chart version; adopting it."
+      touch /mnt/data/.initialized
     else
-      # copy data dir
-      cp -r /usr/share/graylog/data/* /mnt/data/
+      # A volume initialized by an earlier chart version with the journal disabled
+      # has neither marker nor lock, so it lands here and is copied over once more.
+      # That matches the old behaviour, which re-copied on every restart, and it
+      # self-heals: the marker below stops it recurring.
+      echo "Initializing data volume."
+      # The marker is written only on success. Stamping it after a partial copy
+      # would mark a broken volume as done and never retry.
+      if cp -r /usr/share/graylog/data/* /mnt/data/; then
+        touch /mnt/data/.initialized
+      else
+        echo "Error: failed to copy the default data directory to /mnt/data."
+        exit 1
+      fi
     fi
     {{ if and .Values.graylog.config.tls.enabled }}
     # check that the FDQN for all Graylog nodes is part of the certificate SANs

--- a/charts/graylog/templates/config/secret/secrets.yaml
+++ b/charts/graylog/templates/config/secret/secrets.yaml
@@ -1,5 +1,7 @@
 {{/* BYO OpenSearch / Data Node validation (runs regardless of secret source) */}}
 {{- include "graylog.opensearch.validate" . -}}
+{{/* Message journal durability validation (J-03) */}}
+{{- include "graylog.journal.validate" . -}}
 {{/* BYO Mongo validation */}}
 {{- if not .Values.mongodb.communityResource.enabled | and (empty .Values.global.existingSecretName) (empty .Values.graylog.config.mongodb.customUri) }}
   {{- $err := "A MongoDB connection URI must be specified when mongodb.communityResource.enabled is set to 'false'." }}

--- a/charts/graylog/templates/service/graylog.yaml
+++ b/charts/graylog/templates/service/graylog.yaml
@@ -25,7 +25,7 @@ spec:
       targetPort: {{ .targetPort | default .port | int }}
       protocol: {{ .protocol }}
     {{- end }}
-    - name: input-fwd-conf
+    - name: {{ include "graylog.service.port.forwarder.config" . }}
       port: 13302
       targetPort: 13302
       protocol: TCP

--- a/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
+++ b/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
@@ -1,44 +1,67 @@
-{{- if and .Values.ingress.enabled .Values.ingress.forwarder.enabled -}}
+{{- if and .Values.graylog.enabled .Values.ingress.enabled .Values.ingress.forwarder.enabled -}}
+{{- $root := . -}}
+{{- $defaultPath := include "graylog.ingress.defaultPath" . -}}
+{{- $defaultPathType := include "graylog.ingress.defaultPathType" . -}}
+{{/*
+A forwarder needs both gRPC channels reachable: the message channel (13301) it
+sends log data on, and the configuration channel (13302) it polls for updates.
+They listen on separate ports, and an Ingress routes on host/path rather than
+listener port, so each channel gets its own Ingress resource.
+*/}}
+{{- $channels := list
+      (dict "name" (include "graylog.ingress.forwarder.message.name" .)
+            "portName" (include "graylog.service.port.forwarder.message" .)
+            "channel" .Values.ingress.forwarder.messageChannel)
+      (dict "name" (include "graylog.ingress.forwarder.config.name" .)
+            "portName" (include "graylog.service.port.forwarder.config" .)
+            "channel" .Values.ingress.forwarder.configChannel) -}}
+{{- range $channels }}
+{{- if .channel.enabled }}
+{{- $channel := .channel }}
+{{- $portName := .portName }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "graylog.fullname" . | printf "%s-forwarder" }}
+  name: {{ .name }}
   labels:
     app.kubernetes.io/component: forwarder
-    {{- include "graylog.labels" . | nindent 4 }}
-  {{- with .Values.ingress.forwarder.annotations }}
+    {{- include "graylog.labels" $root | nindent 4 }}
+  {{- with $channel.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.forwarder.className }}
+  {{- with $channel.className }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- if .Values.ingress.forwarder.tls }}
+  {{- if $channel.tls }}
   tls:
-    {{- range .Values.ingress.forwarder.tls }}
+    {{- range $channel.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ .secretName | default (include "graylog.fullname" $root | printf "%s-tls") }}
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.forwarder.hosts }}
-    - host: {{ .host | quote }}
+    {{- range $channel.hosts }}
+    - {{ with .host -}}
+      host: {{ . | quote }}
+      {{- end }}
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
+          - path: {{ .path | default $defaultPath }}
+            pathType: {{ .pathType | default $defaultPathType }}
             backend:
               service:
-                name: {{ include "graylog.service.name" $ }}
+                name: {{ include "graylog.service.name" $root }}
                 port:
-                  name: input-forwarder
+                  name: {{ $portName }}
           {{- end }}
     {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/graylog/templates/workload/containers/_prestop-drain.tpl
+++ b/charts/graylog/templates/workload/containers/_prestop-drain.tpl
@@ -1,0 +1,111 @@
+{{/*
+Graylog preStop journal drain — token-free variant.
+
+Renders the `lifecycle:` block for the graylog-app container. Nothing is emitted
+unless graylog.lifecycle.preStopDrain.enabled is true.
+
+Why this exists: a StatefulSet guarantees identity, not data migration. Graylog's
+graceful shutdown flushes in-memory buffers *into* the journal; it never drains
+the journal *out* — that is the replacement pod's job. On scale-in there is no
+replacement pod, so whatever is left in the journal is stranded in an orphaned
+PVC and nothing will ever replay it. This hook is the only chance a doomed
+ordinal gets to work its journal off.
+
+Why it needs no credentials: journal depth is published as
+`gl_journal_entries_uncommitted` by the Prometheus exporter on
+graylog.service.ports.metrics, which answers unauthenticated on localhost. The
+equivalent REST endpoint (GET /api/system/journal) requires admin auth — see
+the token-based variant for what that buys.
+
+Call with: {{ include "graylog.lifecycle" . | nindent 10 }}
+*/}}
+{{- define "graylog.lifecycle" -}}
+{{- if .Values.graylog.lifecycle.preStopDrain.enabled }}
+{{- $drain := .Values.graylog.lifecycle.preStopDrain }}
+{{- $grace := .Values.graylog.terminationGracePeriodSeconds | int }}
+{{- $settle := $drain.endpointPropagationDelaySeconds | int }}
+{{- $reserve := $drain.shutdownReserveSeconds | int }}
+{{- $poll := $drain.pollIntervalSeconds | int }}
+{{/*
+  The grace period is a hard ceiling covering the preStop hook AND the SIGTERM
+  that follows it. If the hook is still running when it expires, the container is
+  SIGKILLed, Graylog never receives SIGTERM, and the in-memory buffers this
+  feature exists to protect are lost — strictly worse than no hook at all. So the
+  drain budget is what is left after reserving time for the shutdown itself.
+*/}}
+{{- $budget := sub $grace (add $settle $reserve) | int }}
+{{- if not .Values.graylog.service.metrics.enabled }}
+{{- fail "graylog.lifecycle.preStopDrain.enabled=true requires graylog.service.metrics.enabled=true.\n  The drain reads journal depth from the Prometheus exporter, which is gated by that value (GRAYLOG_PROMETHEUS_EXPORTER_ENABLED).\n  Either:\n    Set graylog.service.metrics.enabled=true\n    Or set graylog.lifecycle.preStopDrain.enabled=false and drain manually (see the Message Journal Lifecycle runbook in the README)." }}
+{{- end }}
+{{- if le $budget 1 }}
+{{- fail (printf "graylog.lifecycle.preStopDrain leaves no time to drain: terminationGracePeriodSeconds (%d) - endpointPropagationDelaySeconds (%d) - shutdownReserveSeconds (%d) = %d.\n  The drain budget must be positive, and a hook that consumes the whole grace period gets the container SIGKILLed before Graylog can flush its in-memory buffers.\n  Either:\n    Raise graylog.terminationGracePeriodSeconds\n    Or lower graylog.lifecycle.preStopDrain.shutdownReserveSeconds / endpointPropagationDelaySeconds." $grace $settle $reserve $budget) }}
+{{- end }}
+{{/* pollIntervalSeconds >= 1 is enforced by values.schema.json; only the
+     cross-field constraints need a template-time guard. */}}
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - |
+          # Token-free journal drain. Always exits 0: a failing preStop hook
+          # would stall termination for the whole grace period and then get the
+          # container SIGKILLed, so every give-up path here hands over to
+          # Graylog's own graceful shutdown instead of erroring.
+          set -u
+          URL="http://127.0.0.1:{{ .Values.graylog.service.ports.metrics | default 9833 | int }}/metrics"
+          BUDGET={{ $budget }}
+          POLL={{ $poll }}
+          SETTLE={{ $settle }}
+          STALL_LIMIT={{ $drain.stallPolls | int }}
+
+          log() { echo "[prestop-drain] $*"; }
+
+          # Kubernetes removes a Terminating pod from every Service
+          # EndpointSlice, but kube-proxy convergence is not instant. Measuring
+          # before it lands reads traffic that is already going away.
+          log "waiting ${SETTLE}s for endpoint removal to propagate"
+          sleep "${SETTLE}"
+
+          # Wall clock, not a tick count. Each iteration can block for up to the
+          # curl timeout, so counting polls would let the hook overrun BUDGET by
+          # a wide margin and get the container SIGKILLed mid-shutdown.
+          started=$(date +%s)
+          deadline=$((started + BUDGET))
+          stall=0
+          last=""
+          while [ "$(date +%s)" -lt "${deadline}" ]; do
+            elapsed=$(( $(date +%s) - started ))
+            # $NF is the gauge value; ^gl_ skips the "# HELP"/"# TYPE" lines, and
+            # the anchored name avoids the similarly-spelled data-lake and kafka
+            # gauges. awk exits non-zero when the gauge is absent.
+            n=$(curl -fsS --max-time 5 "${URL}" 2>/dev/null \
+              | awk '/^gl_journal_entries_uncommitted[{ ]/ { v = $NF } END { if (v == "") exit 1; printf "%d\n", v }')
+            if [ -z "${n}" ]; then
+              log "journal gauge unavailable after ${elapsed}s; handing over to graceful shutdown"
+              exit 0
+            fi
+            if [ "${n}" -le 0 ]; then
+              log "journal drained after ${elapsed}s"
+              exit 0
+            fi
+            if [ "${n}" = "${last}" ]; then
+              stall=$((stall + 1))
+              if [ "${stall}" -ge "${STALL_LIMIT}" ]; then
+                # Endpoint removal only sheds newly-established connections.
+                # Long-lived TCP inputs and UDP keep arriving, so a flat gauge
+                # means waiting longer will not help.
+                log "journal flat at ${n} uncommitted entries across ${stall} polls (${elapsed}s); senders are still writing, handing over to graceful shutdown"
+                exit 0
+              fi
+            else
+              stall=0
+            fi
+            last="${n}"
+            sleep "${POLL}"
+          done
+          log "drain budget of ${BUDGET}s exhausted with ${last} uncommitted entries remaining; handing over to graceful shutdown"
+          exit 0
+{{- end }}
+{{- end }}

--- a/charts/graylog/templates/workload/containers/_prestop-drain.tpl
+++ b/charts/graylog/templates/workload/containers/_prestop-drain.tpl
@@ -49,83 +49,57 @@ lifecycle:
         - /bin/sh
         - -c
         - |
-          # Token-free journal drain. Always exits 0: a failing preStop hook
-          # would stall termination for the whole grace period and then get the
-          # container SIGKILLed, so every give-up path here hands over to
-          # Graylog's own graceful shutdown instead of erroring.
-          set -u
-          URL="http://127.0.0.1:{{ .Values.graylog.service.ports.metrics | default 9833 | int }}/metrics"
-          BUDGET={{ $budget }}
-          POLL={{ $poll }}
-          SETTLE={{ $settle }}
-          STALL_LIMIT={{ $drain.stallPolls | int }}
+          {{/* A real .sh, kept outside templates/ so it contains no Helm syntax and
+               tooling can read it. .Files.Get returns it verbatim - all of its
+               configuration arrives through the env below. */}}
+          {{- .Files.Get "files/scripts/prestop-drain.sh" | nindent 10 }}
+{{- end }}
+{{- end }}
 
-          # kubelet discards preStop stdout — it only ever surfaces (truncated) in
-          # a FailedPreStopHook event, and only when the hook fails. Writing to
-          # PID 1's stdout puts these lines in the container's real log stream so
-          # `kubectl logs` can see a drain happen. Keep the plain echo too: it is
-          # what lands in the event if this hook ever does fail.
-          log() {
-            echo "[prestop-drain] $*"
-            echo "[prestop-drain] $*" > /proc/1/fd/1 2>/dev/null || true
-          }
+{{/*
+Environment for the preStop drain script.
 
-          # Kubernetes removes a Terminating pod from every Service
-          # EndpointSlice, but kube-proxy convergence is not instant. Measuring
-          # before it lands reads traffic that is already going away.
-          log "waiting ${SETTLE}s for endpoint removal to propagate"
-          sleep "${SETTLE}"
+Rendered into the graylog-app container's `env` so the hook - which inherits the
+container environment - gets its configuration without any templating inside the
+script itself. Also means `kubectl describe pod` shows exactly what the drain was
+configured with, and the script can be run by hand for testing.
 
-          # Wall clock, not a tick count. Each iteration can block for up to the
-          # curl timeout, so counting polls would let the hook overrun BUDGET by
-          # a wide margin and get the container SIGKILLed mid-shutdown.
-          started=$(date +%s)
-          deadline=$((started + BUDGET))
-          # Progress is measured against the best (lowest) depth seen so far, not
-          # against the previous sample. Under live ingest the gauge oscillates
-          # continuously — two consecutive samples are essentially never equal —
-          # so an equality test never fires and the hook burns the whole budget
-          # for nothing. Requiring a new low means "no improvement" is detected
-          # even while the raw number jitters.
-          stall=0
-          best=""
-          while [ "$(date +%s)" -lt "${deadline}" ]; do
-            elapsed=$(( $(date +%s) - started ))
-            # $NF is the gauge value; ^gl_ skips the "# HELP"/"# TYPE" lines, and
-            # the anchored name avoids the similarly-spelled data-lake and kafka
-            # gauges. awk exits non-zero when the gauge is absent. The append rate
-            # is diagnostic only: it explains *why* a drain cannot finish.
-            sample=$(curl -fsS --max-time 5 "${URL}" 2>/dev/null \
-              | awk '/^gl_journal_entries_uncommitted[{ ]/ { v = $NF }
-                     /^gl_journal_append_1_sec_rate[{ ]/   { r = $NF }
-                     END { if (v == "") exit 1; printf "%d %d\n", v, r }')
-            if [ -z "${sample}" ]; then
-              log "journal gauge unavailable after ${elapsed}s; handing over to graceful shutdown"
-              exit 0
-            fi
-            n=${sample% *}
-            rate=${sample#* }
-            if [ "${n}" -le 0 ]; then
-              log "journal drained after ${elapsed}s"
-              exit 0
-            fi
-            if [ -z "${best}" ] || [ "${n}" -lt "${best}" ]; then
-              best="${n}"
-              stall=0
-            else
-              stall=$((stall + 1))
-              if [ "${stall}" -ge "${STALL_LIMIT}" ]; then
-                # Endpoint removal only sheds newly-established connections.
-                # Long-lived TCP inputs and UDP senders keep writing, so the
-                # journal will not reach zero no matter how long we wait. Only
-                # stopping the inputs can do that, and that needs a token.
-                log "no progress in ${stall} polls (${elapsed}s): depth ${n}, best ${best}, still ingesting ${rate} msg/s. A true drain needs inputs stopped; handing over to graceful shutdown"
-                exit 0
-              fi
-            fi
-            sleep "${POLL}"
-          done
-          log "drain budget of ${BUDGET}s exhausted at depth ${n} (best ${best}, ingesting ${rate} msg/s); handing over to graceful shutdown"
-          exit 0
+Deliberately not GRAYLOG_-prefixed: this container's environment is read as
+server.conf overrides, and a GRAYLOG_ name would look like a setting that does
+not exist.
+
+Call with: {{ include "graylog.prestopDrain.env" . | nindent 12 }}
+*/}}
+{{- define "graylog.prestopDrain.env" -}}
+{{- if .Values.graylog.lifecycle.preStopDrain.enabled }}
+{{- $drain := .Values.graylog.lifecycle.preStopDrain }}
+{{- $grace := .Values.graylog.terminationGracePeriodSeconds | int }}
+{{- $settle := $drain.endpointPropagationDelaySeconds | int }}
+{{- $reserve := $drain.shutdownReserveSeconds | int }}
+- name: GL_DRAIN_METRICS_URL
+  value: {{ printf "http://127.0.0.1:%d/metrics" (.Values.graylog.service.ports.metrics | default 9833 | int) | quote }}
+{{/* Same derivation as "graylog.lifecycle", which is where it is validated. */}}
+- name: GL_DRAIN_BUDGET_SECONDS
+  value: {{ sub $grace (add $settle $reserve) | int | quote }}
+- name: GL_DRAIN_POLL_SECONDS
+  value: {{ $drain.pollIntervalSeconds | int | quote }}
+- name: GL_DRAIN_SETTLE_SECONDS
+  value: {{ $settle | quote }}
+- name: GL_DRAIN_STALL_POLLS
+  value: {{ $drain.stallPolls | int | quote }}
+- name: GL_DRAIN_STATUS_INTERVAL_SECONDS
+  value: {{ $drain.statusIntervalSeconds | int | quote }}
+- name: GL_DRAIN_CONFIRM_POLLS
+  value: {{ $drain.confirmPolls | int | quote }}
+- name: GL_DRAIN_METRICS_RETRIES
+  value: {{ $drain.metricsRetries | int | quote }}
+{{/* 0 disables the projection outright, so int is the right coercion here - a
+     `default` would silently turn the intended 0 back into the chart default. */}}
+- name: GL_DRAIN_FEASIBILITY_WARMUP_POLLS
+  value: {{ $drain.feasibilityWarmupPolls | int | quote }}
+- name: GL_DRAIN_GRACE_SECONDS
+  value: {{ $grace | quote }}
+- name: GL_DRAIN_RESERVE_SECONDS
+  value: {{ $reserve | quote }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/workload/containers/_prestop-drain.tpl
+++ b/charts/graylog/templates/workload/containers/_prestop-drain.tpl
@@ -35,7 +35,7 @@ Call with: {{ include "graylog.lifecycle" . | nindent 10 }}
 */}}
 {{- $budget := sub $grace (add $settle $reserve) | int }}
 {{- if not .Values.graylog.service.metrics.enabled }}
-{{- fail "graylog.lifecycle.preStopDrain.enabled=true requires graylog.service.metrics.enabled=true.\n  The drain reads journal depth from the Prometheus exporter, which is gated by that value (GRAYLOG_PROMETHEUS_EXPORTER_ENABLED).\n  Either:\n    Set graylog.service.metrics.enabled=true\n    Or set graylog.lifecycle.preStopDrain.enabled=false and drain manually (see the Message Journal Lifecycle runbook in the README)." }}
+{{- fail "graylog.lifecycle.preStopDrain.enabled=true requires graylog.service.metrics.enabled=true.\n  The drain reads journal depth from the Prometheus exporter, which is gated by that value (GRAYLOG_PROMETHEUS_EXPORTER_ENABLED).\n  Either:\n    Set graylog.service.metrics.enabled=true\n    Or set graylog.lifecycle.preStopDrain.enabled=false and drain manually (see the scale-in runbook in docs/graylog-message-handling.md)." }}
 {{- end }}
 {{- if le $budget 1 }}
 {{- fail (printf "graylog.lifecycle.preStopDrain leaves no time to drain: terminationGracePeriodSeconds (%d) - endpointPropagationDelaySeconds (%d) - shutdownReserveSeconds (%d) = %d.\n  The drain budget must be positive, and a hook that consumes the whole grace period gets the container SIGKILLed before Graylog can flush its in-memory buffers.\n  Either:\n    Raise graylog.terminationGracePeriodSeconds\n    Or lower graylog.lifecycle.preStopDrain.shutdownReserveSeconds / endpointPropagationDelaySeconds." $grace $settle $reserve $budget) }}

--- a/charts/graylog/templates/workload/containers/_prestop-drain.tpl
+++ b/charts/graylog/templates/workload/containers/_prestop-drain.tpl
@@ -60,7 +60,15 @@ lifecycle:
           SETTLE={{ $settle }}
           STALL_LIMIT={{ $drain.stallPolls | int }}
 
-          log() { echo "[prestop-drain] $*"; }
+          # kubelet discards preStop stdout — it only ever surfaces (truncated) in
+          # a FailedPreStopHook event, and only when the hook fails. Writing to
+          # PID 1's stdout puts these lines in the container's real log stream so
+          # `kubectl logs` can see a drain happen. Keep the plain echo too: it is
+          # what lands in the event if this hook ever does fail.
+          log() {
+            echo "[prestop-drain] $*"
+            echo "[prestop-drain] $*" > /proc/1/fd/1 2>/dev/null || true
+          }
 
           # Kubernetes removes a Terminating pod from every Service
           # EndpointSlice, but kube-proxy convergence is not instant. Measuring
@@ -73,39 +81,51 @@ lifecycle:
           # a wide margin and get the container SIGKILLed mid-shutdown.
           started=$(date +%s)
           deadline=$((started + BUDGET))
+          # Progress is measured against the best (lowest) depth seen so far, not
+          # against the previous sample. Under live ingest the gauge oscillates
+          # continuously — two consecutive samples are essentially never equal —
+          # so an equality test never fires and the hook burns the whole budget
+          # for nothing. Requiring a new low means "no improvement" is detected
+          # even while the raw number jitters.
           stall=0
-          last=""
+          best=""
           while [ "$(date +%s)" -lt "${deadline}" ]; do
             elapsed=$(( $(date +%s) - started ))
             # $NF is the gauge value; ^gl_ skips the "# HELP"/"# TYPE" lines, and
             # the anchored name avoids the similarly-spelled data-lake and kafka
-            # gauges. awk exits non-zero when the gauge is absent.
-            n=$(curl -fsS --max-time 5 "${URL}" 2>/dev/null \
-              | awk '/^gl_journal_entries_uncommitted[{ ]/ { v = $NF } END { if (v == "") exit 1; printf "%d\n", v }')
-            if [ -z "${n}" ]; then
+            # gauges. awk exits non-zero when the gauge is absent. The append rate
+            # is diagnostic only: it explains *why* a drain cannot finish.
+            sample=$(curl -fsS --max-time 5 "${URL}" 2>/dev/null \
+              | awk '/^gl_journal_entries_uncommitted[{ ]/ { v = $NF }
+                     /^gl_journal_append_1_sec_rate[{ ]/   { r = $NF }
+                     END { if (v == "") exit 1; printf "%d %d\n", v, r }')
+            if [ -z "${sample}" ]; then
               log "journal gauge unavailable after ${elapsed}s; handing over to graceful shutdown"
               exit 0
             fi
+            n=${sample% *}
+            rate=${sample#* }
             if [ "${n}" -le 0 ]; then
               log "journal drained after ${elapsed}s"
               exit 0
             fi
-            if [ "${n}" = "${last}" ]; then
+            if [ -z "${best}" ] || [ "${n}" -lt "${best}" ]; then
+              best="${n}"
+              stall=0
+            else
               stall=$((stall + 1))
               if [ "${stall}" -ge "${STALL_LIMIT}" ]; then
                 # Endpoint removal only sheds newly-established connections.
-                # Long-lived TCP inputs and UDP keep arriving, so a flat gauge
-                # means waiting longer will not help.
-                log "journal flat at ${n} uncommitted entries across ${stall} polls (${elapsed}s); senders are still writing, handing over to graceful shutdown"
+                # Long-lived TCP inputs and UDP senders keep writing, so the
+                # journal will not reach zero no matter how long we wait. Only
+                # stopping the inputs can do that, and that needs a token.
+                log "no progress in ${stall} polls (${elapsed}s): depth ${n}, best ${best}, still ingesting ${rate} msg/s. A true drain needs inputs stopped; handing over to graceful shutdown"
                 exit 0
               fi
-            else
-              stall=0
             fi
-            last="${n}"
             sleep "${POLL}"
           done
-          log "drain budget of ${BUDGET}s exhausted with ${last} uncommitted entries remaining; handing over to graceful shutdown"
+          log "drain budget of ${BUDGET}s exhausted at depth ${n} (best ${best}, ingesting ${rate} msg/s); handing over to graceful shutdown"
           exit 0
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -25,6 +25,11 @@ spec:
       partition: {{ int . }}
       {{- end }}
     {{- end }}
+  {{/* Explicity add the Datanode retentionPolicy */}}
+  {{- $dnRet := .Values.datanode.persistence.retentionPolicy | default dict }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ $dnRet.whenDeleted | default "Retain" }}
+    whenScaled: {{ $dnRet.whenScaled | default "Retain" }}
   template:
     metadata:
       labels:

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -26,6 +26,13 @@ spec:
       partition: {{ int . }}
       {{- end }}
     {{- end }}
+  {{- $ret := .Values.graylog.persistence.retentionPolicy }}
+  {{- if eq ($ret.whenScaled | default "Retain") "Delete" }}
+  {{- fail "graylog.persistence.retentionPolicy.whenScaled=Delete would destroy the journal of any scaled-in node.\n  Scaling in removes the highest ordinal; anything still unprocessed in its journal exists only on that claim, and nothing replays an orphaned journal.\n  Delete makes that loss silent and unrecoverable.\n  Either:\n    Leave whenScaled=Retain and delete claims by hand once verified empty (see Message Journal Lifecycle in the README)\n    Or set graylog.persistence.enabled=false if this deployment does not need a durable journal." }}
+  {{- end }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ $ret.whenDeleted | default "Retain" }}
+    whenScaled: {{ $ret.whenScaled | default "Retain" }}
   template:
     metadata:
       labels:
@@ -141,6 +148,9 @@ spec:
           {{- if or .Values.graylog.env .Values.graylog.extraEnv }}
             {{- include "graylog.env" .Values.graylog | indent 12 }}
           {{- end }}
+          {{/* Config for the preStop drain hook, which inherits this container's
+               environment. Renders nothing when the drain is disabled. */}}
+          {{- include "graylog.prestopDrain.env" . | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ include "graylog.configmap.name" . }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -162,7 +162,7 @@ spec:
               containerPort: {{ .targetPort | default .port | int }}
               protocol: {{ .protocol }}
             {{- end }}
-            - name: input-fwd-conf
+            - name: {{ include "graylog.service.port.forwarder.config" . }}
               containerPort: 13302
               protocol: TCP
           {{- if .Values.graylog.livenessProbe.enabled }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end }}
   {{- $ret := .Values.graylog.persistence.retentionPolicy }}
   {{- if eq ($ret.whenScaled | default "Retain") "Delete" }}
-  {{- fail "graylog.persistence.retentionPolicy.whenScaled=Delete would destroy the journal of any scaled-in node.\n  Scaling in removes the highest ordinal; anything still unprocessed in its journal exists only on that claim, and nothing replays an orphaned journal.\n  Delete makes that loss silent and unrecoverable.\n  Either:\n    Leave whenScaled=Retain and delete claims by hand once verified empty (see Message Journal Lifecycle in the README)\n    Or set graylog.persistence.enabled=false if this deployment does not need a durable journal." }}
+  {{- fail "graylog.persistence.retentionPolicy.whenScaled=Delete would destroy the journal of any scaled-in node.\n  Scaling in removes the highest ordinal; anything still unprocessed in its journal exists only on that claim, and nothing replays an orphaned journal.\n  Delete makes that loss silent and unrecoverable.\n  Either:\n    Leave whenScaled=Retain and delete claims by hand once verified empty (see docs/graylog-message-handling.md)\n    Or set graylog.persistence.enabled=false if this deployment does not need a durable journal." }}
   {{- end }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ $ret.whenDeleted | default "Retain" }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -40,6 +40,9 @@ spec:
       {{- end }}
     spec:
       dnsPolicy: ClusterFirst
+      {{- with .Values.graylog.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ int . }}
+      {{- end }}
       {{- with .Values.graylog.image.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -182,6 +185,7 @@ spec:
             failureThreshold: {{ .Values.graylog.readinessProbe.failureThreshold | int }}
             successThreshold: {{ .Values.graylog.readinessProbe.successThreshold | int }}
           {{- end }}
+          {{- include "graylog.lifecycle" . | nindent 10 }}
           {{- with .Values.graylog.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/graylog/tests/datanode_statefulset_test.yaml
+++ b/charts/graylog/tests/datanode_statefulset_test.yaml
@@ -75,3 +75,33 @@ tests:
       - notExists:
           path: spec.template.spec.serviceAccountName
         template: workload/statefulsets/datanode.yaml
+
+  # PVC retention. Pinned explicitly rather than left to the Kubernetes default
+  # so it cannot drift, matching the Graylog StatefulSet.
+  - it: retains the Data Node PVCs on scale-in and on delete by default
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Retain
+        template: workload/statefulsets/datanode.yaml
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Retain
+        template: workload/statefulsets/datanode.yaml
+
+  # Unlike the Graylog StatefulSet, which refuses whenScaled=Delete outright:
+  # shard data on a scaled-in Data Node can be rebuilt from replicas, whereas an
+  # orphaned Graylog journal is not replayable by anything.
+  - it: allows Delete on the Data Node, which the Graylog StatefulSet refuses
+    set:
+      datanode.persistence.retentionPolicy.whenScaled: Delete
+      datanode.persistence.retentionPolicy.whenDeleted: Delete
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+        template: workload/statefulsets/datanode.yaml
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+        template: workload/statefulsets/datanode.yaml

--- a/charts/graylog/tests/forwarder_config_test.yaml
+++ b/charts/graylog/tests/forwarder_config_test.yaml
@@ -1,0 +1,62 @@
+suite: graylog forwarder server configuration
+templates:
+  - config/graylog.yaml
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  - it: omits forwarder settings by default
+    asserts:
+      - notExists:
+          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+      - notExists:
+          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
+
+  - it: binds the forwarder ports when the forwarder ingress is enabled
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+    asserts:
+      - equal:
+          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+          value: "0.0.0.0"
+      - equal:
+          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
+          value: "false"
+
+  - it: binds the forwarder ports when enabled explicitly without an ingress
+    set:
+      graylog.config.forwarder.enabled: true
+    asserts:
+      - equal:
+          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+          value: "0.0.0.0"
+
+  - it: an explicit false overrides the forwarder ingress default
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      graylog.config.forwarder.enabled: false
+    asserts:
+      - notExists:
+          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+      - notExists:
+          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
+
+  - it: honours a custom bind address
+    set:
+      graylog.config.forwarder.enabled: true
+      graylog.config.forwarder.bindAddress: "127.0.0.1"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+          value: "127.0.0.1"
+
+  - it: enables gRPC TLS when requested
+    set:
+      graylog.config.forwarder.enabled: true
+      graylog.config.forwarder.grpcEnableTls: true
+    asserts:
+      - equal:
+          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
+          value: "true"

--- a/charts/graylog/tests/forwarder_config_test.yaml
+++ b/charts/graylog/tests/forwarder_config_test.yaml
@@ -5,12 +5,6 @@ release:
   name: graylog
   namespace: graylog
 tests:
-  # DISABLED 2026-07-30 -- graylog.config.forwarder is commented out because the
-  # settings are inert: the forwarder listener is configured as attributes on a
-  # Graylog input of type "Forwarder", not through server.conf, and unrecognised
-  # GRAYLOG_* env vars are silently dropped. The one live assertion below pins the
-  # current behaviour (nothing rendered); the originals are kept for when the
-  # feature is revisited.
   - it: renders no forwarder server settings while the feature is disabled
     asserts:
       - notExists:
@@ -26,62 +20,3 @@ tests:
           path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
       - notExists:
           path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
-
-# --- original suite, restore alongside graylog.config.forwarder ---
-
-#  - it: omits forwarder settings by default
-#    asserts:
-#      - notExists:
-#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
-#      - notExists:
-#          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
-#
-#  - it: binds the forwarder ports when the forwarder ingress is enabled
-#    set:
-#      ingress.enabled: true
-#      ingress.forwarder.enabled: true
-#    asserts:
-#      - equal:
-#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
-#          value: "0.0.0.0"
-#      - equal:
-#          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
-#          value: "false"
-#
-#  - it: binds the forwarder ports when enabled explicitly without an ingress
-#    set:
-#      graylog.config.forwarder.enabled: true
-#    asserts:
-#      - equal:
-#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
-#          value: "0.0.0.0"
-#
-#  - it: an explicit false overrides the forwarder ingress default
-#    set:
-#      ingress.enabled: true
-#      ingress.forwarder.enabled: true
-#      graylog.config.forwarder.enabled: false
-#    asserts:
-#      - notExists:
-#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
-#      - notExists:
-#          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
-#
-#  - it: honours a custom bind address
-#    set:
-#      graylog.config.forwarder.enabled: true
-#      graylog.config.forwarder.bindAddress: "127.0.0.1"
-#    asserts:
-#      - equal:
-#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
-#          value: "127.0.0.1"
-#
-#  - it: enables gRPC TLS when requested
-#    set:
-#      graylog.config.forwarder.enabled: true
-#      graylog.config.forwarder.grpcEnableTls: true
-#    asserts:
-#      - equal:
-#          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
-#          value: "true"
-#

--- a/charts/graylog/tests/forwarder_config_test.yaml
+++ b/charts/graylog/tests/forwarder_config_test.yaml
@@ -5,58 +5,83 @@ release:
   name: graylog
   namespace: graylog
 tests:
-  - it: omits forwarder settings by default
+  # DISABLED 2026-07-30 -- graylog.config.forwarder is commented out because the
+  # settings are inert: the forwarder listener is configured as attributes on a
+  # Graylog input of type "Forwarder", not through server.conf, and unrecognised
+  # GRAYLOG_* env vars are silently dropped. The one live assertion below pins the
+  # current behaviour (nothing rendered); the originals are kept for when the
+  # feature is revisited.
+  - it: renders no forwarder server settings while the feature is disabled
     asserts:
       - notExists:
           path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
       - notExists:
           path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
-
-  - it: binds the forwarder ports when the forwarder ingress is enabled
+  - it: renders none even when the forwarder ingress is enabled
     set:
       ingress.enabled: true
       ingress.forwarder.enabled: true
     asserts:
-      - equal:
-          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
-          value: "0.0.0.0"
-      - equal:
-          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
-          value: "false"
-
-  - it: binds the forwarder ports when enabled explicitly without an ingress
-    set:
-      graylog.config.forwarder.enabled: true
-    asserts:
-      - equal:
-          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
-          value: "0.0.0.0"
-
-  - it: an explicit false overrides the forwarder ingress default
-    set:
-      ingress.enabled: true
-      ingress.forwarder.enabled: true
-      graylog.config.forwarder.enabled: false
-    asserts:
       - notExists:
           path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
       - notExists:
           path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
 
-  - it: honours a custom bind address
-    set:
-      graylog.config.forwarder.enabled: true
-      graylog.config.forwarder.bindAddress: "127.0.0.1"
-    asserts:
-      - equal:
-          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
-          value: "127.0.0.1"
+# --- original suite, restore alongside graylog.config.forwarder ---
 
-  - it: enables gRPC TLS when requested
-    set:
-      graylog.config.forwarder.enabled: true
-      graylog.config.forwarder.grpcEnableTls: true
-    asserts:
-      - equal:
-          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
-          value: "true"
+#  - it: omits forwarder settings by default
+#    asserts:
+#      - notExists:
+#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+#      - notExists:
+#          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
+#
+#  - it: binds the forwarder ports when the forwarder ingress is enabled
+#    set:
+#      ingress.enabled: true
+#      ingress.forwarder.enabled: true
+#    asserts:
+#      - equal:
+#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+#          value: "0.0.0.0"
+#      - equal:
+#          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
+#          value: "false"
+#
+#  - it: binds the forwarder ports when enabled explicitly without an ingress
+#    set:
+#      graylog.config.forwarder.enabled: true
+#    asserts:
+#      - equal:
+#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+#          value: "0.0.0.0"
+#
+#  - it: an explicit false overrides the forwarder ingress default
+#    set:
+#      ingress.enabled: true
+#      ingress.forwarder.enabled: true
+#      graylog.config.forwarder.enabled: false
+#    asserts:
+#      - notExists:
+#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+#      - notExists:
+#          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
+#
+#  - it: honours a custom bind address
+#    set:
+#      graylog.config.forwarder.enabled: true
+#      graylog.config.forwarder.bindAddress: "127.0.0.1"
+#    asserts:
+#      - equal:
+#          path: data.GRAYLOG_FORWARDER_BIND_ADDRESS
+#          value: "127.0.0.1"
+#
+#  - it: enables gRPC TLS when requested
+#    set:
+#      graylog.config.forwarder.enabled: true
+#      graylog.config.forwarder.grpcEnableTls: true
+#    asserts:
+#      - equal:
+#          path: data.GRAYLOG_FORWARDER_GRPC_ENABLE_TLS
+#          value: "true"
+#

--- a/charts/graylog/tests/forwarder_ingress_test.yaml
+++ b/charts/graylog/tests/forwarder_ingress_test.yaml
@@ -18,79 +18,274 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: renders when ingress and forwarder are enabled
+  - it: renders both channels when ingress and forwarder are enabled
     set:
       ingress.enabled: true
       ingress.forwarder.enabled: true
     asserts:
+      - hasDocuments:
+          count: 2
       - isKind:
           of: Ingress
+        documentIndex: 0
       - equal:
           path: apiVersion
           value: networking.k8s.io/v1
+        documentIndex: 0
       - equal:
           path: metadata.name
-          value: graylog-forwarder
+          value: graylog-forwarder-message-channel
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: graylog-forwarder-config-channel
+        documentIndex: 1
 
-  - it: sets the ingressClassName when provided
+  - it: renders only the message channel when the config channel is disabled
     set:
       ingress.enabled: true
       ingress.forwarder.enabled: true
-      ingress.forwarder.className: nginx
+      ingress.forwarder.configChannel.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: graylog-forwarder-message-channel
+
+  - it: renders only the config channel when the message channel is disabled
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.messageChannel.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: graylog-forwarder-config-channel
+
+  - it: does not render when graylog is disabled
+    set:
+      graylog.enabled: false
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: sets the ingressClassName per channel
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.messageChannel.className: alb
+      ingress.forwarder.configChannel.className: nginx
     asserts:
       - equal:
           path: spec.ingressClassName
+          value: alb
+        documentIndex: 0
+      - equal:
+          path: spec.ingressClassName
           value: nginx
+        documentIndex: 1
 
-  - it: applies forwarder annotations
+  - it: omits ingressClassName when not provided
     set:
       ingress.enabled: true
       ingress.forwarder.enabled: true
-      ingress.forwarder.annotations:
-        nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    asserts:
+      - notExists:
+          path: spec.ingressClassName
+        documentIndex: 0
+      - notExists:
+          path: spec.ingressClassName
+        documentIndex: 1
+
+  - it: applies annotations per channel
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.messageChannel.annotations:
+        alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 13301}]'
+      ingress.forwarder.configChannel.annotations:
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 13302}]'
     asserts:
       - equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/backend-protocol"]
-          value: HTTP
+          path: metadata.annotations["alb.ingress.kubernetes.io/backend-protocol-version"]
+          value: GRPC
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/listen-ports"]
+          value: '[{"HTTPS": 13301}]'
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/listen-ports"]
+          value: '[{"HTTPS": 13302}]'
+        documentIndex: 1
+      - notExists:
+          path: metadata.annotations["alb.ingress.kubernetes.io/backend-protocol-version"]
+        documentIndex: 1
 
-  - it: renders host rules with the forwarder service backend
+  - it: backs the message channel with the 13301 service port
     set:
       ingress.enabled: true
       ingress.forwarder.enabled: true
-      ingress.forwarder.hosts:
-        - host: fwd.example.com
+      ingress.forwarder.messageChannel.hosts:
+        - host: ingest.example.com
           paths:
             - path: /
               pathType: Prefix
     asserts:
       - equal:
           path: spec.rules[0].host
-          value: fwd.example.com
+          value: ingest.example.com
+        documentIndex: 0
       - equal:
           path: spec.rules[0].http.paths[0].path
           value: /
+        documentIndex: 0
       - equal:
           path: spec.rules[0].http.paths[0].pathType
           value: Prefix
+        documentIndex: 0
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
           value: graylog-svc
+        documentIndex: 0
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.name
           value: input-forwarder
+        documentIndex: 0
+
+  - it: backs the config channel with the 13302 service port
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.configChannel.hosts:
+        - host: conf.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: conf.example.com
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: graylog-svc
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: input-fwd-conf
+        documentIndex: 1
+
+  - it: omits the host key when host is empty
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+    asserts:
+      - notExists:
+          path: spec.rules[0].host
+        documentIndex: 0
+      - exists:
+          path: spec.rules[0].http.paths[0].backend.service
+        documentIndex: 0
+
+  - it: defaults path and pathType when omitted
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.messageChannel.hosts:
+        - host: ingest.example.com
+          paths:
+            - {}
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: ImplementationSpecific
+        documentIndex: 0
 
   - it: renders TLS block when configured
     set:
       ingress.enabled: true
       ingress.forwarder.enabled: true
-      ingress.forwarder.tls:
+      ingress.forwarder.messageChannel.tls:
         - secretName: fwd-tls
           hosts:
-            - fwd.example.com
+            - ingest.example.com
     asserts:
       - equal:
           path: spec.tls[0].secretName
           value: fwd-tls
+        documentIndex: 0
       - contains:
           path: spec.tls[0].hosts
-          content: fwd.example.com
+          content: ingest.example.com
+        documentIndex: 0
+      - notExists:
+          path: spec.tls
+        documentIndex: 1
+
+  - it: defaults the TLS secretName to the chart TLS secret
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.configChannel.tls:
+        - hosts:
+            - conf.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: graylog-tls
+        documentIndex: 1
+
+  - it: supports multiple hosts and paths on a channel
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.messageChannel.hosts:
+        - host: ingest-a.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+            - path: /alt
+              pathType: Prefix
+        - host: ingest-b.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[1].host
+          value: ingest-b.example.com
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: /alt
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.port.name
+          value: input-forwarder
+        documentIndex: 0
+
+  - it: honours the graylog service nameOverride
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      graylog.service.nameOverride: custom-svc
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: custom-svc
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: custom-svc
+        documentIndex: 1

--- a/charts/graylog/tests/init_graylog_test.yaml
+++ b/charts/graylog/tests/init_graylog_test.yaml
@@ -17,6 +17,47 @@ tests:
       - exists:
           path: data["init-script.sh"]
 
+  # Volume initialization must not be keyed off the journal (J-04). The lock file
+  # only exists while a journal does, so using it as the sentinel meant a disabled
+  # journal re-ran `cp -r` over the volume on every restart.
+  # Runtime behaviour of this logic — including the migration path — is covered by
+  # tests/scripts/init-graylog-behavior-test.sh.
+  - it: uses a dedicated marker file as the initialization sentinel
+    asserts:
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'if \[ -f /mnt/data/\.initialized \]; then'
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'touch /mnt/data/\.initialized'
+
+  - it: does not gate initialization on the journal lock file
+    asserts:
+      # The lock may still appear as a migration signal, but never as the
+      # first-choice sentinel that decides whether to copy. The leading \s is what
+      # keeps this from matching the legitimate `elif` — "elif" ends in "if", so an
+      # unanchored pattern passes vacuously.
+      - notMatchRegex:
+          path: data["init-script.sh"]
+          pattern: '\sif \[ -f /mnt/data/journal/\.lock \]'
+
+  - it: keeps the journal lock only as a migration signal for existing volumes
+    asserts:
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'elif \[ -f /mnt/data/journal/\.lock \]'
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'initialized by an earlier chart version'
+
+  - it: writes the marker only after a successful copy
+    asserts:
+      # A bare `cp -r ...` followed by an unconditional touch would mark a
+      # half-copied volume as initialized and never retry it.
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'if cp -r /usr/share/graylog/data/\* /mnt/data/; then'
+
   - it: always includes the MongoDB credentials check
     asserts:
       - matchRegex:

--- a/charts/graylog/tests/journal_config_test.yaml
+++ b/charts/graylog/tests/journal_config_test.yaml
@@ -1,0 +1,44 @@
+suite: message journal server.conf overrides
+templates:
+  - config/graylog.yaml
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  # The cap (J-06) has to actually reach the server, not just pass validation.
+  # Graylog's suffixes are binary: 5gb is 5 x 1024^3, which is what the exporter
+  # reports as gl_journal_size_limit.
+  - it: renders the journal cap
+    asserts:
+      - equal:
+          path: data.GRAYLOG_MESSAGE_JOURNAL_MAX_SIZE
+          value: "5gb"
+
+  - it: passes an overridden cap through
+    set:
+      graylog.config.messageJournal.maxSize: "12gb"
+      graylog.persistence.size: "20Gi"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_MESSAGE_JOURNAL_MAX_SIZE
+          value: "12gb"
+
+  - it: falls back to Graylog's own default when the cap is unset
+    set:
+      graylog.config.messageJournal.maxSize: ""
+    asserts:
+      - equal:
+          path: data.GRAYLOG_MESSAGE_JOURNAL_MAX_SIZE
+          value: "5gb"
+
+  - it: renders the rest of the journal settings alongside it
+    asserts:
+      - equal:
+          path: data.GRAYLOG_MESSAGE_JOURNAL_ENABLED
+          value: "true"
+      - equal:
+          path: data.GRAYLOG_MESSAGE_JOURNAL_MAX_AGE
+          value: "12h"
+      - equal:
+          path: data.GRAYLOG_MESSAGE_JOURNAL_SEGMENT_SIZE
+          value: "100mb"

--- a/charts/graylog/tests/journal_persistence_test.yaml
+++ b/charts/graylog/tests/journal_persistence_test.yaml
@@ -1,0 +1,214 @@
+suite: message journal durability and sizing guards (J-03, J-06)
+templates:
+  # The guards are validation helpers invoked from the secrets template, next to
+  # the BYO-OpenSearch and C-06 guards. Kept to this one template so the
+  # failedTemplate asserts cannot resolve against a template that renders fine —
+  # the rendered journal env is asserted in journal_config_test.yaml instead.
+  - config/secret/secrets.yaml
+release:
+  name: graylog
+  namespace: graylog
+set:
+  # Suite-wide so the generated-password path never interferes with these cases.
+  graylog.config.rootPassword: test-password
+tests:
+  # ---- the broken combination -------------------------------------------------
+  - it: rejects the default journal on a non-persistent data dir
+    set:
+      graylog.persistence.enabled: false
+    asserts:
+      # Anchored below the first line break: helm-unittest does not match the
+      # opening line of a multi-line fail message.
+      - failedTemplate:
+          errorPattern: "messageJournal.enabled is on while graylog.persistence.enabled=false"
+
+  - it: rejects it when the journal is enabled explicitly
+    set:
+      graylog.persistence.enabled: false
+      graylog.config.messageJournal.enabled: "true"
+    asserts:
+      - failedTemplate:
+          errorPattern: "messageJournal.enabled is on while graylog.persistence.enabled=false"
+
+  - it: explains the emptyDir consequence rather than just naming the values
+    set:
+      graylog.persistence.enabled: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "backed by an emptyDir volume"
+      - failedTemplate:
+          errorPattern: "lost on any pod restart, eviction, or upgrade"
+
+  - it: offers all three remedies
+    set:
+      graylog.persistence.enabled: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "Option A: Durable journal on chart-managed storage"
+      - failedTemplate:
+          errorPattern: "Option B: Durable journal on a pre-provisioned claim"
+      - failedTemplate:
+          errorPattern: "Option C: No journal at all"
+      # Option C is unusable without --set-string, since the schema types this
+      # value as a string and rejects a bare boolean. Saying so in the error is
+      # the difference between a fix and a second failed attempt.
+      - failedTemplate:
+          errorPattern: "Option C needs --set-string"
+
+  # ---- configurations that must keep working ---------------------------------
+  - it: allows the default durable journal
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: allows a journal with persistence explicitly enabled
+    set:
+      graylog.persistence.enabled: true
+      graylog.config.messageJournal.enabled: "true"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: allows no journal on a non-persistent data dir
+    set:
+      graylog.persistence.enabled: false
+      graylog.config.messageJournal.enabled: "false"
+    asserts:
+      - notFailedTemplate: {}
+
+  # persistence.enabled=false + existingClaim still mounts a real PVC, so the
+  # journal is durable. The guard must not fire on a legitimate BYO-claim setup.
+  - it: allows persistence.enabled=false when an existingClaim supplies the volume
+    set:
+      graylog.persistence.enabled: false
+      graylog.persistence.existingClaim: my-graylog-data
+    asserts:
+      - notFailedTemplate: {}
+
+  # No StatefulSet is rendered, so there is no pod and no journal to lose.
+  - it: does not fire when the Graylog server is disabled entirely
+    set:
+      graylog.enabled: false
+      graylog.persistence.enabled: false
+    asserts:
+      - notFailedTemplate: {}
+
+  # ---- the string-typed value ------------------------------------------------
+  # messageJournal.enabled is schema-typed as a string, so a truthiness test on
+  # it would be true even for "false" and the guard would reject the very config
+  # Option C recommends. These pin the comparison, not the truthiness.
+  - it: treats a mixed-case false as disabled
+    set:
+      graylog.persistence.enabled: false
+      graylog.config.messageJournal.enabled: "False"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: treats an unset journal value as enabled, per the config template default
+    set:
+      graylog.persistence.enabled: false
+      graylog.config.messageJournal.enabled: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "messageJournal.enabled is on while graylog.persistence.enabled=false"
+
+  # ---- journal cap vs volume size (J-06) -------------------------------------
+  # A cap the data volume cannot hold is the mistake: the journal shares the volume
+  # with the node-id, truststore, content packs and GeoIP databases. A full journal
+  # throttles inputs by design; a full data volume takes the node down.
+  - it: accepts the default cap on the default volume
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: rejects a cap that claims more than 90% of the volume
+    set:
+      graylog.config.messageJournal.maxSize: "5gb"
+      graylog.persistence.size: "5Gi"
+    asserts:
+      - failedTemplate:
+          errorPattern: "claims more than 90% of graylog.persistence.size"
+
+  - it: rejects a cap larger than the volume outright
+    set:
+      graylog.config.messageJournal.maxSize: "16gb"
+      graylog.persistence.size: "8Gi"
+    asserts:
+      - failedTemplate:
+          errorPattern: "claims more than 90%"
+
+  - it: offers both a smaller cap and a bigger volume, with real numbers
+    set:
+      graylog.config.messageJournal.maxSize: "5gb"
+      graylog.persistence.size: "5Gi"
+    asserts:
+      # 90% of 5Gi in MiB, and 5gb/0.9 rounded up in MiB. Both round-trip through
+      # the guard — verified by the two acceptance cases below.
+      - failedTemplate:
+          errorPattern: "maxSize=4608mb"
+      - failedTemplate:
+          errorPattern: "size=5689Mi"
+      - failedTemplate:
+          errorPattern: "shrinking one is not supported"
+
+  - it: accepts the smaller cap it suggested
+    set:
+      graylog.config.messageJournal.maxSize: "4608mb"
+      graylog.persistence.size: "5Gi"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: accepts the bigger volume it suggested
+    set:
+      graylog.config.messageJournal.maxSize: "5gb"
+      graylog.persistence.size: "5689Mi"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: accepts a cap comfortably inside the volume
+    set:
+      graylog.config.messageJournal.maxSize: "2gb"
+      graylog.persistence.size: "8Gi"
+    asserts:
+      - notFailedTemplate: {}
+
+  # Kubernetes G is 10^9 while Graylog's gb is 2^30, so the suffixes must not be
+  # treated as equivalent. 8G is 8e9, which is less than 8Gi (8.59e9).
+  - it: distinguishes decimal from binary suffixes
+    set:
+      graylog.config.messageJournal.maxSize: "7gb"      # 7 x 2^30 = 7.52e9
+      graylog.persistence.size: "8G"                    # 8 x 10^9 = 8.0e9  -> 94%
+    asserts:
+      - failedTemplate:
+          errorPattern: "claims more than 90%"
+
+  # An existingClaim's capacity is not knowable at render time.
+  - it: skips the size check when an existingClaim supplies the volume
+    set:
+      graylog.config.messageJournal.maxSize: "500gb"
+      graylog.persistence.existingClaim: my-graylog-data
+    asserts:
+      - notFailedTemplate: {}
+
+  # A size the parser cannot read is not grounds for refusing to render. Fractional
+  # quantities are the known gap.
+  - it: skips the size check on an unparseable cap
+    set:
+      graylog.config.messageJournal.maxSize: "1.5gb"
+      graylog.persistence.size: "1Gi"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: skips the size check on an unparseable volume size
+    set:
+      graylog.config.messageJournal.maxSize: "5gb"
+      graylog.persistence.size: "1.5Gi"
+    asserts:
+      - notFailedTemplate: {}
+
+  # No journal, no cap to check.
+  - it: skips the size check when the journal is disabled
+    set:
+      graylog.config.messageJournal.enabled: "false"
+      graylog.config.messageJournal.maxSize: "500gb"
+      graylog.persistence.size: "1Gi"
+    asserts:
+      - notFailedTemplate: {}
+

--- a/charts/graylog/tests/prestop_drain_test.yaml
+++ b/charts/graylog/tests/prestop_drain_test.yaml
@@ -1,0 +1,146 @@
+suite: graylog preStop journal drain
+templates:
+  # The StatefulSet's pod-spec annotations reference two checksum helpers that
+  # `include` other templates by path. helm-unittest's `templates:` filter must
+  # list those dependencies so the includes resolve.
+  - workload/statefulsets/graylog.yaml
+  - config/graylog.yaml         # checksum/config dependency
+  - config/secret/secrets.yaml  # checksum/secret dependency
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  - it: sets terminationGracePeriodSeconds on the pod spec, not the container
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 300
+        template: workload/statefulsets/graylog.yaml
+      # Regression guard: this used to render as a misspelled container-level
+      # "terminationGracePeriodSecond", which the API server silently dropped.
+      - notExists:
+          path: spec.template.spec.containers[0].terminationGracePeriodSecond
+        template: workload/statefulsets/graylog.yaml
+      - notExists:
+          path: spec.template.spec.containers[0].terminationGracePeriodSeconds
+        template: workload/statefulsets/graylog.yaml
+
+  - it: honours an overridden terminationGracePeriodSeconds
+    set:
+      graylog.terminationGracePeriodSeconds: 600
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 600
+        template: workload/statefulsets/graylog.yaml
+
+  - it: omits the lifecycle block when the drain is disabled (the default)
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+        template: workload/statefulsets/graylog.yaml
+
+  - it: renders a preStop exec hook when the drain is enabled
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[0]
+          value: /bin/sh
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[1]
+          value: -c
+        template: workload/statefulsets/graylog.yaml
+
+  - it: reads the unauthenticated journal gauge from the metrics port
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.service.ports.metrics: 9999
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'URL="http://127\.0\.0\.1:9999/metrics"'
+        template: workload/statefulsets/graylog.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "gl_journal_entries_uncommitted"
+        template: workload/statefulsets/graylog.yaml
+
+  - it: derives the drain budget as grace minus settle minus reserve
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.terminationGracePeriodSeconds: 120
+      graylog.lifecycle.preStopDrain.endpointPropagationDelaySeconds: 15
+      graylog.lifecycle.preStopDrain.shutdownReserveSeconds: 45
+    asserts:
+      # 120 - 15 - 45 = 60. The budget must never be the full grace period, or
+      # the hook gets SIGKILLed before Graylog can flush its in-memory buffers.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "(?m)^BUDGET=60$"
+        template: workload/statefulsets/graylog.yaml
+
+  - it: passes the tuning values through to the script
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.lifecycle.preStopDrain.pollIntervalSeconds: 7
+      graylog.lifecycle.preStopDrain.endpointPropagationDelaySeconds: 3
+      graylog.lifecycle.preStopDrain.stallPolls: 4
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "(?m)^POLL=7$"
+        template: workload/statefulsets/graylog.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "(?m)^SETTLE=3$"
+        template: workload/statefulsets/graylog.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "(?m)^STALL_LIMIT=4$"
+        template: workload/statefulsets/graylog.yaml
+
+  - it: bounds the drain by wall clock rather than by poll count
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      # Counting poll ticks would let a slow metrics endpoint overrun the budget
+      # by curl-timeout per iteration and defeat the shutdown reserve.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'deadline=\$\(\(started \+ BUDGET\)\)'
+        template: workload/statefulsets/graylog.yaml
+
+  - it: fails when the drain is enabled without the metrics exporter
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.service.metrics.enabled: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "The drain reads journal depth from the Prometheus exporter"
+
+  - it: fails when the reserve leaves no room to drain
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.terminationGracePeriodSeconds: 30
+      graylog.lifecycle.preStopDrain.endpointPropagationDelaySeconds: 15
+      graylog.lifecycle.preStopDrain.shutdownReserveSeconds: 45
+    asserts:
+      - failedTemplate:
+          errorPattern: "The drain budget must be positive"
+
+  - it: does not validate the drain budget when the drain is disabled
+    set:
+      graylog.terminationGracePeriodSeconds: 30
+      graylog.service.metrics.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+        template: workload/statefulsets/graylog.yaml
+

--- a/charts/graylog/tests/prestop_drain_test.yaml
+++ b/charts/graylog/tests/prestop_drain_test.yaml
@@ -61,9 +61,13 @@ tests:
       graylog.lifecycle.preStopDrain.enabled: true
       graylog.service.ports.metrics: 9999
     asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
-          pattern: 'URL="http://127\.0\.0\.1:9999/metrics"'
+      # The endpoint is supplied as env, so the script itself stays free of
+      # template syntax; only the gauge name is baked in.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GL_DRAIN_METRICS_URL
+            value: "http://127.0.0.1:9999/metrics"
         template: workload/statefulsets/graylog.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
@@ -79,29 +83,31 @@ tests:
     asserts:
       # 120 - 15 - 45 = 60. The budget must never be the full grace period, or
       # the hook gets SIGKILLed before Graylog can flush its in-memory buffers.
-      - matchRegex:
-          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
-          pattern: "(?m)^BUDGET=60$"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GL_DRAIN_BUDGET_SECONDS
+            value: "60"
         template: workload/statefulsets/graylog.yaml
 
-  - it: passes the tuning values through to the script
+  - it: passes the tuning values through as environment
     set:
       graylog.lifecycle.preStopDrain.enabled: true
       graylog.lifecycle.preStopDrain.pollIntervalSeconds: 7
       graylog.lifecycle.preStopDrain.endpointPropagationDelaySeconds: 3
       graylog.lifecycle.preStopDrain.stallPolls: 4
     asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
-          pattern: "(?m)^POLL=7$"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: { name: GL_DRAIN_POLL_SECONDS, value: "7" }
         template: workload/statefulsets/graylog.yaml
-      - matchRegex:
-          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
-          pattern: "(?m)^SETTLE=3$"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: { name: GL_DRAIN_SETTLE_SECONDS, value: "3" }
         template: workload/statefulsets/graylog.yaml
-      - matchRegex:
-          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
-          pattern: "(?m)^STALL_LIMIT=4$"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: { name: GL_DRAIN_STALL_POLLS, value: "4" }
         template: workload/statefulsets/graylog.yaml
 
   - it: bounds the drain by wall clock rather than by poll count
@@ -112,7 +118,7 @@ tests:
       # by curl-timeout per iteration and defeat the shutdown reserve.
       - matchRegex:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
-          pattern: 'deadline=\$\(\(started \+ BUDGET\)\)'
+          pattern: 'while \[ "\$\(date \+%s\)" -lt "\$\{deadline\}" \]'
         template: workload/statefulsets/graylog.yaml
 
   - it: fails when the drain is enabled without the metrics exporter
@@ -166,3 +172,488 @@ tests:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
           pattern: "still ingesting \\$\\{rate\\} msg/s"
         template: workload/statefulsets/graylog.yaml
+
+  - it: logs its configuration before doing anything
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      # An operator reading the container log should be able to see what the hook
+      # was configured with, without cross-referencing values.yaml.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'config: budget=\$\{BUDGET\}s retries=\$\{METRICS_RETRIES\} poll=\$\{POLL\}s settle=\$\{SETTLE\}s'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'config: metrics=\$\{URL\} depthGauge=\$\{DEPTH_GAUGE\}'
+      # The budget is derived, so show the arithmetic rather than just the result.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'terminationGracePeriodSeconds\(\$\{GRACE\}s\)'
+
+  - it: emits INFO, WARN, ERROR and CRIT levels
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'info\(\)  \{ log "INFO " '
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'warn\(\)  \{ log "WARN " '
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'error\(\) \{ log "ERROR" '
+      # CRIT is reserved for the feasibility abort: the one verdict that means
+      # data loss is already committed and only manual action can prevent it.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'crit\(\)  \{ log "CRIT " '
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "date -u '\\+%Y-%m-%dT%H:%M:%SZ'"
+
+  # Checked before the settle wait, so a broken exporter is reported immediately
+  # rather than after burning the budget.
+  - it: preflights the metrics endpoint and reports the starting backlog
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "metrics endpoint reachable"
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'journal at start: \$\{start_depth\} messages on disk awaiting processing'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'did not answer after \$\{METRICS_RETRIES\} attempts, or \$\{DEPTH_GAUGE\} is absent'
+
+  # Every exit path must state whether the journal actually emptied before the
+  # cutoff -- that is the whole point of the hook.
+  - it: reports a verdict on every exit path
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "RESULT: SUCCESS - journal fully drained"
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'RESULT: INCOMPLETE - \$\{BUDGET\}s timeout cutoff reached'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "RESULT: INCOMPLETE - \\$\\{depth\\} messages still queued"
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "RESULT: UNKNOWN - "
+      # The operationally important consequence of an incomplete drain.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "will be stranded in its PVC"
+
+  - it: logs progress on a throttle separate from the poll interval
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.lifecycle.preStopDrain.statusIntervalSeconds: 25
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: { name: GL_DRAIN_STATUS_INTERVAL_SECONDS, value: "25" }
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'elapsed - last_status \)\) -ge "\$\{STATUS_EVERY\}"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'draining: \$\{n\} messages queued \(best \$\{best\}\)'
+
+  - it: guards the PID 1 log redirect instead of relying on 2>/dev/null
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '\[ -w /proc/1/fd/1 \]'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '>> /proc/1/fd/1'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'echo "\$\{line\}" > /proc/1/fd/1'
+
+  # The point of the env indirection: the script file is plain shell, so an editor
+  # or shellcheck can read it and it can be run by hand inside a pod.
+  - it: renders a script with no template syntax in it
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '\{\{'
+      # Missing configuration must fail loudly rather than default to empty and
+      # produce nonsense arithmetic further down.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'GL_DRAIN_BUDGET_SECONDS:\?GL_DRAIN_BUDGET_SECONDS is not set'
+
+  - it: adds no drain environment when the drain is disabled
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].env[*].name
+          pattern: "^GL_DRAIN_"
+
+  # The verdict says whether it finished; this says how far it got. Baseline is the
+  # preflight sample, i.e. what was on disk when termination began.
+  - it: reports what percentage of the starting backlog was drained
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'drained \$\(\( \(base - depth\) \* 100 / base \)\)% of the starting backlog'
+      # Ingest can outrun processing, so the backlog may be larger at the end than
+      # at the start. A negative percentage would be noise; report 0% and the two
+      # absolute numbers instead.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "drained 0% of the starting backlog - it grew from"
+      # Dividing by a zero baseline must not happen.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "drained n/a - the journal was already empty"
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'base="\$\{start_depth:-0\}"'
+
+  # The poll loop's clock starts AFTER the settle wait, so quoting it alone reports
+  # "0s" for a journal that actually took settle+poll to clear. Report the total
+  # and break it down, and say plainly when the settle wait did the work.
+  - it: reports total elapsed, not just the poll loop's clock
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'total=\$\(\( now - hook_started \)\)'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'spent="\$\{total\}s total \(\$\(\( settle_started - hook_started \)\)s preflight'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "it cleared during the \\$\\{SETTLE\\}s settle wait"
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'depth held at 0 across \$\{zero_streak\} consecutive polls'
+      # hook_started must be stamped before any work, or the total is wrong.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'hook_started=\$\(date \+%s\)\ninfo "journal drain starting'
+
+  # Reporting the configured SETTLE unconditionally produced a self-contradicting
+  # line on the preflight path: "0s total (15s settle + 0s draining)" for an exit
+  # that happens before the wait even starts. Each phase must be measured.
+  - it: only reports phases that actually ran
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'spent="\$\{total\}s total, before the settle wait began"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'spent="\$\{total\}s total, during the settle wait"'
+      # Measured from timestamps, not from the configured value.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '\$\(\( loop_started - settle_started \)\)s settle'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '\$\{SETTLE\}s settle \+'
+      # A failure before the drain starts is not the same as one that abandons it.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "RESULT: UNKNOWN - no drain attempted"
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "RESULT: UNKNOWN - drain abandoned"
+
+  # A single zero reading is not proof of a drain: under live ingest the depth
+  # oscillates and momentarily touches zero while messages are still arriving.
+  # Exiting on that declares success, yields to SIGTERM, and lets whatever arrives
+  # next be journaled and then orphaned.
+  - it: requires the depth to hold at zero before declaring success
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.lifecycle.preStopDrain.confirmPolls: 4
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: { name: GL_DRAIN_CONFIRM_POLLS, value: "4" }
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'zero_streak" \] -ge "\$\{CONFIRM_POLLS\}"|zero_streak\}" -ge "\$\{CONFIRM_POLLS\}"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "depth rose back to \\$\\{n\\} after \\$\\{zero_streak\\} zero reading"
+      # Leaving best at 0 after a zero would make every later reading "no new low",
+      # so the stall counter would climb and report INCOMPLETE mid-drain.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'zero_streak=0\n    # Restart the progress baseline'
+
+  - it: retries the metrics probe before giving up
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.lifecycle.preStopDrain.metricsRetries: 9
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: { name: GL_DRAIN_METRICS_RETRIES, value: "9" }
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'attempt\}" -ge "\$\{METRICS_RETRIES\}"'
+      # sample_retry sets a global rather than echoing: warn() inside a $( ) would
+      # otherwise be captured into the caller's value instead of reaching the log.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "if SAMPLE=\\$\\(sample\\); then"
+
+  # Preflight retries and an overrunning settle both consume wall clock before the
+  # loop starts. Deriving the deadline from BUDGET alone would push past the grace
+  # period and get the container SIGKILLed with buffers unflushed.
+  - it: anchors the deadline so the shutdown reserve always survives
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'deadline=\$\(\( hook_started \+ GRACE - RESERVE \)\)'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'deadline=\$\(\(loop_started \+ BUDGET\)\)'
+
+  # The safety net for messages that are left behind anyway: the claim must survive.
+  - it: pins the PVC retention policy to Retain
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Retain
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Retain
+
+  - it: refuses whenScaled Delete, which would destroy a scaled-in journal
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.persistence.retentionPolicy.whenScaled: Delete
+    asserts:
+      - failedTemplate:
+          errorPattern: "Scaling in removes the highest ordinal"
+
+  - it: allows whenDeleted Delete, which only applies on uninstall
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.persistence.retentionPolicy.whenDeleted: Delete
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Retain
+
+  # RESERVE is the guaranteed floor, not what is actually left. Quoting the floor
+  # understated it badly: 45s reported on a drain that finished 20s into a 300s
+  # grace period, where 280s in fact remained.
+  - it: reports the grace period actually remaining, not the configured floor
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'left=\$\(\( GRACE - total \)\)'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'handing over to SIGTERM with ~\$\{left\}s of the \$\{GRACE\}s grace period left'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'Graylog has ~\$\{RESERVE\}s reserved'
+      # The three phases must sum to the total, or the line invites "where did the
+      # rest go?" - metrics retries can put real time into preflight.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 's preflight \+ \$\(\( loop_started - settle_started \)\)s settle \+'
+      # A second or two on the preflight scrape is not worth a warning.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'remaining_budget\}" -lt \$\(\( BUDGET - 10 \)\)'
+
+  # ---- feasibility gate -------------------------------------------------
+  # The stall detector only notices a journal that has stopped falling. It cannot
+  # notice one falling far too slowly to matter, because every new low resets the
+  # counter — so against a deep backlog the hook held termination for its whole
+  # budget, cleared ~2% and stranded the rest. Observed on a flooded cluster:
+  # 7.24M messages at ~1k msg/s needed ~2h against a 240s budget.
+  - it: projects whether the drain can finish, and aborts early when it cannot
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'FEASIBILITY: drain cannot finish in the time available'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'finish infeasible "\$\{n\}"'
+      # A depth that is flat or growing can never finish, and must be reported as
+      # such rather than as a very large ETA.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'FEASIBILITY: journal is NOT draining'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'time to clear:   never at this rate'
+
+  - it: projects the ETA by multiplication so a floored rate cannot divide by zero
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      # depth / (cleared/observed) would be 0 for any drain slower than 1 msg/s,
+      # and `$(( n / 0 ))` aborts the shell mid-hook. The algebraically equal
+      # n * observed / cleared has no such hole and keeps sub-1-msg/s precision.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'eta=\$\(\( n \* observed / cleared \)\)'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'eta=\$\(\( n / drain_rate \)\)'
+      # The observation window is guarded too: a fast loop can measure it as 0s.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '\[ "\$\{observed\}" -lt 1 \] && observed=1'
+
+  - it: reports disk size and processing time in the abort verdict
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      # An operator has seconds to act on this, so the verdict must carry the
+      # numbers that decide what to do next: how much is on disk, how fast it is
+      # actually moving, how long it would take, and how far short that falls.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'journal on disk: \$\(fmt_bytes "\$\{S_SIZE\}"\) of \$\(fmt_bytes "\$\{S_LIMIT\}"\) cap'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'drain rate:      \$\{drain_rate\} msg/s measured over \$\{observed\}s'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'time to clear:   ~\$\(fmt_duration "\$\{eta\}"\) at that rate'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'short by:        ~\$\(fmt_duration \$\(\( eta - budget_left \)\)\)'
+      # Bytes and seconds are formatted for humans; a raw 5390146435 or 7452 does
+      # not communicate urgency. No floating point in POSIX sh, hence the
+      # scale-then-divide arithmetic.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "printf '%d\\.%01dGiB'"
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "printf '%dh%dm'"
+
+  - it: warns when the journal is at its cap and already discarding messages
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      # A journal at its size cap evicts the oldest segments to make room, so
+      # messages are being lost before the hook ever runs. Reporting a drain
+      # percentage without saying that would be misleading.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'the journal is AT its cap'
+      # Dividing by an unpublished limit gauge would abort the hook.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'if \[ "\$\{S_LIMIT\}" -gt 0 \]'
+
+  - it: anchors the size gauge so it cannot match the limit gauge
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      # gl_journal_size is a strict prefix of gl_journal_size_limit, so an
+      # unanchored match would read the cap as the current size. Requiring "{"
+      # or a space immediately after the name is what separates them — the same
+      # guard that keeps the data-lake and kafka journal gauges out.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'SIZE_GAUGE="gl_journal_size"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'LIMIT_GAUGE="gl_journal_size_limit"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '\$1 ~ "\^"s"\[\{ \]" \|\| index\(\$1, s"\{"\) == 1'
+
+  - it: passes the feasibility warmup through as environment
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.lifecycle.preStopDrain.feasibilityWarmupPolls: 8
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: { name: GL_DRAIN_FEASIBILITY_WARMUP_POLLS, value: "8" }
+
+  - it: allows the projection to be disabled with zero
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.lifecycle.preStopDrain.feasibilityWarmupPolls: 0
+    asserts:
+      # `| default` would coerce an intentional 0 back to the chart default and
+      # silently re-enable the gate, so the template uses `int` alone.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: { name: GL_DRAIN_FEASIBILITY_WARMUP_POLLS, value: "0" }
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'projection disabled \(feasibilityWarmupPolls=0\)'
+
+  - it: carries no leftover debug hold on the success path
+    template: workload/statefulsets/graylog.yaml
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      # Regression guard: a `sleep 60` debug hold shipped on the drained branch
+      # once. It only fires on healthy fast drains, so a flooded test cluster
+      # never reaches it — exactly the shape of thing that survives manual
+      # testing and must be caught here instead.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'Sleeping 60'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'remove before merging'
+      # Only the settle wait and the poll interval may sleep; nothing constant.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: 'sleep [0-9]'

--- a/charts/graylog/tests/prestop_drain_test.yaml
+++ b/charts/graylog/tests/prestop_drain_test.yaml
@@ -144,3 +144,25 @@ tests:
           path: spec.template.spec.containers[0].lifecycle
         template: workload/statefulsets/graylog.yaml
 
+
+  - it: measures progress against the best depth seen, not the previous sample
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+    asserts:
+      # Live gauges oscillate under ingest (observed 31->82->36->126->231->9->3...),
+      # so an equality test against the previous sample never fires and the hook
+      # burns its entire budget. Progress must mean "a new low".
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '\[ "\$\{n\}" -lt "\$\{best\}" \]'
+        template: workload/statefulsets/graylog.yaml
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: '\[ "\$\{n\}" = "\$\{last\}" \]'
+        template: workload/statefulsets/graylog.yaml
+      # The give-up message must report the ingest rate, since that is the actual
+      # reason a drain cannot complete.
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: "still ingesting \\$\\{rate\\} msg/s"
+        template: workload/statefulsets/graylog.yaml

--- a/charts/graylog/tests/scripts/init-graylog-behavior-test.sh
+++ b/charts/graylog/tests/scripts/init-graylog-behavior-test.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+# Behavioural tests for the data-volume initialization logic in
+# templates/config/init-graylog.yaml (J-04).
+#
+# The helm-unittest suite (tests/init_graylog_test.yaml) asserts on the *rendered*
+# script text: that the sentinel is the marker, that the lock survives only as an
+# elif, that the copy is guarded. None of that can tell you whether an existing
+# volume gets clobbered on the first upgrade — which is the actual risk in this
+# change, because volumes initialized by earlier chart versions carry the journal
+# lock and no marker.
+#
+# So this renders the real script and runs it against fixture volumes.
+#
+# Run it:
+#   sh charts/graylog/tests/scripts/init-graylog-behavior-test.sh
+#   sh charts/graylog/tests/scripts/init-graylog-behavior-test.sh -v   # show output
+#
+# Two substitutions, and only two
+# ------------------------------
+# The script hardcodes /mnt/data (the volume) and /usr/share/graylog/data (the
+# image defaults). Both are rewritten to temp directories so the script can run
+# unprivileged. Everything else — the branch structure, the copy, the marker, the
+# exit code — is the rendered article.
+#
+# Requires helm on PATH. Renders with default values, which yields the init
+# sequence plus the MongoDB credentials check; GRAYLOG_MONGODB_URI is exported so
+# that final check passes and does not mask the exit code under test.
+
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+CHART_DIR=$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)
+
+VERBOSE=0
+[ "${1:-}" = "-v" ] && VERBOSE=1
+
+command -v helm >/dev/null 2>&1 || { echo "FATAL: helm not on PATH" >&2; exit 1; }
+
+WORK=$(mktemp -d 2>/dev/null) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "${WORK}"' EXIT
+trap 'rm -rf "${WORK}"; exit 130' INT TERM
+
+# ---- render the real init script ---------------------------------------------
+# Pulled out of the ConfigMap by the same key the pod mounts. sed rather than a
+# YAML parser to keep this dependency-free; the data key is a literal block scalar
+# indented by 4, so stripping that indent reproduces the file verbatim.
+RENDERED="${WORK}/init-script.rendered.sh"
+helm template graylog "${CHART_DIR}" \
+  --set graylog.config.rootPassword=behavior-test \
+  > "${WORK}/all.yaml" 2>"${WORK}/helm.err" || {
+    echo "FATAL: helm template failed" >&2; cat "${WORK}/helm.err" >&2; exit 1; }
+
+awk '
+  /^  init-script\.sh: \|$/ { grab=1; next }
+  grab && /^    / { sub(/^    /, ""); print; next }
+  grab && /^[[:space:]]*$/ { print ""; next }
+  grab { exit }
+' "${WORK}/all.yaml" > "${RENDERED}"
+
+if [ ! -s "${RENDERED}" ]; then
+  echo "FATAL: could not extract init-script.sh from the rendered chart" >&2
+  exit 1
+fi
+grep -q '\.initialized' "${RENDERED}" || {
+  echo "FATAL: extracted script has no .initialized logic - extraction is wrong" >&2
+  sed -n 1,15p "${RENDERED}" >&2
+  exit 1
+}
+
+# ---- fixtures ----------------------------------------------------------------
+# The image's default data dir. Real Graylog images ship config/contentpacks/etc;
+# the exact contents don't matter, only that the copy is observable.
+IMAGE="${WORK}/image-data"
+mkdir -p "${IMAGE}/config" "${IMAGE}/contentpacks"
+echo "image-default" > "${IMAGE}/config/graylog.conf"
+echo "image-default" > "${IMAGE}/contentpacks/pack.json"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=""
+
+ok()  { PASS=$(( PASS + 1 )); printf '  ok   %s\n' "$1"; }
+bad() {
+  FAIL=$(( FAIL + 1 ))
+  FAILED_NAMES="${FAILED_NAMES}
+  - ${NAME}: $1"
+  printf '  FAIL %s\n' "$1"
+  [ "${VERBOSE}" = "1" ] && sed 's/^/       | /' "${OUT}"
+}
+
+SCENARIO_N=0
+# begin <name> — fresh empty volume for the scenario.
+begin() {
+  SCENARIO_N=$(( SCENARIO_N + 1 ))
+  NAME="$1"
+  VOL="${WORK}/vol${SCENARIO_N}"
+  OUT="${WORK}/vol${SCENARIO_N}.out"
+  mkdir -p "${VOL}"
+  printf '\n%s\n' "${SCENARIO_N}. ${NAME}"
+}
+
+# run — executes the rendered script against this scenario's volume.
+run() {
+  sed -e "s#/mnt/data#${VOL}#g" -e "s#/usr/share/graylog/data#${IMAGE}#g" \
+    "${RENDERED}" > "${WORK}/run.sh"
+  GRAYLOG_MONGODB_URI="mongodb://user:pass@host:27017/graylog" \
+    sh "${WORK}/run.sh" > "${OUT}" 2>&1
+  RC=$?
+}
+
+expect()    { if grep -qF -- "$1" "${OUT}"; then ok "says: $1"; else bad "missing: $1"; fi }
+refute()    { if grep -qF -- "$1" "${OUT}"; then bad "must not say: $1"; else ok "silent on: $1"; fi }
+expect_rc() { if [ "${RC}" = "$1" ]; then ok "exit ${RC}"; else bad "exit ${RC}, wanted $1"; fi }
+exists()    { if [ -e "${VOL}/$1" ]; then ok "volume has $1"; else bad "volume missing $1"; fi }
+absent()    { if [ -e "${VOL}/$1" ]; then bad "volume should not have $1"; else ok "volume lacks $1"; fi }
+# content <relpath> <expected> — the file's contents, for detecting a clobber.
+content() {
+  actual=$(cat "${VOL}/$1" 2>/dev/null)
+  if [ "${actual}" = "$2" ]; then ok "$1 == '$2'"; else bad "$1 == '${actual}', wanted '$2'"; fi
+}
+
+echo "init-graylog data-volume initialization: behavioural tests"
+echo "rendered from: ${CHART_DIR}"
+
+# =============================================================================
+begin "a fresh volume is initialized and marked"
+run
+expect_rc 0
+expect "Initializing data volume."
+exists "config/graylog.conf"
+exists ".initialized"
+content "config/graylog.conf" "image-default"
+
+# =============================================================================
+begin "an already-marked volume is left alone"
+touch "${VOL}/.initialized"
+mkdir -p "${VOL}/config"
+echo "live-data" > "${VOL}/config/graylog.conf"
+run
+expect_rc 0
+expect "Data volume already initialized, skipping copy."
+refute "Initializing data volume."
+# The decisive assertion: local edits survive.
+content "config/graylog.conf" "live-data"
+
+# =============================================================================
+# The upgrade path. Volumes initialized by earlier chart versions carry the
+# journal lock and no marker. Re-running the copy here would overwrite a live
+# volume with image defaults - the exact clobbering J-04 exists to prevent,
+# triggered by the fix for it.
+begin "a legacy volume with the journal lock is adopted, not clobbered"
+mkdir -p "${VOL}/journal" "${VOL}/config"
+touch "${VOL}/journal/.lock"
+echo "0000000000000000042.log" > "${VOL}/journal/segment.log"
+echo "live-data" > "${VOL}/config/graylog.conf"
+echo "node-id-abc123" > "${VOL}/node-id"
+run
+expect_rc 0
+expect "initialized by an earlier chart version"
+refute "Initializing data volume."
+content "config/graylog.conf" "live-data"
+content "node-id" "node-id-abc123"
+exists "journal/segment.log"
+# ...and it is stamped, so the adoption happens exactly once.
+exists ".initialized"
+
+# =============================================================================
+begin "an adopted legacy volume is skipped on the next restart"
+mkdir -p "${VOL}/journal" "${VOL}/config"
+touch "${VOL}/journal/.lock"
+echo "live-data" > "${VOL}/config/graylog.conf"
+run                                  # first boot after upgrade: adopts
+expect "initialized by an earlier chart version"
+run                                  # second boot: marker present
+expect "Data volume already initialized, skipping copy."
+refute "initialized by an earlier chart version"
+content "config/graylog.conf" "live-data"
+
+# =============================================================================
+# The old sentinel's actual bug: no journal means no lock, so every restart
+# re-ran the copy. Under the new logic such a volume is copied once more and then
+# marked, so it self-heals instead of recurring forever.
+begin "a legacy volume with no journal self-heals after one copy"
+mkdir -p "${VOL}/config"
+echo "live-data" > "${VOL}/config/graylog.conf"
+run                                  # no marker, no lock -> copies (as before)
+expect "Initializing data volume."
+exists ".initialized"
+run                                  # ...but only once
+expect "Data volume already initialized, skipping copy."
+refute "Initializing data volume."
+
+# =============================================================================
+# The regression J-04 is really about: initialization must not track journal
+# state. A marked volume with the journal removed entirely must still be skipped.
+begin "removing the journal does not re-trigger initialization"
+touch "${VOL}/.initialized"
+mkdir -p "${VOL}/config"
+echo "live-data" > "${VOL}/config/graylog.conf"
+run
+expect_rc 0
+expect "Data volume already initialized, skipping copy."
+content "config/graylog.conf" "live-data"
+absent "journal/.lock"
+
+# =============================================================================
+begin "deleting the marker forces a deliberate re-initialization"
+touch "${VOL}/.initialized"
+run
+expect "already initialized"
+rm -f "${VOL}/.initialized"
+run
+expect "Initializing data volume."
+exists ".initialized"
+
+# =============================================================================
+# A partial copy must not be stamped as done, or the volume is permanently broken
+# and never retried. Simulated by making the volume unwritable so cp fails.
+begin "a failed copy is not marked initialized"
+if [ "$(id -u)" = "0" ]; then
+  printf '  skip root bypasses the mode bits this scenario relies on\n'
+else
+chmod 500 "${VOL}"
+run
+chmod 700 "${VOL}"
+if [ "${RC}" = "0" ]; then
+  bad "exit 0 after a failed copy, wanted non-zero"
+else
+  ok "exit ${RC} (non-zero on copy failure)"
+fi
+expect "failed to copy the default data directory"
+absent ".initialized"
+fi
+
+# =============================================================================
+printf '\n---\n'
+printf '%d passed, %d failed\n' "${PASS}" "${FAIL}"
+if [ "${FAIL}" != "0" ]; then
+  printf 'failures:%s\n' "${FAILED_NAMES}"
+  [ "${VERBOSE}" = "0" ] && printf '\nre-run with -v to see the script output for each failure\n'
+  exit 1
+fi
+exit 0

--- a/charts/graylog/tests/scripts/prestop-drain-behavior-test.sh
+++ b/charts/graylog/tests/scripts/prestop-drain-behavior-test.sh
@@ -93,10 +93,13 @@ begin() {
   mkdir -p "${FX}"
   SAMPLE_N=0
   SHAPE=labeled
-  # Zero poll/settle keeps the suite fast. GRACE-RESERVE is the real deadline,
-  # so 60s of headroom means no scenario ends by timeout unless it asks to.
-  E_BUDGET=60; E_POLL=0; E_SETTLE=0; E_STALL=10; E_STATUS=0
-  E_CONFIRM=3; E_RETRIES=3; E_GRACE=60; E_RESERVE=0; E_WARMUP=0
+  # Zero poll/settle keeps the suite fast. GRACE-RESERVE is the real deadline, and
+  # it doubles as the per-scenario ceiling: with POLL=0 a scenario whose exit
+  # condition stops firing busy-spins until the deadline, so keep it small. 15s is
+  # ample headroom for every scenario here (the slowest uses 2s polls) while
+  # bounding a future regression to 15s instead of a minute.
+  E_BUDGET=15; E_POLL=0; E_SETTLE=0; E_STALL=10; E_STATUS=0
+  E_CONFIRM=3; E_RETRIES=3; E_GRACE=15; E_RESERVE=0; E_WARMUP=0
 }
 
 # sample <depth> [rate] [size] [limit] — appends one scripted /metrics response.
@@ -176,6 +179,20 @@ refute() {
 expect_rc() {
   if [ "${RC}" = "$1" ]; then ok "exit ${RC}"; else bad "exit ${RC}, wanted $1"; fi
 }
+# expect_phases_sum — the verdict's "Ns total (As preflight + Bs settle + Cs draining)"
+# breakdown must actually add up to the total. Asserting literal zeros here was
+# flaky: preflight legitimately takes a second under load.
+expect_phases_sum() {
+  _line=$(grep -oE '[0-9]+s total \([0-9]+s preflight \+ [0-9]+s settle \+ [0-9]+s draining\)' "${OUT}" | head -1)
+  if [ -z "${_line}" ]; then bad "no phase breakdown in the verdict"; return; fi
+  set -- $(printf '%s' "${_line}" | tr -cd '0-9 ' | tr -s ' ')
+  if [ "$(( $2 + $3 + $4 ))" = "$1" ]; then
+    ok "phases sum to the total (${_line})"
+  else
+    bad "phases do not sum: ${_line}"
+  fi
+}
+
 # expect_before <a> <b> — a must appear earlier in the log than b.
 expect_before() {
   _la=$(grep -nF -- "$1" "${OUT}" | head -1 | cut -d: -f1)
@@ -304,7 +321,7 @@ expect "stop the inputs and drain manually to save them"
 header "8. feasibility gate: a drain too slow to finish aborts with an ETA"
 begin "infeasible - too slow"
 E_WARMUP=3
-E_GRACE=60; E_RESERVE=0; E_BUDGET=60
+E_GRACE=15; E_RESERVE=0; E_BUDGET=15
 sample 1000000 5000
 sample 1000000; sample 999900; sample 999800
 run
@@ -462,7 +479,7 @@ run
 expect_rc 0
 # Preflight + settle + draining, all measured. A preflight-only exit must not
 # claim a settle it never waited.
-expect "s total (0s preflight + 0s settle + 0s draining)"
+expect_phases_sum
 expect "handing over to SIGTERM with"
 expect "guaranteed floor was 0s"
 

--- a/charts/graylog/tests/scripts/prestop-drain-behavior-test.sh
+++ b/charts/graylog/tests/scripts/prestop-drain-behavior-test.sh
@@ -1,0 +1,500 @@
+#!/bin/sh
+# Behavioural tests for files/scripts/prestop-drain.sh.
+#
+# The helm-unittest suite (tests/prestop_drain_test.yaml) asserts on the
+# *rendered* hook: that the lifecycle block exists, that the budget arithmetic is
+# right, that no debug `sleep` survived. It cannot tell whether the script
+# actually drains anything - a `matchRegex` for "gl_journal_entries_uncommitted"
+# passes whether or not the awk can match that gauge in real exporter output.
+#
+# So this runs the real script, unmodified, and asserts on what it decides.
+#
+# Run it:
+#   sh charts/graylog/tests/scripts/prestop-drain-behavior-test.sh
+#   sh charts/graylog/tests/scripts/prestop-drain-behavior-test.sh -v   # show output of failures
+#
+# How the exporter is faked
+# -------------------------
+# A stub `curl` is placed first on PATH. It serves one scripted /metrics
+# response per invocation, so poll N of the drain loop sees sample N - no HTTP
+# server, no timing races, no sleeps to tune. Invocation 1 is always the
+# preflight scrape. Once the script runs off the end of a scenario's samples the
+# stub keeps serving the last one, which is what lets a 5-sample fixture drive a
+# stall or a timeout.
+#
+# Stubbing curl is the only substitution: every other line of the script - the
+# awk parsing, the zero-confirmation streak, the stall detector, the feasibility
+# projection, the verdict arithmetic - executes for real. What this deliberately
+# does NOT cover is whether the real curl invocation is correct (its flags, the
+# --max-time behaviour, HTTP error handling); that boundary is the stub.
+#
+# Scenarios run with poll/settle intervals of 0 so the suite finishes in about a
+# second. Two scenarios that need a measurable rate window use real 1s polls and
+# are marked accordingly.
+
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+CHART_DIR=$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)
+DRAIN="${CHART_DIR}/files/scripts/prestop-drain.sh"
+
+VERBOSE=0
+[ "${1:-}" = "-v" ] && VERBOSE=1
+
+if [ ! -f "${DRAIN}" ]; then
+  echo "FATAL: cannot find ${DRAIN}" >&2
+  exit 1
+fi
+
+WORK=$(mktemp -d 2>/dev/null) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "${WORK}"' EXIT
+trap 'rm -rf "${WORK}"; exit 130' INT TERM
+
+# ---- the fake exporter -------------------------------------------------------
+mkdir -p "${WORK}/bin"
+cat > "${WORK}/bin/curl" <<'STUB'
+#!/bin/sh
+# Stub curl: serves ${GL_TEST_FIXTURES}/<n> on the nth invocation, ignoring all
+# arguments. A fixture whose content is the single word FAIL exits non-zero,
+# which is how an unreachable exporter is simulated. Past the end of the
+# sequence the last fixture repeats, so a short fixture list can still drive a
+# stall or a timeout.
+set -u
+n=$(cat "${GL_TEST_COUNTER}")
+n=$(( n + 1 ))
+echo "${n}" > "${GL_TEST_COUNTER}"
+f="${GL_TEST_FIXTURES}/${n}"
+if [ ! -f "${f}" ]; then
+  last=$(ls "${GL_TEST_FIXTURES}" | sort -n | tail -1)
+  f="${GL_TEST_FIXTURES}/${last}"
+fi
+if [ "$(cat "${f}")" = "FAIL" ]; then
+  echo "curl: (7) Failed to connect to 127.0.0.1 port 9833" >&2
+  exit 7
+fi
+cat "${f}"
+STUB
+chmod +x "${WORK}/bin/curl"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=""
+
+# ---- scenario construction ---------------------------------------------------
+SCENARIO_N=0
+SHAPE=labeled
+
+# begin <name> — starts a scenario and resets its config to the fast defaults.
+begin() {
+  SCENARIO_N=$(( SCENARIO_N + 1 ))
+  NAME="$1"
+  FX="${WORK}/s${SCENARIO_N}"
+  OUT="${WORK}/s${SCENARIO_N}.out"
+  mkdir -p "${FX}"
+  SAMPLE_N=0
+  SHAPE=labeled
+  # Zero poll/settle keeps the suite fast. GRACE-RESERVE is the real deadline,
+  # so 60s of headroom means no scenario ends by timeout unless it asks to.
+  E_BUDGET=60; E_POLL=0; E_SETTLE=0; E_STALL=10; E_STATUS=0
+  E_CONFIRM=3; E_RETRIES=3; E_GRACE=60; E_RESERVE=0; E_WARMUP=0
+}
+
+# sample <depth> [rate] [size] [limit] — appends one scripted /metrics response.
+#
+# The decoy gauges are the point of the last two lines: gl_dataLakeJournal_* and
+# the kafka gauge must not be read as the journal depth, and gl_journal_size must
+# not pick up gl_journal_size_limit's value (it is a strict prefix of it).
+sample() {
+  SAMPLE_N=$(( SAMPLE_N + 1 ))
+  _d="$1"; _r="${2:-100}"; _z="${3:-1048576}"; _l="${4:-5368709120}"
+  case "${SHAPE}" in
+    labeled)   _sfx='{node="a1b2c3d4-0000-0000-0000-000000000000",}' ;;
+    unlabeled) _sfx='' ;;
+    *) echo "FATAL: bad shape ${SHAPE}" >&2; exit 1 ;;
+  esac
+  cat > "${FX}/${SAMPLE_N}" <<EOF
+# HELP gl_journal_entries_uncommitted Generated from Dropwizard metric import
+# TYPE gl_journal_entries_uncommitted gauge
+gl_journal_entries_uncommitted${_sfx} ${_d}
+gl_journal_append_1_sec_rate${_sfx} ${_r}
+gl_journal_size${_sfx} ${_z}
+gl_journal_size_limit${_sfx} ${_l}
+gl_dataLakeJournal_entries_uncommitted${_sfx} 7777777
+gl_journal_kafka_entries_uncommitted${_sfx} 8888888
+EOF
+}
+
+# unreachable — appends one scrape that fails.
+unreachable() {
+  SAMPLE_N=$(( SAMPLE_N + 1 ))
+  echo FAIL > "${FX}/${SAMPLE_N}"
+}
+
+# run — executes the drain script against the scenario's fixtures.
+run() {
+  echo 0 > "${FX}.counter"
+  GL_TEST_FIXTURES="${FX}" \
+  GL_TEST_COUNTER="${FX}.counter" \
+  PATH="${WORK}/bin:${PATH}" \
+  GL_DRAIN_METRICS_URL="http://127.0.0.1:9833/metrics" \
+  GL_DRAIN_BUDGET_SECONDS="${E_BUDGET}" \
+  GL_DRAIN_POLL_SECONDS="${E_POLL}" \
+  GL_DRAIN_SETTLE_SECONDS="${E_SETTLE}" \
+  GL_DRAIN_STALL_POLLS="${E_STALL}" \
+  GL_DRAIN_STATUS_INTERVAL_SECONDS="${E_STATUS}" \
+  GL_DRAIN_CONFIRM_POLLS="${E_CONFIRM}" \
+  GL_DRAIN_METRICS_RETRIES="${E_RETRIES}" \
+  GL_DRAIN_GRACE_SECONDS="${E_GRACE}" \
+  GL_DRAIN_RESERVE_SECONDS="${E_RESERVE}" \
+  GL_DRAIN_FEASIBILITY_WARMUP_POLLS="${E_WARMUP}" \
+  HOSTNAME="graylog-app-2" \
+    sh "${DRAIN}" > "${OUT}" 2>&1
+  RC=$?
+}
+
+# ---- assertions --------------------------------------------------------------
+ok()   { PASS=$(( PASS + 1 )); printf '  ok   %s\n' "$1"; }
+bad()  {
+  FAIL=$(( FAIL + 1 ))
+  FAILED_NAMES="${FAILED_NAMES}
+  - ${NAME}: $1"
+  printf '  FAIL %s\n' "$1"
+  if [ "${VERBOSE}" = "1" ]; then
+    sed 's/^/       | /' "${OUT}"
+  fi
+}
+
+# expect <literal substring> — the drain must have said this.
+expect() {
+  if grep -qF -- "$1" "${OUT}"; then ok "says: $1"; else bad "missing: $1"; fi
+}
+# refute <literal substring> — the drain must NOT have said this.
+refute() {
+  if grep -qF -- "$1" "${OUT}"; then bad "must not say: $1"; else ok "silent on: $1"; fi
+}
+# expect_rc <code>
+expect_rc() {
+  if [ "${RC}" = "$1" ]; then ok "exit ${RC}"; else bad "exit ${RC}, wanted $1"; fi
+}
+# expect_before <a> <b> — a must appear earlier in the log than b.
+expect_before() {
+  _la=$(grep -nF -- "$1" "${OUT}" | head -1 | cut -d: -f1)
+  _lb=$(grep -nF -- "$2" "${OUT}" | head -1 | cut -d: -f1)
+  if [ -n "${_la}" ] && [ -n "${_lb}" ] && [ "${_la}" -lt "${_lb}" ]; then
+    ok "'$1' precedes '$2'"
+  else
+    bad "'$1' (line ${_la:-none}) should precede '$2' (line ${_lb:-none})"
+  fi
+}
+
+header() { printf '\n%s\n' "$1"; }
+
+echo "prestop-drain.sh behavioural tests"
+echo "script under test: ${DRAIN}"
+
+# =============================================================================
+header "1. a journal that drains to zero reports SUCCESS"
+begin "clean drain"
+sample 500; sample 300; sample 120; sample 0; sample 0; sample 0
+run
+expect_rc 0
+expect "RESULT: SUCCESS - journal fully drained (0 messages remaining)"
+expect "depth held at 0 across 3 consecutive polls"
+expect "drained 100% of the starting backlog (500 -> 0 messages)"
+# A drained journal must not warn about stranding anything on the PVC.
+refute "will be stranded in its PVC"
+
+# =============================================================================
+header "2. gauges without labels are still readable"
+# The awk in sample() matches on '^name[{ ]' or index(\$1, name\"{\")==1. awk
+# splits on whitespace, so \$1 can never contain a space - which makes the
+# space branch unreachable and a match conditional on a '{' following the name.
+# An exporter that publishes these gauges bare would therefore be unreadable and
+# the hook would no-op with RESULT: UNKNOWN. Both shapes must work.
+begin "unlabeled gauges"
+SHAPE=unlabeled
+sample 500; sample 200; sample 0; sample 0; sample 0
+run
+expect_rc 0
+expect "RESULT: SUCCESS - journal fully drained (0 messages remaining)"
+refute "RESULT: UNKNOWN"
+
+# =============================================================================
+header "3. decoy gauges are not mistaken for the journal's"
+# gl_journal_size is a strict prefix of gl_journal_size_limit, and the data-lake
+# and kafka gauges are spelled similarly to the depth gauge. A misread here
+# would silently report the wrong backlog or the wrong disk figure.
+begin "gauge anchoring"
+sample 500 100 1073741824 2147483648
+sample 0;  sample 0; sample 0
+run
+expect_rc 0
+# 1GiB of a 2GiB cap = 50%. If SIZE had picked up LIMIT this would read 100%.
+expect "journal on disk: 1.0GiB of 2.0GiB cap (50% full)"
+# 7777777 / 8888888 are the decoys; the real depth is 500.
+expect "journal at start: 500 messages on disk awaiting processing"
+refute "7777777"
+refute "8888888"
+
+# =============================================================================
+header "4. a momentary zero under live ingest is not success"
+begin "zero blip"
+sample 400
+sample 0     # depth touches zero while messages are still arriving
+sample 250   # ...and immediately pops back
+sample 100; sample 0; sample 0; sample 0
+run
+expect_rc 0
+expect "depth is 0 (confirmation 1/3)"
+expect "depth rose back to 250 after 1 zero reading(s)"
+# It must reach the real conclusion only after the confirmed streak.
+expect "RESULT: SUCCESS"
+expect_before "depth rose back to 250" "RESULT: SUCCESS"
+
+# =============================================================================
+header "5. a zero blip does not abort a drain that is still working"
+# When depth pops back off zero the script resets `best` so later readings can
+# still register as new lows - its own comment says this exists to stop the
+# stall counter reporting INCOMPLETE "while the drain was in fact still
+# working". The accumulated `stall` count has to be reset for that to hold.
+begin "zero blip mid-stall"
+E_STALL=4
+sample 100
+sample 60    # first loop poll: best=60, stall=1
+sample 60    # stall=2
+sample 60    # stall=3  (one short of the limit)
+sample 0     # zero_streak=1
+sample 55    # rose back: best=55. Genuine progress from 60.
+sample 50; sample 40; sample 20; sample 0; sample 0; sample 0
+run
+expect_rc 0
+expect "RESULT: SUCCESS"
+refute "RESULT: INCOMPLETE"
+
+# =============================================================================
+header "6. a journal that stops falling reports INCOMPLETE"
+begin "stalled"
+E_STALL=3
+sample 800 250
+run
+expect_rc 0
+expect "RESULT: INCOMPLETE"
+expect "no longer decreasing"
+expect "the write side never stopped"
+expect "no new low in 3 polls"
+# Stalling on a scale-in is exactly when the operator needs the PVC warning.
+expect "will be stranded in its PVC - nothing replays an orphaned journal"
+
+# =============================================================================
+header "7. feasibility gate: a journal that is not draining at all aborts"
+begin "infeasible - flat"
+E_WARMUP=3
+sample 1000000 5000
+sample 1000000; sample 1010000; sample 1020000
+run
+expect_rc 0
+expect "FEASIBILITY: journal is NOT draining"
+expect "time to clear:   never at this rate"
+expect "drain rate:      0 msg/s - nothing is being worked off"
+expect "RESULT: ABORTED - drain is not feasible"
+expect "read-only index block or a disk watermark"
+expect "stop the inputs and drain manually to save them"
+
+# =============================================================================
+header "8. feasibility gate: a drain too slow to finish aborts with an ETA"
+begin "infeasible - too slow"
+E_WARMUP=3
+E_GRACE=60; E_RESERVE=0; E_BUDGET=60
+sample 1000000 5000
+sample 1000000; sample 999900; sample 999800
+run
+expect_rc 0
+expect "FEASIBILITY: drain cannot finish in the time available"
+expect "RESULT: ABORTED - drain is not feasible"
+expect "short by:"
+# Must hand the unused grace period back rather than sit on it.
+expect "returning the rest of the grace period to Graylog's own shutdown"
+
+# =============================================================================
+header "9. feasibility gate: a viable drain passes and completes"
+begin "feasible"
+E_WARMUP=3
+sample 1000
+sample 800; sample 500; sample 200; sample 0; sample 0; sample 0
+run
+expect_rc 0
+expect "feasibility OK:"
+expect "RESULT: SUCCESS"
+refute "RESULT: ABORTED"
+
+# =============================================================================
+header "10. feasibilityWarmupPolls=0 disables the projection"
+begin "feasibility disabled"
+E_WARMUP=0
+E_STALL=3
+sample 1000000 5000
+sample 1000000
+run
+expect_rc 0
+expect "feasibility: projection disabled (feasibilityWarmupPolls=0)"
+refute "FEASIBILITY:"
+# Without the projection the only backstop is the stall detector.
+expect "RESULT: INCOMPLETE"
+
+# =============================================================================
+header "11. a sub-1-msg/s drain does not divide by zero"
+# drain_rate floors to 0 msg/s for anything slower than one message per second.
+# The ETA is computed as n*observed/cleared rather than n/drain_rate precisely
+# so that 0 never reaches a divisor; `$(( n / 0 ))` would abort the hook
+# mid-shutdown.
+#
+# Needs a real poll interval to make the rate window measurable. One message
+# cleared across a >=2s window is what floors the integer division to 0 - with
+# 1s polls the window lands on either side of a second boundary and the rate
+# comes out 1 or 2 depending on timing, which made this flaky.
+begin "sub-1 msg/s"
+E_WARMUP=2
+E_POLL=2
+sample 900000 5000
+sample 900000; sample 899999
+run
+expect_rc 0
+expect "drain rate:      0 msg/s"
+expect "RESULT: ABORTED"
+refute "divide by zero"
+refute "division by 0"
+
+# =============================================================================
+header "12. a journal at its size cap is called out explicitly"
+begin "at cap"
+E_WARMUP=3
+# The cap has to be on every sample, not just preflight: report_journal_state
+# reads the most recent parse, so a fixture that only caps the first sample
+# reports the cap at preflight and then a stale-looking 0% in the verdict.
+sample 2000000 7000 5368709120 5368709120
+sample 2000000 7000 5368709120 5368709120
+sample 2000000 7000 5368709120 5368709120
+sample 2000000 7000 5368709120 5368709120
+run
+expect_rc 0
+# Reported once at preflight and again in the verdict.
+expect "journal on disk: 5.0GiB of 5.0GiB cap (100% full)"
+expect "the journal is AT its cap"
+expect "messages are being lost right now"
+
+# =============================================================================
+header "13. an unreachable exporter at preflight attempts no drain"
+begin "preflight unreachable"
+E_RETRIES=3
+unreachable
+run
+expect_rc 0
+expect "RESULT: UNKNOWN - no drain attempted; journal depth was never measurable"
+expect "did not answer after 3 attempts"
+# It must not claim to have waited for endpoints or drained anything.
+refute "waiting 0s for EndpointSlice removal"
+refute "drained"
+
+# =============================================================================
+header "14. a transient scrape failure is retried, not fatal"
+begin "retry recovers"
+E_RETRIES=5
+unreachable; unreachable   # two blips at preflight...
+sample 300                 # ...then the exporter answers
+sample 0; sample 0; sample 0
+run
+expect_rc 0
+expect "metrics probe failed (attempt 1/5)"
+expect "metrics probe recovered on attempt 3"
+expect "RESULT: SUCCESS"
+
+# =============================================================================
+header "15. losing the exporter mid-drain abandons rather than lies"
+begin "lost mid-drain"
+E_RETRIES=2
+sample 500      # preflight fine
+sample 400      # draining
+unreachable     # and then gone for good
+run
+expect_rc 0
+expect "RESULT: UNKNOWN - drain abandoned; journal depth stopped being measurable"
+expect "metrics endpoint stopped answering"
+refute "RESULT: SUCCESS"
+
+# =============================================================================
+header "16. an already-empty journal short-circuits"
+begin "already empty"
+sample 0
+run
+expect_rc 0
+expect "journal already empty before the settle wait"
+expect "RESULT: SUCCESS"
+expect "drained n/a - the journal was already empty when the hook began"
+
+# =============================================================================
+header "17. exhausting the budget reports the timeout, not success"
+# GRACE - RESERVE = 0 puts the deadline at the hook's start, so the loop is
+# never entered - the deterministic way to reach the timeout verdict.
+begin "timeout"
+E_GRACE=1; E_RESERVE=1; E_BUDGET=0
+sample 750
+run
+expect_rc 0
+expect "RESULT: INCOMPLETE - 0s timeout cutoff reached with 750 messages still undrained"
+expect "will be stranded in its PVC"
+refute "RESULT: SUCCESS"
+
+# =============================================================================
+header "18. a journal that grows is reported as no progress, not negative"
+begin "backlog grew"
+E_STALL=3
+sample 100 500
+sample 200; sample 300; sample 400
+run
+expect_rc 0
+expect "drained 0% of the starting backlog - it grew from 100 to 400 messages"
+
+# =============================================================================
+header "19. the verdict's phase breakdown sums to the total"
+begin "phase accounting"
+sample 50; sample 0; sample 0; sample 0
+run
+expect_rc 0
+# Preflight + settle + draining, all measured. A preflight-only exit must not
+# claim a settle it never waited.
+expect "s total (0s preflight + 0s settle + 0s draining)"
+expect "handing over to SIGTERM with"
+expect "guaranteed floor was 0s"
+
+begin "phase accounting - preflight exit"
+unreachable
+run
+expect_rc 0
+expect "before the settle wait began"
+refute "settle + "
+
+# =============================================================================
+header "20. a missing configuration variable fails loudly"
+# Every GL_DRAIN_* is read with ${VAR:?} so an incomplete environment aborts at
+# the top instead of defaulting to empty and producing nonsense arithmetic.
+# This is the one path that is allowed to exit non-zero.
+begin "missing env"
+sample 100
+echo 0 > "${FX}.counter"
+GL_TEST_FIXTURES="${FX}" GL_TEST_COUNTER="${FX}.counter" \
+PATH="${WORK}/bin:${PATH}" \
+GL_DRAIN_METRICS_URL="http://127.0.0.1:9833/metrics" \
+  sh "${DRAIN}" > "${OUT}" 2>&1
+RC=$?
+if [ "${RC}" != "0" ]; then ok "exit ${RC} (non-zero as designed)"; else bad "exited 0 with no config"; fi
+expect "GL_DRAIN_BUDGET_SECONDS"
+
+# =============================================================================
+printf '\n---\n'
+printf '%d passed, %d failed\n' "${PASS}" "${FAIL}"
+if [ "${FAIL}" != "0" ]; then
+  printf 'failures:%s\n' "${FAILED_NAMES}"
+  [ "${VERBOSE}" = "0" ] && printf '\nre-run with -v to see the drain output for each failure\n'
+  exit 1
+fi
+exit 0

--- a/charts/graylog/values.schema.json
+++ b/charts/graylog/values.schema.json
@@ -162,6 +162,7 @@
               "type": "object",
               "properties": {
                 "enabled": { "type": "string" },
+                "maxSize": { "type": "string", "description": "On-disk journal cap (message_journal_max_size). Must stay under 90% of graylog.persistence.size; the chart validates this." },
                 "flushAge": { "type": "string" },
                 "flushInterval": { "type": "string" },
                 "maxAge": { "type": "string" },
@@ -597,6 +598,14 @@
         "persistence": {
           "type": "object",
           "properties": {
+            "retentionPolicy": {
+              "type": "object",
+              "description": "PVC lifecycle for the Data Node volumes. Delete is permitted, unlike on the Graylog StatefulSet, because shard data can be rebuilt from replicas.",
+              "properties": {
+                "whenDeleted": { "type": "string", "enum": ["Retain", "Delete"] },
+                "whenScaled": { "type": "string", "enum": ["Retain", "Delete"] }
+              }
+            },
             "data": {
               "type": "object",
               "properties": {

--- a/charts/graylog/values.schema.json
+++ b/charts/graylog/values.schema.json
@@ -412,6 +412,27 @@
             "successThreshold": { "type": "integer" }
           }
         },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Seconds Kubernetes allows for shutdown before SIGKILL. Covers the preStop hook and the SIGTERM that follows it."
+        },
+        "lifecycle": {
+          "type": "object",
+          "properties": {
+            "preStopDrain": {
+              "type": "object",
+              "description": "Hold pod termination while the on-disk journal drains, so scaling in does not strand unprocessed messages. Requires graylog.service.metrics.enabled.",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "endpointPropagationDelaySeconds": { "type": "integer", "minimum": 0 },
+                "pollIntervalSeconds": { "type": "integer", "minimum": 1 },
+                "shutdownReserveSeconds": { "type": "integer", "minimum": 0 },
+                "stallPolls": { "type": "integer", "minimum": 1 }
+              }
+            }
+          }
+        },
         "podDisruptionBudget": {
           "type": "object",
           "properties": {

--- a/charts/graylog/values.schema.json
+++ b/charts/graylog/values.schema.json
@@ -377,6 +377,14 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
+            "retentionPolicy": {
+              "type": "object",
+              "description": "PVC lifecycle for the journal volumes. whenScaled must remain Retain; Delete destroys the journal of a scaled-in ordinal.",
+              "properties": {
+                "whenDeleted": { "type": "string", "enum": ["Retain", "Delete"] },
+                "whenScaled": { "type": "string", "enum": ["Retain", "Delete"] }
+              }
+            },
             "storageClass": { "type": [ "string", "null" ] },
             "volumeNameOverride": { "type": [ "string", "null" ] },
             "existingClaim": { "type": [ "string", "null" ] },
@@ -428,7 +436,11 @@
                 "endpointPropagationDelaySeconds": { "type": "integer", "minimum": 0 },
                 "pollIntervalSeconds": { "type": "integer", "minimum": 1 },
                 "shutdownReserveSeconds": { "type": "integer", "minimum": 0 },
-                "stallPolls": { "type": "integer", "minimum": 1 }
+                "stallPolls": { "type": "integer", "minimum": 1 },
+                "statusIntervalSeconds": { "type": "integer", "minimum": 1 },
+                "confirmPolls": { "type": "integer", "minimum": 1 },
+                "metricsRetries": { "type": "integer", "minimum": 1 },
+                "feasibilityWarmupPolls": { "type": "integer", "minimum": 0 }
               }
             }
           }

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -101,6 +101,18 @@ graylog:
       updateKeyStore: true
       # keyStorePass is the password of the JVM trust store.
       keyStorePass: "changeit"
+    # Graylog Forwarder ingest (enterprise feature).
+    # Graylog only listens on 13301/13302 when a bind address is configured AND a
+    # Forwarder input exists. Self-managed deployments must create that input
+    # manually under System > Inputs; Graylog Cloud provisions it automatically.
+    forwarder:
+      # Unset defaults to ingress.forwarder.enabled. Set true to bind the ports
+      # without an Ingress (e.g. when fronting them with your own load balancer).
+      enabled:
+      bindAddress: "0.0.0.0"
+      # Transport encryption between the forwarder and Graylog. Leave false when
+      # a load balancer terminates TLS and speaks cleartext HTTP/2 to Graylog.
+      grpcEnableTls: false
     mongodb:
       # customUri is a full MongoDB connection string for an externally
       # managed MongoDB. Required when mongodb.communityResource.enabled=false.
@@ -593,17 +605,33 @@ ingress:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
-  # forwarder exposes the Graylog forwarder input.
+  # Graylog Forwarder ingest. A forwarder requires BOTH gRPC channels to be
+  # reachable: the message channel (13301) it ships log data on, and the
+  # configuration channel (13302) it polls for configuration updates.
+  # Each channel is a separate Ingress resource because they listen on
+  # different ports and an Ingress routes on host/path, not listener port.
   forwarder:
     enabled: false
-    className: ""
-    annotations: {}
-    hosts:
-      - host: chart-example.local
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-    tls: []
+    messageChannel:
+      enabled: true
+      className: ""
+      annotations: {}
+      hosts:
+        - host: ""
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls: []
+    configChannel:
+      enabled: true
+      className: ""
+      annotations: {}
+      hosts:
+        - host: ""
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls: []
 
 # MongoDB Community Resource configuration
 # Requires MongoDB Kubernetes Operator: https://github.com/mongodb/mongodb-kubernetes/tree/master/docs/mongodbcommunity

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -16,6 +16,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 # global values are shared by the Graylog, Datanode, and MongoDB workloads.
+
+
 global:
   # imagePullSecrets is applied to the Graylog and Datanode pods unless
   # overridden per image (MongoDB images are pulled by the operator).
@@ -25,6 +27,7 @@ global:
   existingSecretName: ""
   # storageClass is the default StorageClass for all persistent volumes.
   storageClass: ""
+
 
 # graylog configures the Graylog server application.
 graylog:
@@ -101,10 +104,15 @@ graylog:
       updateKeyStore: true
       # keyStorePass is the password of the JVM trust store.
       keyStorePass: "changeit"
+
     # Graylog Forwarder ingest (enterprise feature).
     # Graylog only listens on 13301/13302 when a bind address is configured AND a
     # Forwarder input exists. Self-managed deployments must create that input
     # manually under System > Inputs; Graylog Cloud provisions it automatically.
+
+    # @ WARNING: These values have been removed as the application is not respecting their
+    # configuration currently. These will be brought back in future versions.
+
     forwarder:
       # Unset defaults to ingress.forwarder.enabled. Set true to bind the ports
       # without an Ingress (e.g. when fronting them with your own load balancer).
@@ -271,6 +279,17 @@ graylog:
   # persistence configures the Graylog data volume (journal, node-id, ...).
   persistence:
     enabled: true
+    # What happens to the journal PVCs when the StatefulSet is scaled in or
+    # deleted. Both default to Retain, which is also the Kubernetes default -
+    # set explicitly so it cannot drift, and so the schema can police it.
+    #
+    # whenScaled MUST stay Retain. Scaling in removes the highest ordinal, and
+    # anything still unprocessed in its journal lives only on that claim; Delete
+    # would destroy exactly the data the drain hook exists to protect, silently.
+    # The chart refuses to render whenScaled: Delete for that reason.
+    retentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Retain
     # storageClass overrides global.storageClass for this volume.
     storageClass:
     # volumeNameOverride replaces the generated PVC/volume name.
@@ -336,6 +355,35 @@ graylog:
       # removal only sheds new connections; long-lived TCP and UDP senders keep
       # writing, and against those the journal never reaches zero.
       stallPolls: 10
+      # How many times to retry the metrics probe before giving up. A single
+      # failed scrape is usually a blip - the exporter briefly busy, a dropped
+      # connection - and abandoning the drain on one miss defeats the hook.
+      # Applies both to the preflight check and to failures mid-drain; retries
+      # are spaced pollIntervalSeconds apart.
+      metricsRetries: 5
+      # A single reading of zero does not mean drained: under live ingest the
+      # depth oscillates and can momentarily touch zero while messages are still
+      # arriving. Require it to hold at zero across this many consecutive polls
+      # before declaring success, so anything still writing resets the streak.
+      # Costs confirmPolls x pollIntervalSeconds on an otherwise finished drain.
+      confirmPolls: 3
+      # How often to emit a progress line during the drain. Throttled separately
+      # from pollIntervalSeconds so a long drain does not bury the container log;
+      # the start, the verdict, and any warning are always logged regardless.
+      statusIntervalSeconds: 10
+      # Polls to observe before projecting whether the drain can finish at all.
+      # stallPolls only notices a journal that has stopped falling; it cannot
+      # notice one that is falling far too slowly to matter, because every new
+      # low resets the counter. Against a deep backlog that means the hook holds
+      # termination for the whole budget to clear a couple of percent, then
+      # strands the rest anyway - and on a rolling upgrade it pays that per pod.
+      # After this many polls the drain rate is measured and the finish time
+      # projected; if it does not fit in the remaining budget the hook logs a
+      # CRIT verdict (journal size on disk, measured rate, time to clear, how
+      # much it is short by) and gives up at once, returning the grace period to
+      # Graylog's own shutdown. Set to 0 to disable the projection and always
+      # drain for the full budget.
+      feasibilityWarmupPolls: 5
   # PodDisruptionBudgets are enabled by default for production deployments
   # They prevent cluster upgrades and maintenance from disrupting all instances
   # Set enabled: false only for non-production clusters or single-replica deployments
@@ -380,6 +428,7 @@ graylog:
   # extraEnv sets additional environment variables using full EnvVar syntax
   # (supports valueFrom); entries here win over graylog.env keys.
   extraEnv: []
+
 
 # datanode configures the Graylog Data Node (managed OpenSearch).
 datanode:
@@ -516,6 +565,7 @@ datanode:
   # (supports valueFrom); entries here win over datanode.env keys.
   extraEnv: []
 
+
 # External OpenSearch
 # Point Graylog at an existing, self-managed OpenSearch cluster instead of the bundled
 # Graylog Data Node. Enable this AND set `datanode.enabled: false` (the two are mutually
@@ -546,6 +596,7 @@ opensearch:
     caSecret: ""
     caKey: "ca.crt"
 
+
 # Graylog service account
 serviceAccount:
   # create makes the chart manage the ServiceAccount. Set create=false and
@@ -566,6 +617,8 @@ serviceAccount:
 #        resources: [ "pods" ]
 #        resourceNames: []
 #        verbs: [ "get" ]
+
+
 # Ingress configuration
 # more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
@@ -632,6 +685,7 @@ ingress:
             - path: /
               pathType: ImplementationSpecific
       tls: []
+
 
 # MongoDB Community Resource configuration
 # Requires MongoDB Kubernetes Operator: https://github.com/mongodb/mongodb-kubernetes/tree/master/docs/mongodbcommunity

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -288,6 +288,42 @@ graylog:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
+  # Time Kubernetes allows for shutdown before SIGKILL. This budget covers the
+  # preStop hook AND the SIGTERM that follows it — Graylog's graceful shutdown
+  # (flip lb_status to DEAD, stop inputs, flush in-memory buffers into the
+  # journal) has to finish inside whatever is left. The Kubernetes default of
+  # 30s is not enough under load, which is why this is set explicitly.
+  terminationGracePeriodSeconds: 300
+  lifecycle:
+    # Hold pod termination while the on-disk journal is worked off.
+    #
+    # Scaling in is the case that matters: the ordinal stops existing, so its
+    # journal is stranded in an orphaned PVC and nothing will ever replay it.
+    # Graceful shutdown flushes buffers *into* the journal, never *out* of it.
+    # This hook gives the doomed pod a chance to finish processing first.
+    #
+    # Off by default because it slows every rolling upgrade by the drain time.
+    # It is best-effort, not a guarantee — see the Message Journal Lifecycle
+    # runbook in the README for the drain procedure it does not replace.
+    preStopDrain:
+      enabled: false
+      # Requires graylog.service.metrics.enabled: journal depth is read from the
+      # unauthenticated Prometheus exporter, so no admin token is needed.
+      #
+      # Seconds to wait for EndpointSlice removal to reach kube-proxy before
+      # sampling. Measuring earlier reads traffic that is already going away.
+      endpointPropagationDelaySeconds: 15
+      pollIntervalSeconds: 2
+      # Reserved out of terminationGracePeriodSeconds for Graylog's own shutdown.
+      # The drain never runs past
+      #   terminationGracePeriodSeconds - endpointPropagationDelaySeconds - shutdownReserveSeconds
+      # because a hook that eats the whole grace period gets the container
+      # SIGKILLed with its in-memory buffers unflushed.
+      shutdownReserveSeconds: 45
+      # Give up once journal depth stops falling for this many polls. Endpoint
+      # removal only sheds new connections; long-lived TCP and UDP senders keep
+      # writing, and against those the journal never reaches zero.
+      stallPolls: 10
   # PodDisruptionBudgets are enabled by default for production deployments
   # They prevent cluster upgrades and maintenance from disrupting all instances
   # Set enabled: false only for non-production clusters or single-replica deployments

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -105,22 +105,16 @@ graylog:
       # keyStorePass is the password of the JVM trust store.
       keyStorePass: "changeit"
 
-    # Graylog Forwarder ingest (enterprise feature).
-    # Graylog only listens on 13301/13302 when a bind address is configured AND a
-    # Forwarder input exists. Self-managed deployments must create that input
-    # manually under System > Inputs; Graylog Cloud provisions it automatically.
-
-    # @ WARNING: These values have been removed as the application is not respecting their
-    # configuration currently. These will be brought back in future versions.
-
-    forwarder:
-      # Unset defaults to ingress.forwarder.enabled. Set true to bind the ports
-      # without an Ingress (e.g. when fronting them with your own load balancer).
-      enabled:
-      bindAddress: "0.0.0.0"
-      # Transport encryption between the forwarder and Graylog. Leave false when
-      # a load balancer terminates TLS and speaks cleartext HTTP/2 to Graylog.
-      grpcEnableTls: false
+    # Graylog Forwarder ingest (enterprise feature) has no server.conf settings.
+    # The listener is configured as attributes on a Graylog input of type
+    # "Forwarder" (org.graylog.plugins.forwarder.input.ForwarderServiceInput):
+    # bind address, message port (13301), configuration port (13302), and gRPC
+    # TLS all live there. Graylog binds 13301/13302 on every node once that input
+    # exists. Self-managed deployments must create it under System > Inputs;
+    # Graylog Cloud provisions it automatically. Behind a TLS-terminating load
+    # balancer set forwarder_grpc_enable_tls false on the input -- it defaults to
+    # true, and targets stay unhealthy otherwise.
+    # Expose the ports with ingress.forwarder.*; there is nothing to set here.
     mongodb:
       # customUri is a full MongoDB connection string for an externally
       # managed MongoDB. Required when mongodb.communityResource.enabled=false.
@@ -132,8 +126,30 @@ graylog:
       versionProbeAttempts: "0"
     # messageJournal configures the on-disk message journal; fields map to
     # the message_journal_* settings in server.conf.
+    #
+    # An enabled journal requires durable storage: either
+    # graylog.persistence.enabled=true or graylog.persistence.existingClaim. With
+    # neither, the data dir is an emptyDir and unprocessed messages are lost on
+    # every pod restart while Graylog still believes the journal is durable. The
+    # chart refuses to render that combination.
+    #
+    # These are strings, not booleans - disabling the journal needs
+    # `--set-string ...enabled=false`, as a bare `--set` is rejected by the schema.
     messageJournal:
       enabled: "true"
+      # maxSize caps the on-disk journal (message_journal_max_size). Graylog's
+      # own default is 5gb; it is set explicitly here because the cap and the
+      # volume have to be sized together and the chart validates them together.
+      #
+      # This must leave room on graylog.persistence.size (default 8Gi) for the
+      # node-id, truststore, content packs and GeoIP databases, which share the
+      # volume. The chart refuses to render a cap above 90% of the volume.
+      #
+      # Raising this without raising persistence.size is the mistake it guards
+      # against: a full journal throttles inputs by design, a full data volume
+      # takes the node down. Suffixes are Graylog's own and binary - 5gb is
+      # 5 x 1024^3 bytes, matching gl_journal_size_limit on the metrics endpoint.
+      maxSize: "5gb"
       flushAge: "1m"
       flushInterval: "1000000"
       maxAge: "12h"
@@ -335,7 +351,8 @@ graylog:
     #
     # Off by default because it slows every rolling upgrade by the drain time.
     # It is best-effort, not a guarantee — see the Message Journal Lifecycle
-    # runbook in the README for the drain procedure it does not replace.
+    # scale-in runbook in docs/graylog-message-handling.md for the drain
+    # procedure it does not replace.
     preStopDrain:
       enabled: false
       # Requires graylog.service.metrics.enabled: journal depth is read from the
@@ -504,6 +521,17 @@ datanode:
       memory: "3.5Gi"
   # persistence configures the Datanode volumes.
   persistence:
+    # What happens to the Datanode PVCs when the StatefulSet is scaled in or
+    # deleted. Both default to Retain, which is also the Kubernetes default -
+    # set explicitly so it cannot drift, matching graylog.persistence.
+    #
+    # Delete is permitted here, unlike on the Graylog StatefulSet: shard data on
+    # a scaled-in Data Node can be rebuilt from replicas, whereas an orphaned
+    # Graylog journal cannot be replayed by anything. Only set whenScaled=Delete
+    # if your indexes carry replicas and the cluster is green before you scale.
+    retentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Retain
     # data is the OpenSearch data volume.
     data:
       enabled: true

--- a/docs/graylog-message-handling.md
+++ b/docs/graylog-message-handling.md
@@ -1,0 +1,326 @@
+# Graylog Message Handling
+
+How messages are buffered on disk, what happens to them when pods go away, and how
+to scale in without losing any.
+
+For the values that configure this, see
+[Message Journal Lifecycle](../charts/graylog/README.md#message-journal-lifecycle).
+
+## Contents
+
+- [The journal](#the-journal)
+  - [Sizing](#sizing)
+- [Scaling in safely](#scaling-in-safely)
+- [Automatic drain on shutdown](#automatic-drain-on-shutdown)
+- [Reading the drain logs](#reading-the-drain-logs)
+- [Failure modes](#failure-modes)
+- [Deleting a leftover PVC](#deleting-a-leftover-pvc)
+- [Recovering a stranded journal](#recovering-a-stranded-journal)
+
+## The journal
+
+Each Graylog node writes incoming messages to an on-disk journal on its own PVC,
+then works them off into the indexer. Two counters matter and they are not the same
+thing:
+
+| | Means |
+|---|---|
+| `gl_journal_entries_uncommitted` | messages **left to process** — this is "how much is undrained" |
+| `gl_journal_size` | bytes **still stored**, including already-processed segments |
+
+Graylog does not delete a segment just because it has been processed. Segments are
+kept for `graylog.config.messageJournal.maxAge` (default 12h) and reaped only once
+fully committed *and* past retention. A drained node still holds hundreds of MB.
+Judge a journal by `uncommitted`, never by `du`.
+
+### Sizing
+
+The journal cap and the data volume have to be sized together.
+
+| Value | Default | |
+|---|---|---|
+| `graylog.config.messageJournal.maxSize` | `5gb` | on-disk journal cap |
+| `graylog.persistence.size` | `8Gi` | the whole data volume |
+
+Graylog's suffixes are binary: `5gb` is 5×1024³, which is what the exporter reports
+as `gl_journal_size_limit`. Kubernetes quantities are not the same — `8G` is 8×10⁹,
+`8Gi` is 8×1024³.
+
+The journal is not alone on that volume. It shares it with the `node-id`, the JVM
+truststore, content packs, and GeoIP databases, and it can briefly overshoot its cap
+because reaping happens a whole segment at a time. **The chart refuses to render a
+cap above 90% of the volume** and tells you both a smaller cap and a larger volume
+that would fit.
+
+Raising the cap without raising the volume is the mistake this guards against. A full
+journal throttles inputs — that is its designed backpressure. A full data volume
+takes the node down.
+
+Two constraints when changing them:
+
+- Growing a volume needs a StorageClass with `allowVolumeExpansion: true`. Shrinking
+  is not supported by Kubernetes at all.
+- The cap is not a reservation. A journal that has never filled uses less; see the
+  `uncommitted` vs `gl_journal_size` distinction above.
+
+The check is skipped when the chart cannot know the size — an `existingClaim`, or a
+quantity it cannot parse such as `1.5Gi`. It declines rather than guessing.
+
+### Why upgrades are safe and scale-in is not
+
+A StatefulSet guarantees identity, not data migration.
+
+On a rolling upgrade, `graylog-2` is replaced by a new `graylog-2` that re-binds the
+same PVC, finds the same journal and the same `node-id`, and carries on. Nothing is
+lost and no procedure is needed.
+
+On scale-in the ordinal stops existing. Its PVC is retained but no pod will mount it
+again. Graceful shutdown flushes in-memory buffers **into** the journal; it never
+drains the journal **out** — that is the replacement pod's job, and on scale-in
+there is no replacement pod.
+
+Kubernetes has no decommission hook. A pod cannot tell whether its SIGTERM means
+upgrade, drain, or removal, so drain-before-scale-in can only live in a runbook or a
+preStop hook. Both are below.
+
+## Scaling in safely
+
+Scaling out needs no procedure. Scaling in does. Run this against the highest
+ordinals first — StatefulSets terminate from the highest ordinal down.
+
+**1. Stop the inputs.** This is the only step that guarantees the journal can reach
+zero. Endpoint removal alone does not stop long-lived TCP connections, UDP senders,
+or internally generated inputs.
+
+```sh
+# list inputs
+curl -su "admin:$PASS" http://localhost:9000/api/system/inputs | jq '.inputs[] | {id, title}'
+# stop one
+curl -su "admin:$PASS" -X DELETE http://localhost:9000/api/system/inputs/<id>
+```
+
+Or **System > Inputs** in the UI. Requires admin auth.
+
+**2. Take the node out of rotation.** Graylog publishes its load-balancer state at
+`/api/system/lbstatus` — unauthenticated, returns `200` alive, `429` throttled,
+`503` dead.
+
+```sh
+kubectl exec -n graylog graylog-2 -- curl -so /dev/null -w '%{http_code}\n' \
+  http://localhost:9000/api/system/lbstatus
+```
+
+Force it dead before scaling (requires admin auth):
+
+```sh
+kubectl exec -n graylog graylog-2 -- curl -su "admin:$PASS" \
+  -X PUT http://localhost:9000/api/system/lbstatus/override/dead
+```
+
+> [!NOTE]
+> The chart's readiness probe is a TCP check, so `lb_status: DEAD` does not currently
+> remove the pod from Service endpoints on its own. Until the probe is HTTP-based,
+> treat this step as signalling to external load balancers, and rely on step 1 to
+> actually stop ingest.
+
+**3. Watch the journal drain to zero.**
+
+```sh
+kubectl port-forward -n graylog pod/graylog-2 9833:9833
+curl -s localhost:9833/metrics | grep '^gl_journal_entries_uncommitted'
+```
+
+Port-forward the **pod**, not the Service — the Service answers from an arbitrary
+node. The equivalent REST call is `GET /api/system/journal` (`uncommitted_entries`),
+which needs admin auth; the metrics gauge does not.
+
+**4. Scale down by one and wait.** Do not jump several ordinals at once.
+
+```sh
+helm upgrade graylog graylog/graylog -n graylog --set graylog.replicas=2 --reuse-values
+```
+
+To hold the rollout at a specific ordinal instead, use `updateStrategy.rollingUpdate.partition`
+(note the schema types it as a string, so use `--set-string`):
+
+```sh
+helm upgrade graylog graylog/graylog -n graylog --reuse-values \
+  --set-string graylog.updateStrategy.rollingUpdate.partition=2
+```
+
+**5. Verify, then repeat.** Confirm `uncommitted` is 0 on the remaining pods before
+scaling in the next ordinal.
+
+**6. Audit what was left behind.**
+
+```sh
+kubectl get pvc -n graylog       # e.g. graylog-data-graylog-2 remains
+```
+
+See [Deleting a leftover PVC](#deleting-a-leftover-pvc) before removing it.
+
+### PVC retention
+
+The chart pins `persistentVolumeClaimRetentionPolicy` to `Retain` on both fields for
+both StatefulSets, and **refuses to render `graylog.persistence.retentionPolicy.whenScaled: Delete`**.
+`Delete` would destroy the journal of every scaled-in node, silently. The Data Node
+allows `Delete` because shard data rebuilds from replicas; a Graylog journal does not.
+
+## Automatic drain on shutdown
+
+The chart can hold pod termination while the journal is worked off:
+
+```sh
+helm upgrade graylog graylog/graylog -n graylog \
+  --set graylog.lifecycle.preStopDrain.enabled=true --reuse-values
+```
+
+A `preStop` hook polls `gl_journal_entries_uncommitted` from the Prometheus exporter
+on localhost and returns once the journal is empty. No credentials needed. Requires
+`graylog.service.metrics.enabled` (the default); the chart refuses to render
+otherwise.
+
+Off by default: it slows every rolling upgrade, where it protects nothing.
+
+### The budget
+
+`terminationGracePeriodSeconds` is a hard ceiling covering the hook **and** the
+SIGTERM after it. If the hook is still running when it expires the container is
+SIGKILLed, Graylog never gets SIGTERM, and the in-memory buffers this feature exists
+to protect are lost — worse than no hook. So:
+
+```
+drain budget = terminationGracePeriodSeconds
+             - endpointPropagationDelaySeconds   # settle: wait for endpoint removal to propagate
+             - shutdownReserveSeconds            # left for Graylog's own shutdown
+```
+
+Defaults: `300 - 15 - 45 = 240s`. The chart fails to render if that is not positive.
+
+**settle** is a plain sleep before the first sample. Endpoint removal is eventually
+consistent, and measuring during that window reads ingest that is about to stop —
+which skews the drain rate and can trip the feasibility abort on a pod that would
+have drained fine. Raise it if a load balancer targets pod IPs directly (ALB/NLB IP
+mode deregisters slower than kube-proxy), and raise the grace period with it.
+
+### What it cannot do
+
+| Limit | Consequence |
+|---|---|
+| Bounded by the grace period | If the journal is still full, termination proceeds anyway. |
+| Only sheds *new* connections | Long-lived TCP, UDP, and internal inputs keep writing. The journal never reaches zero and the hook gives up after `stallPolls` samples without a new low. |
+| Cannot stop inputs | That needs authenticated API calls. Only the runbook above guarantees an empty journal. |
+| Useless on rolling upgrades | The replacement pod replays the journal itself. The hook cannot tell an upgrade from a scale-in, so it pays the cost on both. |
+| Cannot drain a blocked indexer | Nothing can be worked off and the journal only grows. The feasibility check aborts in seconds instead of stalling the rollout. |
+
+## Reading the drain logs
+
+The hook writes to the container's log stream. Follow it **before** terminating — a
+pod's logs die with the pod, so a post-mortem `kubectl logs` finds nothing.
+
+```sh
+kubectl logs -n graylog -l app=graylog-app -c graylog-app \
+  --follow --prefix --tail=0 --max-log-requests=20 | grep prestop-drain
+```
+
+Every run ends in one `RESULT:` line. That line is the whole verdict.
+
+### RESULT: SUCCESS
+
+```
+RESULT: SUCCESS - journal fully drained (0 messages remaining) in 34s total
+        (1s preflight + 15s settle + 18s draining), within the 240s budget
+drained 100% of the starting backlog (18432 -> 0 messages)
+```
+
+Depth held at 0 across `confirmPolls` samples. Safe to scale in. A single zero is
+never treated as drained — under live ingest the gauge touches zero while messages
+are still arriving, so the streak has to hold.
+
+### RESULT: INCOMPLETE — stalled
+
+```
+no new low in 10 polls: depth 163, best 4, still ingesting 113 msg/s
+RESULT: INCOMPLETE - 163 messages still queued and no longer decreasing after 89s
+the write side never stopped, so the journal cannot reach zero
+if this pod is being removed by a scale-in, those 163 messages will be stranded
+```
+
+**Most common failure.** Something is still writing. Endpoint removal only sheds new
+connections. Expected on a node under live load — the fix is step 1 of the runbook,
+not a longer budget. `best 4` means it nearly made it.
+
+### RESULT: INCOMPLETE — timeout
+
+```
+RESULT: INCOMPLETE - 240s timeout cutoff reached with 51200 messages still undrained
+```
+
+Depth kept falling but ran out of budget. Raise `terminationGracePeriodSeconds`, or
+stop the inputs and drain manually. If this appears with a large backlog, the
+feasibility check should have caught it — check whether `feasibilityWarmupPolls` is 0.
+
+### RESULT: ABORTED — not draining
+
+```
+CRIT FEASIBILITY: journal is NOT draining - depth went 7240000 -> 7240000 over 8s
+CRIT   drain rate:      0 msg/s - nothing is being worked off (ingest 1200 msg/s)
+CRIT   time to clear:   never at this rate
+CRIT   the indexer is refusing writes or cannot keep up; check for a read-only
+       index block or a disk watermark on the indexer
+```
+
+The indexer is not accepting writes. Usually OpenSearch crossed its flood-stage
+watermark and stamped `index.blocks.read_only_allow_delete: true` on the write
+index. Free disk on the indexer; the block releases below the *high* watermark
+(90%), not the flood stage (95%). **Disable the hook before rolling a cluster in
+this state** — it still costs the warmup window per pod.
+
+### RESULT: ABORTED — cannot finish in time
+
+```
+CRIT FEASIBILITY: drain cannot finish in the time available
+CRIT   journal on disk: 5.0GiB of 5.0GiB cap (100% full)
+CRIT   the journal is AT its cap - Graylog is already discarding the oldest
+       segments, so messages are being lost right now
+CRIT   backlog:         999727 messages awaiting processing
+CRIT   drain rate:      107 msg/s measured over 2s (ingest 1200 msg/s)
+CRIT   time to clear:   ~2h35m at that rate
+CRIT   short by:        ~2h34m
+```
+
+Draining, but nowhere near fast enough. The hook gives up immediately rather than
+holding termination to clear a couple of percent. `AT its cap` means data is being
+lost right now regardless of what you do with the pod — deal with the backlog first.
+
+### RESULT: UNKNOWN
+
+```
+RESULT: UNKNOWN - no drain attempted; journal depth was never measurable
+metrics endpoint http://127.0.0.1:9833/metrics did not answer after 5 attempts
+```
+
+No drain happened; the hook could not read the gauge. Check
+`graylog.service.metrics.enabled`, and whether the pod was still starting or already
+unhealthy. `drain abandoned` instead of `no drain attempted` means the endpoint
+answered at preflight and then stopped.
+
+### No prestop-drain lines at all
+
+The hook did not run. Check `graylog.lifecycle.preStopDrain.enabled`, and that you
+are following logs from before termination. Kubernetes discards `preStop` stdout by
+default — these lines are visible only because the hook writes to PID 1's stdout
+deliberately.
+
+## Recovering a stranded journal
+
+If you scaled in without draining, the data is unreachable, not gone. Scale back up
+to the original replica count. The ordinal returns, re-binds its claim, and Graylog
+replays the journal.
+
+Expect late arrivals: days-old messages entering the pipeline will hit alerts,
+dashboards, and index retention. Then drain properly and scale in again.
+
+If the PVC was already deleted but the PV was `Retain`, the PV survives as
+`Released`. It is not immediately reusable — `spec.claimRef` still points at the
+deleted PVC. Clear that, then bind a new PVC with `volumeName` set to the PV.

--- a/docs/graylog-message-handling.md
+++ b/docs/graylog-message-handling.md
@@ -13,7 +13,6 @@ For the values that configure this, see
 - [Scaling in safely](#scaling-in-safely)
 - [Automatic drain on shutdown](#automatic-drain-on-shutdown)
 - [Reading the drain logs](#reading-the-drain-logs)
-- [Failure modes](#failure-modes)
 - [Deleting a leftover PVC](#deleting-a-leftover-pvc)
 - [Recovering a stranded journal](#recovering-a-stranded-journal)
 
@@ -42,9 +41,9 @@ The journal cap and the data volume have to be sized together.
 | `graylog.config.messageJournal.maxSize` | `5gb` | on-disk journal cap |
 | `graylog.persistence.size` | `8Gi` | the whole data volume |
 
-Graylog's suffixes are binary: `5gb` is 5×1024³, which is what the exporter reports
-as `gl_journal_size_limit`. Kubernetes quantities are not the same — `8G` is 8×10⁹,
-`8Gi` is 8×1024³.
+> [!NOTE]
+> Graylog's suffixes are binary: `5gb` is 5×1024³, which is what the exporter reports
+> as `gl_journal_size_limit`. Kubernetes quantities are not the same — `8G` is 8×10⁹, `8Gi` is 8×1024³.
 
 The journal is not alone on that volume. It shares it with the `node-id`, the JVM
 truststore, content packs, and GeoIP databases, and it can briefly overshoot its cap
@@ -95,15 +94,28 @@ or internally generated inputs.
 ```sh
 # list inputs
 curl -su "admin:$PASS" http://localhost:9000/api/system/inputs | jq '.inputs[] | {id, title}'
-# stop one
-curl -su "admin:$PASS" -X DELETE http://localhost:9000/api/system/inputs/<id>
+
+# stop one across the whole cluster (this is the one you want for a scale-in)
+curl -su "admin:$PASS" -H 'X-Requested-By: cli' \
+  -X DELETE http://localhost:9000/api/cluster/inputstates/<id>
 ```
 
 Or **System > Inputs** in the UI. Requires admin auth.
 
+> [!WARNING]
+> Stop inputs via `inputstates`, never `DELETE /api/system/inputs/<id>` — that one is
+> "Terminate input on this node" and removes the input definition. `inputstates` stops
+> a running input and leaves it configured, so `PUT` on the same path starts it again.
+> `/api/system/inputstates/<id>` is the node-scoped variant; `/api/cluster/inputstates/<id>`
+> covers every node, which is what quiesces the journal.
+
+Every state-changing Graylog API call needs an `X-Requested-By` header (any value) or
+it fails with `CSRF protection header is missing`. That applies to the `lbstatus`
+override below too.
+
 **2. Take the node out of rotation.** Graylog publishes its load-balancer state at
-`/api/system/lbstatus` — unauthenticated, returns `200` alive, `429` throttled,
-`503` dead.
+`/api/system/lbstatus` — unauthenticated, and the body is the plain word `ALIVE`,
+`THROTTLED` or `DEAD` with HTTP `200`, `429` or `503` respectively.
 
 ```sh
 kubectl exec -n graylog graylog-2 -- curl -so /dev/null -w '%{http_code}\n' \
@@ -113,9 +125,12 @@ kubectl exec -n graylog graylog-2 -- curl -so /dev/null -w '%{http_code}\n' \
 Force it dead before scaling (requires admin auth):
 
 ```sh
-kubectl exec -n graylog graylog-2 -- curl -su "admin:$PASS" \
+kubectl exec -n graylog graylog-2 -- curl -su "admin:$PASS" -H 'X-Requested-By: cli' \
   -X PUT http://localhost:9000/api/system/lbstatus/override/dead
 ```
+
+Returns `204`. The value is case-insensitive, and `ALIVE`/`DEAD`/`THROTTLED` are the
+only ones accepted. Undo it with `override/alive`; a lifecycle change also resets it.
 
 > [!NOTE]
 > The chart's readiness probe is a TCP check, so `lb_status: DEAD` does not currently
@@ -131,8 +146,12 @@ curl -s localhost:9833/metrics | grep '^gl_journal_entries_uncommitted'
 ```
 
 Port-forward the **pod**, not the Service — the Service answers from an arbitrary
-node. The equivalent REST call is `GET /api/system/journal` (`uncommitted_entries`),
-which needs admin auth; the metrics gauge does not.
+node. The equivalent REST call is `GET /api/system/journal`, which needs admin auth; the
+metrics gauge does not. The field is **`uncommitted_journal_entries`** — not
+`uncommitted_entries`. That response also carries `journal_size`,
+`journal_size_limit`, `number_of_segments`, `oldest_segment`, and a `journal_config`
+block echoing the effective settings, which is the quickest way to confirm a
+`maxSize` change actually took.
 
 **4. Scale down by one and wait.** Do not jump several ordinals at once.
 
@@ -311,6 +330,78 @@ The hook did not run. Check `graylog.lifecycle.preStopDrain.enabled`, and that y
 are following logs from before termination. Kubernetes discards `preStop` stdout by
 default — these lines are visible only because the hook writes to PID 1's stdout
 deliberately.
+
+## Deleting a leftover PVC
+
+Scale-in leaves the highest ordinal's claim behind. The chart never deletes it. The
+decision is yours, and it is not reversible by default.
+
+> [!WARNING]
+> Deleting the PVC is what destroys the data, and most StorageClasses use
+> `reclaimPolicy: Delete` — including this chart's own gp3 class — so the underlying
+> disk goes with it. The chart's retention policy protects the claim from the
+> StatefulSet controller, not from you or from a GitOps prune.
+
+Make the volume survivable first. A PV's reclaim policy is mutable, unlike a
+StorageClass's:
+
+```sh
+PV=$(kubectl get pvc graylog-data-graylog-2 -n graylog -o jsonpath='{.spec.volumeName}')
+kubectl patch pv "$PV" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+```
+
+A PV only picks up its reclaim policy at provision time, so changing the
+StorageClass later does not help existing volumes. Patch the PV.
+
+For GitOps, `graylog.persistence.annotations` flows into the volumeClaimTemplate, so
+`argocd.argoproj.io/sync-options: Prune=false` works — but volumeClaimTemplates are
+effectively immutable, so annotations only land on PVCs created *after* you set
+them. Adding this later does not protect the ordinal you are trying to save.
+
+### Verifying before you delete
+
+The drain verdict is good evidence but point-in-time, and "committed" means read out
+of the journal into the pipeline — the last hop into OpenSearch happens from an
+in-memory buffer during shutdown. Confirm rather than assume. Strongest first:
+
+1. **Re-attach it.** Scale back up by one. The ordinal returns, re-binds the claim,
+   and Graylog replays anything unprocessed. Watch `uncommitted` settle at 0 with
+   inputs stopped, then scale in again and delete. This is both the test and the fix.
+
+2. **Inspect it offline.** Graylog ships a journal CLI, which is the most direct
+   option once the claim is mounted somewhere:
+
+   ```sh
+   # needs a config file with data_dir pointing at the mounted volume
+   graylog journal show --show-segments
+   ```
+
+   `graylog journal decode <range>` reads messages back out. Avoid
+   `graylog journal truncate` unless you intend to discard entries.
+
+   `examples/inspect-orphaned-journal.yaml` mounts the claim read-only and compares
+   the committed offset against the segments without needing a config file.
+
+   ```sh
+   kubectl apply -n graylog -f examples/inspect-orphaned-journal.yaml
+   kubectl logs -n graylog journal-inspector -f
+   kubectl delete -n graylog pod/journal-inspector
+   ```
+
+   > [!IMPORTANT]
+   > This can prove messages **were** stranded, not that they were not. Graylog's
+   > offset index is sparse, so records past the last index entry are invisible to any
+   > offline reader. Measured on a live node: the index looked clean while the node
+   > had 537 unprocessed messages. `NO EVIDENCE OF STRANDED DATA` means no evidence.
+
+Expect the on-disk size to sawtooth — climbing, then dropping ~100MB at once as a
+fully-committed segment is reaped. That is retention, not loss.
+
+Then:
+
+```sh
+kubectl delete pvc graylog-data-graylog-2 -n graylog
+```
 
 ## Recovering a stranded journal
 

--- a/examples/forwarder-ingress.yaml
+++ b/examples/forwarder-ingress.yaml
@@ -1,0 +1,82 @@
+# Graylog Forwarder ingest via AWS ALB
+#
+# A forwarder is configured with a single server hostname plus two ports:
+#   forwarder_message_transmission_port  13301  (log data)
+#   forwarder_configuration_port         13302  (configuration updates)
+#
+# Both must be reachable, on the SAME hostname. The chart therefore renders one
+# Ingress per channel. Give both the same `group.name` so the AWS Load Balancer
+# Controller provisions a SINGLE ALB with two listeners: rules are scoped to the
+# `listen-ports` declared on each Ingress, so each listener reaches its own
+# target group.
+#
+# Prerequisites:
+#   - An enterprise license (the Forwarder is an enterprise feature).
+#   - A Forwarder input created under System > Forwarders. Graylog does not bind
+#     13301/13302 until one exists, so ALB targets stay unhealthy until then.
+#   - An ACM certificate covering the ingest hostname. The ALB terminates TLS and
+#     speaks cleartext HTTP/2 to Graylog, so the forwarder should be configured
+#     with forwarder_grpc_enable_tls = true.
+#
+ingress:
+  enabled: true
+  forwarder:
+    enabled: true
+
+    # Message channel — log data, port 13301.
+    messageChannel:
+      enabled: true
+      className: alb
+      annotations:
+        alb.ingress.kubernetes.io/group.name: my-graylog
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 13301}]'
+        alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:123456789012:certificate/REPLACE-ME
+        alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+        alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+        alb.ingress.kubernetes.io/healthcheck-port: "13301"
+        alb.ingress.kubernetes.io/healthcheck-path: /grpc.health.v1.Health/Check
+        # gRPC status codes: 0 = OK, 12 = UNIMPLEMENTED. Accepting 12 keeps the
+        # target healthy when the endpoint answers gRPC but does not serve the
+        # standard health service.
+        alb.ingress.kubernetes.io/success-codes: "0,12"
+        alb.ingress.kubernetes.io/healthcheck-interval-seconds: "10"
+        alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+        alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+        alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        external-dns.alpha.kubernetes.io/hostname: ingest-my-graylog.example.com
+      hosts:
+        - host: ingest-my-graylog.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+
+    # Configuration channel — configuration polling, port 13302.
+    # Same hostname and same ALB group; only the ports differ.
+    configChannel:
+      enabled: true
+      className: alb
+      annotations:
+        alb.ingress.kubernetes.io/group.name: my-graylog
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 13302}]'
+        alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:123456789012:certificate/REPLACE-ME
+        alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+        alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+        alb.ingress.kubernetes.io/healthcheck-port: "13302"
+        alb.ingress.kubernetes.io/healthcheck-path: /grpc.health.v1.Health/Check
+        alb.ingress.kubernetes.io/success-codes: "0,12"
+        alb.ingress.kubernetes.io/healthcheck-interval-seconds: "10"
+        alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+        alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+        alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        external-dns.alpha.kubernetes.io/hostname: ingest-my-graylog.example.com
+      hosts:
+        - host: ingest-my-graylog.example.com
+          paths:
+            - path: /
+              pathType: Prefix

--- a/examples/inspect-orphaned-journal.yaml
+++ b/examples/inspect-orphaned-journal.yaml
@@ -1,0 +1,156 @@
+# Inspect the journal left behind by a scaled-in Graylog node.
+#
+# When you reduce graylog.replicas, the highest ordinal disappears but its PVC is
+# retained. Nothing will ever mount that claim again, so anything still unprocessed
+# in its journal is stranded. This pod mounts the claim READ-ONLY and reports what
+# is on it, so you can decide whether the PVC is safe to delete.
+#
+# ── Usage ────────────────────────────────────────────────────────────────────
+#   # 1. scale in (drain first - see docs/graylog-message-handling.md)
+#   helm upgrade graylog graylog/graylog -n graylog --set graylog.replicas=3 --reuse-values
+#
+#   # 2. confirm the claim of the removed ordinal is still there
+#   kubectl get pvc -n graylog | grep data
+#
+#   # 3. point CLAIM_NAME below at it, then
+#   kubectl apply -n graylog -f inspect-orphaned-journal.yaml
+#   kubectl logs -n graylog journal-inspector -f
+#   kubectl delete -n graylog pod/journal-inspector
+#
+# The claim is named <fullname>-data-<statefulset>-<ordinal>, e.g. for release
+# "graylog" scaling 3 -> 2 the orphan is:
+#   graylog-data-graylog-2
+#
+# Graylog also ships a journal CLI that reads the same files, if you would rather
+# mount the claim yourself and run it against a config whose data_dir points at the
+# mount: `graylog journal show --show-segments`. Do not use `journal truncate`
+# unless you intend to discard entries.
+#
+# ── What this can and cannot tell you ────────────────────────────────────────
+# It CAN prove that messages were stranded: if the committed offset sits below an
+# offset the index shows was written, those messages were never processed.
+#
+# It CANNOT prove the opposite. Graylog's offset index is sparse, so the highest
+# offset it records is only a lower bound on what the segment holds - a journal
+# can look clean here and still have unprocessed records past the last index
+# entry. Measured on a live node: committed was 2750 offsets beyond the last index
+# entry while the live gauge still reported 386 uncommitted messages.
+#
+# For a definitive answer, put the volume back under a running Graylog: scale the
+# StatefulSet back up by one. The ordinal returns, re-binds this same claim, and
+# replays anything unprocessed. Watch gl_journal_entries_uncommitted on that pod;
+# if it settles at 0 with inputs quiesced, nothing was stranded. That is both the
+# test and the fix - if something WAS stranded, replaying it is what you wanted.
+#
+# ── Constraints ──────────────────────────────────────────────────────────────
+#   * RWO: the claim must not be attached elsewhere. After a scale-in the pod is
+#     gone, but an ungraceful node loss can hold the attachment for ~6 minutes.
+#   * Zonal block storage: this pod must schedule into the volume's AZ. The PV's
+#     nodeAffinity handles that automatically; if it cannot be satisfied the pod
+#     just sits Pending.
+#   * readOnly on both the mount and the volume, so inspection cannot alter the
+#     journal or advance any offset.
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: journal-inspector
+  labels:
+    app.kubernetes.io/name: journal-inspector
+spec:
+  restartPolicy: Never
+  # Matches the Graylog pod's context: the journal is mode 2770 owned by
+  # 1100:1100, so a different uid cannot read it.
+  securityContext:
+    runAsUser: 1100
+    runAsGroup: 1100
+    fsGroup: 1100
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: inspect
+      # The Graylog image is already present on the nodes and has od/awk/stat.
+      # Any busybox-class image works; keep the tag in step with your release.
+      image: graylog/graylog-enterprise:7.1.6-1
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -u
+          J=/mnt/journal/journal
+          echo "=== orphaned journal: ${J} ==="
+          if [ ! -d "${J}" ]; then
+            echo "no journal directory on this claim - nothing was ever written, or"
+            echo "the mount path differs from the chart default."
+            ls -la /mnt/journal || true
+            exit 0
+          fi
+
+          OFFSET_FILE="${J}/graylog2-committed-read-offset"
+          if [ ! -f "${OFFSET_FILE}" ]; then
+            echo "VERDICT: UNKNOWN - no committed-read-offset file."
+            echo "Cannot tell what was processed. Do not delete this claim without"
+            echo "re-attaching it to a running Graylog."
+            exit 0
+          fi
+          COMMITTED=$(cat "${OFFSET_FILE}")
+          echo "committed-read-offset (last message processed): ${COMMITTED}"
+          echo
+          echo "segments (filename = first offset the segment holds):"
+          for f in "${J}"/messagejournal-0/*.log; do
+            [ -e "${f}" ] || { echo "  (none)"; break; }
+            base=$(basename "${f}" .log | sed 's/^0*//')
+            printf '  base=%-14s %8.1f MiB   last modified %s\n' \
+              "${base}" "$(stat -c %s "${f}" | awk '{print $1/1048576}')" "$(stat -c %y "${f}" | cut -d. -f1)"
+          done
+          echo
+
+          # Highest offset the sparse index proves was written. Index entries are
+          # 8 bytes: 4-byte offset relative to the segment base, 4-byte file
+          # position. The file is preallocated and zero-filled, so the last
+          # non-zero pair is the tail.
+          LAST_LOG=$(ls "${J}"/messagejournal-0/*.log 2>/dev/null | sort | tail -1)
+          [ -n "${LAST_LOG}" ] || { echo "no segments; journal is empty."; exit 0; }
+          BASE=$(basename "${LAST_LOG}" .log | sed 's/^0*//')
+          IDX="${J}/messagejournal-0/$(basename "${LAST_LOG}" .log).index"
+          REL=0
+          [ -f "${IDX}" ] && REL=$(od -An -tu4 -w8 "${IDX}" | awk '$1 != 0 || $2 != 0 {rel=$1} END{print rel+0}')
+          KNOWN_WRITTEN=$(( BASE + REL ))
+          echo "highest offset the index proves was written: ${KNOWN_WRITTEN}"
+          echo
+
+          if [ "${COMMITTED}" -lt "${KNOWN_WRITTEN}" ]; then
+            echo "VERDICT: STRANDED DATA - at least $(( KNOWN_WRITTEN - COMMITTED )) messages"
+            echo "were written past the committed offset and never processed."
+            echo
+            echo "DO NOT DELETE this claim. Scale the StatefulSet back up by one so the"
+            echo "ordinal returns, re-binds this volume and replays them. Expect late"
+            echo "arrivals to hit alerts, dashboards and index retention."
+          else
+            echo "VERDICT: NO EVIDENCE OF STRANDED DATA."
+            echo
+            echo "The committed offset is at or beyond every offset the index records,"
+            echo "so the segments on disk hold already-processed messages retained for"
+            echo "messageJournal.maxAge. Their size is retention, not backlog."
+            echo
+            echo "This is NOT proof the journal was empty: the index is sparse, so"
+            echo "records after the last index entry are invisible here. If you need"
+            echo "certainty, scale back up by one and watch"
+            echo "gl_journal_entries_uncommitted settle at 0 before deleting."
+          fi
+      volumeMounts:
+        - name: orphaned-journal
+          mountPath: /mnt/journal
+          readOnly: true
+  volumes:
+    - name: orphaned-journal
+      persistentVolumeClaim:
+        # CHANGE ME to the claim of the ordinal you removed.
+        claimName: graylog-data-graylog-2
+        readOnly: true


### PR DESCRIPTION
## Summary
Makes the Graylog message journal safe to operate: the chart now refuses configurations where the journal silently isn't durable, stops the init script from re-initializing a live data volume, and adds an opt-in preStop hook that works the on-disk journal off before a pod goes away. The drain is **best-effort** — it is not a substitute for the documented scale-in runbook.

## Details

**Guardrails (#123)**
- New `graylog.journal.validate` helper fails rendering when `messageJournal.enabled` is truthy while `persistence.enabled=false` and no `existingClaim` is set — the case where the journal lands on an `emptyDir` while Graylog believes its write-ahead log is durable. The failure message spells out the three valid resolutions, including the `--set-string` caveat for the string-typed `enabled` field.
- Journal cap vs. volume sizing: `messageJournal.maxSize` (now explicit at `5gb`) is validated against `persistence.size` at a 90% threshold, since the journal shares the volume with node-id, truststore, content packs and GeoIP data. The error suggests both a lower cap and a larger volume.
- `persistence.retentionPolicy` is now explicit (`whenDeleted`/`whenScaled: Retain`) on both Graylog and Datanode. `whenScaled: Delete` is rejected for Graylog — it would destroy exactly the journal the drain exists to protect — but permitted for Datanode, where shard data can be rebuilt from replicas.
- `terminationGracePeriodSeconds` is exposed and defaults to `300`; the Kubernetes default of 30s is not enough to flush buffers under load.

**Init sentinel (#124)**
- `init-graylog.yaml` now uses a dedicated `/mnt/data/.initialized` marker instead of the journal lock file, so volume initialization no longer depends on journal configuration.
- Volumes carrying the old `journal/.lock` but no marker are *adopted*, not re-copied — re-running the copy there would clobber a live volume.
- The marker is written only on a successful copy, and a failed copy now exits non-zero instead of leaving a half-initialized volume.

**preStop drain (#122)**
- New `files/scripts/prestop-drain.sh` plus a `_prestop-drain.tpl` container snippet, gated behind `graylog.lifecycle.preStopDrain.enabled` (off by default — it slows every rolling upgrade by the drain time).
- Journal depth is read from the unauthenticated Prometheus exporter (requires `graylog.service.metrics.enabled`), so no admin credentials are needed.
- Waits `endpointPropagationDelaySeconds` for EndpointSlice removal to reach kube-proxy before sampling, and always leaves `shutdownReserveSeconds` of the grace period to Graylog's own shutdown so the container is never SIGKILLed mid-flush.
- Stall detection measures progress as *reaching a new low*, not equality with the previous sample. Under live ingest the gauge oscillates (observed 31, 82, 36, 126, 231, 9, 3), so the original equality check never fired and the hook burned its full budget — a 259s termination. On the same workload it now finishes in 89s.
- Feasibility projection (`feasibilityWarmupPolls`): after a warmup the drain rate is measured and the finish time projected. A backlog that cannot clear in the remaining budget logs a CRIT verdict (journal size, measured rate, time to clear, shortfall) and gives the grace period back immediately rather than holding termination per pod to clear a few percent.
- `confirmPolls` requires depth to hold at zero across consecutive polls before declaring success, and `metricsRetries` tolerates transient scrape failures.
- Observability: kubelet discards preStop stdout (it surfaces only truncated, in a `FailedPreStopHook` event, and only on failure). `log()` now also writes to `/proc/1/fd/1` so the drain appears in the container log stream.

**Docs**
- New `docs/graylog-message-handling.md` (~330 lines): what the journal protects, sizing, the scale-in runbook with the API endpoints (`/api/system/lbstatus`, `/api/system/journal`), how to audit orphaned PVCs, and the limits of the preStop hook.
- README section on message handling and safe scale-down.

**Also on this branch** (incidental, reviewed together)
- `fix(forwarder-ingress)`: reworked forwarder ingress into separate message (13301) and configuration (13302) channels with dedicated name helpers, plus `examples/forwarder-ingress.yaml`.
- `fix(secrets)`: accept secret peppers of exactly 64 characters.
- `fix(values)`: removed persistence values the templates never consumed (`mountPath`, `selector`, per-volume `existingClaim`/`dataSource`).

## Linked issues
This fixes #122
This fixes #123
This fixes #124

## PR Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [ ] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog`
- [ ] Helm tests pass: `helm test graylog`

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] Inputs can be created and receive data

### Specific to this PR
- Unit tests: `prestop_drain_test.yaml`, `journal_config_test.yaml`, `journal_persistence_test.yaml`, `init_graylog_test.yaml`, `graylog_secret_test.yaml`, `forwarder_*_test.yaml`, `datanode_statefulset_test.yaml`.
- Behavioral shell tests for the two scripts: `tests/scripts/prestop-drain-behavior-test.sh` and `tests/scripts/init-graylog-behavior-test.sh`.
- Drain observed against a live cluster under continuous ingest: full drain completed in 89s; the stall and feasibility paths were both exercised, and progress lines were confirmed visible in the container log.
- Upgrade path verified on a volume initialized by an earlier chart version (`journal/.lock` present, no marker): adopted without re-copy.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable

The preStop drain is deliberately **off by default** and **best-effort**: endpoint removal only sheds new connections, so long-lived TCP and UDP senders keep writing and the journal may never reach zero. The docs runbook remains the authoritative procedure for a guaranteed-safe scale-in.
