### PR TITLE
fix(helpers): Prefer an explicit externalUri over the Service lookup

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -274,6 +274,31 @@ pre-existing dependencies.
 helm upgrade graylog graylog/graylog -n graylog --set graylog.service.type="LoadBalancer" --reuse-values
 ```
 
+### Override the public URI
+The chart gives Graylog a public URI in `GRAYLOG_HTTP_EXTERNAL_URI`. Browsers and API clients use this URI.
+The chart reads it from the Ingress hostname or from the LoadBalancer Service address.
+
+These two sources are not always correct. The public URI differs from them in these cases:
+
+- Graylog is behind a path prefix, such as `https://example.com/graylog/`.
+- An external proxy or CDN answers on a different name.
+- TLS ends outside the cluster, so the public scheme is `https` but the Ingress has no TLS.
+- The Ingress has more than one hostname, and the first one is not the public one.
+
+In these cases, set the URI directly:
+
+```sh
+helm upgrade graylog graylog/graylog -n graylog --set graylog.config.network.externalUri="https://logs.example.com/graylog" --reuse-values
+```
+
+This value comes before the Ingress hostnames and the LoadBalancer Service address.
+Only `graylog.config.tls.cn` comes before this value, and only when `graylog.config.tls.enabled` is `true`.
+
+Use the full URI form in all four cases. A bare hostname becomes `<scheme>://<hostname>:<port>/`.
+The chart takes this scheme from `graylog.config.tls.enabled` and this port from `graylog.service.ports.app`.
+Both values describe the connection to the pod, not the public endpoint.
+A bare hostname is therefore not correct behind an Ingress, a proxy, a CDN, or external TLS.
+
 ### Temporary access: Port Forwarding
 Finally, if you wish to enable external access _temporarily_, you can always use port forwarding:
 
@@ -765,7 +790,7 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.config.network.maxHeaderSize`                                | Max header size.                                            | `"8192"`                        |
 | `graylog.config.network.readTimeout`                                  | Network read timeout.                                       | `"10s"`                         |
 | `graylog.config.network.threadPoolSize`                               | Network thread pool size.                                   | `"64"`                          |
-| `graylog.config.network.externalUri`                                  | External URI for Graylog web interface.                     | `""`                            |
+| `graylog.config.network.externalUri`                                  | Public URI of the Graylog web interface. Comes before the Ingress hostnames and the LoadBalancer Service address, so upgrades do not restart the pods when the load balancer address changes. Give a full URI. A bare hostname gets the chart scheme and the app port. | `""`                            |
 | `graylog.config.performance.asyncEventbusProcessors`                  | Async event bus processors.                                 | `"2"`                           |
 | `graylog.config.performance.autoRestartInputs`                        | Automatically restart inputs.                               | `"false"`                       |
 | `graylog.config.performance.inputBufferProcessors`                    | Input buffer processors.                                    | `"2"`                           |
@@ -812,7 +837,7 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.image.imagePullPolicy`                                       | Pull policy for Graylog image.                              | `IfNotPresent`                  |
 | `graylog.image.imagePullSecrets`                                      | Pull secrets for image.                                     | `[]`                            |
 | `graylog.updateStrategy.type`                                         | Pod update strategy for StatefulSet.                        | `"RollingUpdate"`               |
-| `graylog.updateStrategy.rollingUpdate.maxUnavailable`                 | Max unavailable pods during an update.                      | `1`                             |
+| `graylog.updateStrategy.rollingUpdate.maxUnavailable`                 | Max unavailable pods during an update. Honored only where the `MaxUnavailableStatefulSet` feature gate is enabled, silently dropped otherwise. | `1`                             |
 | `graylog.updateStrategy.rollingUpdate.partition`                      | Pods that will remain unaffected by the update.             | `""`                            |
 | `graylog.resources.limits.cpu`                                        | CPU limit for the Graylog pod.                              | `"2"`                           |
 | `graylog.resources.limits.memory`                                     | Memory limit for the Graylog pod.                           | `"2Gi"`                         |
@@ -899,7 +924,7 @@ These values affect Graylog, DataNode, and MongoDB.
 | `datanode.image.imagePullPolicy`                       | Image pull policy.                              | `IfNotPresent`    |
 | `datanode.image.imagePullSecrets`                      | Image pull secrets.                             | `[]`              |
 | `datanode.updateStrategy.type`                         | Pod update strategy for StatefulSet.            | `"RollingUpdate"` |
-| `datanode.updateStrategy.rollingUpdate.maxUnavailable` | Max unavailable pods during an update.          | `1`               |
+| `datanode.updateStrategy.rollingUpdate.maxUnavailable` | Max unavailable pods during an update. Honored only where the `MaxUnavailableStatefulSet` feature gate is enabled, silently dropped otherwise. | `1`               |
 | `datanode.updateStrategy.rollingUpdate.partition`      | Pods that will remain unaffected by the update. | `""`              |
 | `datanode.resources.limits.cpu`                        | CPU limit for the datanode pod.                 | `"1"`             |
 | `datanode.resources.limits.memory`                     | Memory limit for the datanode pod.              | `"5Gi"`           |

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -478,16 +478,29 @@ Graylog Publish URI
 {{- end }}
 
 {{/*
-Graylog External URI
+Graylog External URI, or "" when no source gives a hostname.
+An explicit network.externalUri skips the Service lookup, so a changed load
+balancer address cannot restart the pods. A bare hostname gets the tls.enabled
+scheme and the app port, so a public endpoint needs the full URI form.
 */}}
 {{- define "graylog.externalUri" }}
+{{- $externalUri := "" }}
 {{- $externalHost := "" }}
 {{- $scheme := "http" }}
 {{- $port := include "graylog.service.port.app" . | printf ":%s" }}
-{{- $svc := include "graylog.service.name" . | lookup "v1" "Service" .Release.Namespace }}
+{{- $explicit := .Values.graylog.config.network.externalUri | default "" }}
 {{- if and .Values.graylog.config.tls.enabled .Values.graylog.config.tls.cn }}
   {{- $externalHost = .Values.graylog.config.tls.cn }}
   {{- $scheme = "https" }}
+{{- else if $explicit }}
+  {{- if contains "://" $explicit }}
+    {{- $externalUri = printf "%s/" (trimSuffix "/" $explicit) }}
+  {{- else }}
+    {{- $externalHost = $explicit }}
+    {{- if .Values.graylog.config.tls.enabled }}
+      {{- $scheme = "https" }}
+    {{- end }}
+  {{- end }}
 {{- else if and .Values.ingress.enabled .Values.ingress.web.enabled .Values.ingress.web.tls }}
   {{- with .Values.ingress.web.tls }}
     {{- with (index . 0).hosts }}
@@ -503,12 +516,16 @@ Graylog External URI
     {{- end }}
   {{- end }}
   {{- $port = "" }}
-{{- else if eq .Values.graylog.service.type "LoadBalancer" | and $svc $svc.status.loadBalancer }}
-  {{- $lbName := index $svc.status.loadBalancer.ingress 0 }}
-  {{- $externalHost = coalesce $lbName.hostname $lbName.ip }}
+{{- else if eq .Values.graylog.service.type "LoadBalancer" }}
+  {{- $svc := include "graylog.service.name" . | lookup "v1" "Service" .Release.Namespace }}
+  {{- if and $svc $svc.status.loadBalancer $svc.status.loadBalancer.ingress }}
+    {{- $lb := index $svc.status.loadBalancer.ingress 0 }}
+    {{- $externalHost = coalesce $lb.hostname $lb.ip }}
+  {{- end }}
 {{- end }}
-{{- $externalHost = $externalHost | default .Values.graylog.config.network.externalUri }}
-{{- if $externalHost }}
+{{- if $externalUri }}
+  {{- $externalUri }}
+{{- else if $externalHost }}
   {{- printf "%s://%s%s/" $scheme $externalHost $port }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/tests/externaluri_test.yaml
+++ b/charts/graylog/tests/externaluri_test.yaml
@@ -1,0 +1,128 @@
+suite: graylog external URI
+templates:
+  - config/graylog.yaml
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  - it: omits GRAYLOG_HTTP_EXTERNAL_URI by default
+    asserts:
+      - notExists:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+
+  - it: wraps a bare hostname with scheme and app port
+    set:
+      graylog.config.network.externalUri: "logs.example.com"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "http://logs.example.com:9000/"
+
+  - it: uses https for a bare hostname when TLS is enabled
+    set:
+      graylog.config.tls.enabled: true
+      graylog.config.network.externalUri: "logs.example.com"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "https://logs.example.com:9000/"
+
+  - it: passes a full URI through verbatim and appends the trailing slash
+    set:
+      graylog.config.network.externalUri: "https://logs.example.com"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "https://logs.example.com/"
+
+  - it: does not double an existing trailing slash on a full URI
+    set:
+      graylog.config.network.externalUri: "https://logs.example.com/"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "https://logs.example.com/"
+
+  - it: preserves an explicit port in a full URI
+    set:
+      graylog.config.network.externalUri: "http://logs.example.com:8443"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "http://logs.example.com:8443/"
+
+  - it: prefers tls.cn over the explicit externalUri
+    set:
+      graylog.config.tls.enabled: true
+      graylog.config.tls.cn: "graylog.example.com"
+      graylog.config.network.externalUri: "https://other.example.com"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "https://graylog.example.com:9000/"
+
+  - it: prefers the explicit externalUri over the ingress host
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.web.hosts:
+        - host: gl.example.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      graylog.config.network.externalUri: "https://other.example.com/graylog"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "https://other.example.com/graylog/"
+
+  - it: prefers the explicit externalUri over the ingress TLS host
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.web.hosts:
+        - host: gl.example.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      ingress.web.tls:
+        - secretName: gl-tls
+          hosts:
+            - gl.example.com
+      graylog.config.network.externalUri: "https://other.example.com"
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "https://other.example.com/"
+
+  - it: uses the ingress host when no externalUri is set
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.web.hosts:
+        - host: gl.example.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "http://gl.example.com/"
+
+  - it: uses the ingress TLS host when no externalUri is set
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.web.hosts:
+        - host: gl.example.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      ingress.web.tls:
+        - secretName: gl-tls
+          hosts:
+            - gl.example.com
+    asserts:
+      - equal:
+          path: data.GRAYLOG_HTTP_EXTERNAL_URI
+          value: "https://gl.example.com/"

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -127,8 +127,9 @@ graylog:
       maxHeaderSize: "8192"
       readTimeout: "10s"
       threadPoolSize: "64"
-      # externalUri is the public URI of the Graylog web interface, used when
-      # it cannot be derived from the Service, Ingress, or TLS configuration.
+      # externalUri is the public URI of the Graylog web interface. It comes
+      # before the Ingress hostnames and the LoadBalancer address. Give a full
+      # URI: a bare hostname gets the chart scheme and app port.
       externalUri: ""
     # performance maps to the processing/buffer tuning knobs of server.conf.
     performance:
@@ -242,7 +243,9 @@ graylog:
     imagePullPolicy: IfNotPresent
     # imagePullSecrets overrides global.imagePullSecrets for this image.
     imagePullSecrets: []
-  # updateStrategy is the StatefulSet update strategy.
+  # updateStrategy is the StatefulSet update strategy. maxUnavailable needs the
+  # MaxUnavailableStatefulSet feature gate. Without the gate, the API server
+  # drops the field.
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -391,7 +394,9 @@ datanode:
     securityContext:
       privileged: true
     vmMaxMapCount: 262144
-  # updateStrategy is the StatefulSet update strategy.
+  # updateStrategy is the StatefulSet update strategy. maxUnavailable needs the
+  # MaxUnavailableStatefulSet feature gate. Without the gate, the API server
+  # drops the field.
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Summary
Setting `graylog.config.network.externalUri` now takes precedence over the Ingress hostnames and the live Service lookup, so a LoadBalancer acquiring or changing its address no longer rolls the Graylog StatefulSet on the next upgrade. The value accepts a full URI or a bare hostname. Also documents that `rollingUpdate.maxUnavailable` only works where the `MaxUnavailableStatefulSet` feature gate is enabled.

## Details
- The explicit value preempts the `lookup` in the `graylog.externalUri` helper. The lookup does not run at all when the value is set. TLS cn keeps its precedence. Following review feedback on this PR, the explicit value now also comes before the Ingress hostnames: an Ingress hostname cannot carry a path prefix, a public port, or a scheme that differs from the Ingress. Installs without an explicit value render exactly as before.
- Full URIs pass through with their scheme intact (previously a full URI rendered as `http://https://...`). Bare hostnames get the scheme and app port as before, with https when TLS is enabled.
- Guarded the `status.loadBalancer.ingress[0]` access so a Service with empty LB status cannot fail the render.
- Feature-gate note for `maxUnavailable` in values.yaml and both README rows.
- New unit test suite `tests/externaluri_test.yaml` covering the precedence and formatting matrix.
- Behavior change: a release that sets both `externalUri` and an Ingress hostname now renders the explicit value, so its config checksum changes once and its pods roll once on the next upgrade. Releases that do not set `externalUri` render identically and do not roll.

## Linked issues
This fixes #154

## PR Checklist
Please check the items that apply to your change.

- [x] Tests added/updated
- [x] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [x] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [x] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [x] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [x] Configuration changes apply correctly

### Specific to this PR
- [x] Live test on a Talos cluster with a working LoadBalancer pool: fresh install renders no external URI, the first upgrade picks it up from the Service lookup (unchanged fallback), and repeat upgrades hold the checksum steady. With `externalUri` pinned while LB status existed, the explicit value won, the config checksum stayed identical across repeated upgrades, and the StatefulSet generation never moved. Stack came up healthy (server, Datanode, external MongoDB 7.0.25) and `/api/system/lbstatus` answered ALIVE through the LB, with the pinned URI in the pod env. Full unit suite passes (177 tests).
- [x] Ingress precedence verified on a kind cluster with a real ingress-nginx controller and a real MetalLB LoadBalancer: with an Ingress hostname configured and `externalUri` set to a different host, the running container held the explicit URI and `/api/system/lbstatus` still answered ALIVE through the Ingress. Upgrading an existing release from this branch's previous state changed the config checksum once for the both-values-set case and not at all for releases without `externalUri`.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable

