### PR TITLE
fix(secrets): Accept secret peppers of exactly 64 characters

### DIFF
--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -207,7 +207,7 @@ Graylog secret pepper
 */}}
 {{- define "graylog.secretPepper" }}
 {{- $pepper := .Values.graylog.config.customSecretPepper | default (randAlphaNum 96) }}
-{{- if len $pepper | ge 64 }}
+{{- if lt (len $pepper) 64 }}
 {{- fail "Use at least 64 characters when setting a secret to pepper the stored user data." }}
 {{- else }}
 {{- print $pepper }}

--- a/charts/graylog/tests/graylog_secret_test.yaml
+++ b/charts/graylog/tests/graylog_secret_test.yaml
@@ -102,3 +102,41 @@ tests:
     asserts:
       - notExists:
           path: data.graylog-root-password
+
+  # B-02: the pepper minimum-length check was written as `len $pepper | ge 64`,
+  # which pipes the length in as the LAST argument (`ge 64 <len>` = 64 >= len)
+  # and so rejected a pepper of exactly 64 characters while the error message
+  # promises "at least 64" is fine. These pin the boundary on both sides.
+  - it: rejects a custom secret pepper shorter than 64 characters
+    set:
+      graylog.config.customSecretPepper: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    asserts:
+      - failedTemplate:
+          errorPattern: "at least 64 characters"
+
+  - it: accepts a custom secret pepper of exactly 64 characters
+    set:
+      graylog.config.customSecretPepper: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: data.GRAYLOG_PASSWORD_SECRET
+          value: YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==
+
+  - it: accepts a custom secret pepper longer than 64 characters
+    set:
+      graylog.config.customSecretPepper: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: data.GRAYLOG_PASSWORD_SECRET
+          value: YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh
+
+  - it: backs up the custom secret pepper in the backup secret
+    set:
+      graylog.config.customSecretPepper: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: data.graylog-secret
+          value: YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==


### PR DESCRIPTION
## Summary
Fixes the secret-pepper minimum-length validation so a `graylog.config.customSecretPepper` of exactly 64 characters is accepted, matching the documented "at least 64 characters" requirement.

## Details
- Go template pipelines pass the piped value as the last argument, so the old `len $pepper | ge 64` evaluated as `64 >= length` — it correctly rejected short peppers and accepted 65+, but wrongly rejected exactly 64. The condition is now the explicit `lt (len $pepper) 64`, which fails only below the minimum.
- Note for reviewers: the diff intentionally differs from the fix proposed in #118. `len $pepper | lt 64` evaluates as `64 < length` and would reject every pepper longer than 64 characters while accepting short ones.
- Adds 4 unit tests pinning the boundary: 63 chars fails with the "at least 64 characters" error; exactly 64 and 96 chars render into `GRAYLOG_PASSWORD_SECRET`; the custom pepper lands in the backup secret.

## Linked issues
This fixes #118

## PR Checklist
Please check the items that apply to your change.

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

### Specific to this PR
- [x] Boundary renders verified before/after: 63 chars fails, 64/65/96 chars pass, and the default generated-pepper path still renders. All 166 helm-unittest tests pass (4 new). A chart-wide sweep found no other piped comparison operators with the same reversed-argument issue. Server-side `--validate` run with external-MongoDB overrides (local cluster has no MongoDB operator).

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
