### PR TITLE
fix(values): Remove unused persistence configuration values

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -822,12 +822,10 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.persistence.storageClass`                                    | Storage class for the persistent volume.                    | `""`                            |
 | `graylog.persistence.volumeNameOverride`                              | Override name of the persistent volume.                     | `""`                            |
 | `graylog.persistence.existingClaim`                                   | Use an existing PVC.                                        | `""`                            |
-| `graylog.persistence.mountPath`                                       | Path where volume will be mounted.                          | `""`                            |
 | `graylog.persistence.accessModes`                                     | Access modes for the persistent volume.                     | `[]`                            |
 | `graylog.persistence.size`                                            | Size of the persistent volume.                              | `""`                            |
 | `graylog.persistence.annotations`                                     | Annotations for the persistent volume claim.                | `{}`                            |
 | `graylog.persistence.labels`                                          | Labels for the persistent volume claim.                     | `{}`                            |
-| `graylog.persistence.selector`                                        | Selector for the persistent volume.                         | `{}`                            |
 | `graylog.livenessProbe.enabled`                                       | Enable liveness probe.                                      | `true`                          |
 | `graylog.livenessProbe.initialDelaySeconds`                           | Initial delay for liveness probe.                           | `60`                            |
 | `graylog.livenessProbe.periodSeconds`                                 | Period between liveness probe checks.                       | `10`                            |
@@ -907,26 +905,16 @@ These values affect Graylog, DataNode, and MongoDB.
 | `datanode.resources.limits.memory`                     | Memory limit for the datanode pod.              | `"5Gi"`           |
 | `datanode.resources.requests.cpu`                      | CPU request for the datanode pod.               | `"500m"`          |
 | `datanode.resources.requests.memory`                   | Memory request for the datanode pod.            | `"3.5Gi"`         |
-| `datanode.persistence.enabled`                         | Enable persistence.                             | `true`            |
 | `datanode.persistence.data.enabled`                    | Enable persistent volume for data.              | `true`            |
 | `datanode.persistence.data.storageClass`               | Storage class for data PVC.                     | `""`              |
-| `datanode.persistence.data.existingClaim`              | Use existing PVC for data.                      | `""`              |
 | `datanode.persistence.data.mountPath`                  | Mount path for data volume.                     | `""`              |
 | `datanode.persistence.data.accessModes`                | Access modes for data PVC.                      | `[]`              |
 | `datanode.persistence.data.size`                       | Size of the data volume.                        | `"8Gi"`           |
-| `datanode.persistence.data.annotations`                | Annotations for data PVC.                       | `{}`              |
-| `datanode.persistence.data.labels`                     | Labels for data PVC.                            | `{}`              |
-| `datanode.persistence.data.selector`                   | Selector for data PVC.                          | `{}`              |
-| `datanode.persistence.data.dataSource`                 | Data source for data PVC.                       | `{}`              |
 | `datanode.persistence.nativeLibs.enabled`              | Enable persistence for native libraries.        | `false`           |
 | `datanode.persistence.nativeLibs.storageClass`         | Storage class for native libs PVC.              | `""`              |
-| `datanode.persistence.nativeLibs.existingClaim`        | Use existing PVC for native libs.               | `""`              |
 | `datanode.persistence.nativeLibs.mountPath`            | Mount path for native libs volume.              | `""`              |
 | `datanode.persistence.nativeLibs.accessModes`          | Access modes for native libs PVC.               | `[]`              |
 | `datanode.persistence.nativeLibs.size`                 | Size of the native libs volume.                 | `"2Gi"`           |
-| `datanode.persistence.nativeLibs.annotations`          | Annotations for native libs PVC.                | `{}`              |
-| `datanode.persistence.nativeLibs.labels`               | Labels for native libs PVC.                     | `{}`              |
-| `datanode.persistence.nativeLibs.selector`             | Selector for native libs PVC.                   | `{}`              |
 | `datanode.livenessProbe.enabled`                       | Enable liveness probe.                          | `true`            |
 | `datanode.livenessProbe.initialDelaySeconds`           | Initial delay for liveness probe.               | `30`              |
 | `datanode.livenessProbe.periodSeconds`                 | Period between liveness probe checks.           | `10`              |

--- a/charts/graylog/values.schema.json
+++ b/charts/graylog/values.schema.json
@@ -380,16 +380,12 @@
             "storageClass": { "type": [ "string", "null" ] },
             "volumeNameOverride": { "type": [ "string", "null" ] },
             "existingClaim": { "type": [ "string", "null" ] },
-            "mountPath": { "type": [ "string", "null" ] },
             "accessModes": { "type": "array" },
             "size": { "type": [ "string", "null" ] },
             "annotations": {
               "type": "object"
             },
             "labels": {
-              "type": "object"
-            },
-            "selector": {
               "type": "object"
             }
           }
@@ -568,28 +564,14 @@
         "persistence": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" },
             "data": {
               "type": "object",
               "properties": {
                 "enabled": { "type": "boolean" },
                 "storageClass": { "type": "string" },
-                "existingClaim": { "type": "string" },
                 "mountPath": { "type": "string" },
                 "accessModes": { "type": "array" },
-                "size": { "type": "string" },
-                "annotations": {
-                  "type": "object"
-                },
-                "labels": {
-                  "type": "object"
-                },
-                "selector": {
-                  "type": "object"
-                },
-                "dataSource": {
-                  "type": "object"
-                }
+                "size": { "type": "string" }
               }
             },
             "nativeLibs": {
@@ -597,19 +579,9 @@
               "properties": {
                 "enabled": { "type": "boolean" },
                 "storageClass": { "type": "string" },
-                "existingClaim": { "type": "string" },
                 "mountPath": { "type": "string" },
                 "accessModes": { "type": "array" },
-                "size": { "type": "string" },
-                "annotations": {
-                  "type": "object"
-                },
-                "labels": {
-                  "type": "object"
-                },
-                "selector": {
-                  "type": "object"
-                }
+                "size": { "type": "string" }
               }
             }
           }

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -266,14 +266,12 @@ graylog:
     # existingClaim mounts a pre-provisioned PVC instead of using a
     # volumeClaimTemplate.
     existingClaim:
-    mountPath:
     # accessModes defaults to ["ReadWriteOnce"] when empty.
     accessModes: []
     # size is the requested volume size (default 8Gi).
     size:
     annotations: {}
     labels: {}
-    selector: {}
   # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
   # for the Graylog container (TCP checks against the app port).
   livenessProbe:
@@ -407,36 +405,22 @@ datanode:
     requests:
       cpu: "500m"
       memory: "3.5Gi"
-  # persistence configures the Datanode volumes. Each volume consumes its
-  # enabled, storageClass, mountPath, accessModes, and size fields; the
-  # remaining fields (existingClaim, annotations, labels, selector,
-  # dataSource) and the parent enabled flag are currently not consumed by
-  # the templates.
+  # persistence configures the Datanode volumes.
   persistence:
-    enabled: true
     # data is the OpenSearch data volume.
     data:
       enabled: true
       storageClass: ""
-      existingClaim: ""
       mountPath: ""
       accessModes: []
       size: "8Gi"
-      annotations: {}
-      labels: {}
-      selector: {}
-      dataSource: {}
     # nativeLibs is an optional volume for OpenSearch native libraries.
     nativeLibs:
       enabled: false
       storageClass: ""
-      existingClaim: ""
       mountPath: ""
       accessModes: []
       size: "2Gi"
-      annotations: {}
-      labels: {}
-      selector: {}
   # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
   # for the Datanode container.
   livenessProbe:

--- a/examples/values/values-example-aws.yaml
+++ b/examples/values/values-example-aws.yaml
@@ -24,7 +24,6 @@ graylog:
 datanode:
   replicas: 3
   persistence:
-    enabled: true
     data:
       enabled: true
       storageClass: "gp3"


### PR DESCRIPTION
## Summary
Removes persistence values that are defined in values.yaml but never consumed by any template, so users no longer configure them expecting an effect. No rendered output changes.

## Details
- Remove `graylog.persistence.mountPath` and `graylog.persistence.selector`. `annotations`/`labels` stay — they are rendered into the volumeClaimTemplate.
- Remove the unreferenced Datanode fields: the parent `persistence.enabled` flag (templates only consult `data.enabled`/`nativeLibs.enabled`), `existingClaim` on both volumes, `data.dataSource`, and `annotations`/`labels`/`selector` on both volumes. The parent flag, both `existingClaim`s, and `dataSource` are not listed in #120 but were equally dead.
- Drop the same fields from values.schema.json and the README values tables; the AWS example no longer sets the dead parent flag.
- The schema stays permissive (`additionalProperties` unset), so stale keys in existing values files are still ignored silently rather than erroring. Strict validation would be a chart-wide decision — flagging it here as a possible follow-up issue.

## Linked issues
This fixes #120

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [x] All 162 helm-unittest tests pass unchanged. Rendering with the removed keys supplied produces byte-identical manifests to rendering without them, so there is no behavior change to install or upgrade. Server-side `--validate` was run with `mongodb.communityResource.enabled=false` + an external URI (the local cluster has no MongoDB operator, so defaults hit the intentional CRD guard).

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
