### PR TITLE
feat: customization

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -515,6 +515,163 @@ helm upgrade graylog graylog/graylog -n graylog --set graylog.readinessProbe.ini
 helm upgrade graylog graylog/graylog -n graylog --set global.storageClass="gp2" --reuse-values
 ```
 
+### Labels and annotations
+
+Every object the chart deploys accepts custom labels and annotations. Set them
+once with `global.commonLabels` / `global.commonAnnotations`, and use the
+per-object values when only one resource needs them:
+
+```yaml
+# custom-metadata.yaml
+global:
+  commonLabels:
+    cost-center: "1234"
+    environment: production
+  commonAnnotations:
+    owner: observability-team
+
+graylog:
+  # StatefulSet, ConfigMaps and Secrets
+  labels:
+    tier: backend
+  annotations:
+    reloader.stakater.com/auto: "true"
+  # Graylog pods only
+  podLabels:
+    tier: backend
+  podAnnotations:
+    prometheus.io/scrape: "true"
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+
+datanode:
+  labels:
+    tier: storage
+
+ingress:
+  web:
+    labels:
+      tier: edge
+```
+
+Precedence, lowest to highest: `global.common*`, the per-object value, then the
+chart's own identity labels (`app.kubernetes.io/*`, `helm.sh/chart`, `app`) and
+its Helm hook and resource-policy annotations. Chart-owned values always win, so
+custom metadata can never break release lifecycle handling.
+
+> [!NOTE]
+> Custom labels never reach a workload's `spec.selector`, which is immutable
+> once created. They land on the object and on the pod template only, so labels
+> can safely be added to a release that is already running — `helm upgrade` will
+> not fail on a changed selector.
+
+### Extra volumes, mounts and containers
+
+Graylog and Data Node pods accept additional volumes, volume mounts, init
+containers and sidecars:
+
+```yaml
+# extra-volumes.yaml
+graylog:
+  extraVolumes:
+    - name: corporate-ca
+      secret:
+        secretName: corporate-ca
+  extraVolumeMounts:
+    - name: corporate-ca
+      mountPath: /etc/ssl/corporate
+      readOnly: true
+  # the chart's copy-data init container can mount them too
+  extraInitVolumeMounts:
+    - name: corporate-ca
+      mountPath: /mnt/ca
+      readOnly: true
+  extraInitContainers:
+    - name: wait-for-mongodb
+      image: busybox:1.37
+      command: ["sh", "-c", "until nc -z graylog-mongo-rs-svc 27017; do sleep 2; done"]
+  extraContainers:
+    - name: log-shipper
+      image: busybox:1.37
+```
+
+### Pod scheduling and runtime
+
+Both workloads expose `nodeSelector`, `tolerations`, `affinity`,
+`topologySpreadConstraints`, `priorityClassName`, `schedulerName`,
+`runtimeClassName`, `terminationGracePeriodSeconds`, `dnsPolicy`, `dnsConfig`,
+`hostAliases` and container `lifecycle` hooks:
+
+```yaml
+# scheduling.yaml
+graylog:
+  priorityClassName: high-priority
+  terminationGracePeriodSeconds: 120
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app: graylog-app
+  lifecycle:
+    preStop:
+      exec:
+        command: ["/bin/sh", "-c", "sleep 10"]
+```
+
+`topologySpreadConstraints` is the one to reach for in a multi-AZ cluster. The
+chart's default anti-affinity is a *soft* hostname preference: it spreads pods
+across nodes when it can, but it does not guarantee a spread across zones, so a
+single-zone failure can still take every Data Node replica with it.
+
+> [!IMPORTANT]
+> On the Graylog workload, `lifecycle.preStop` and
+> `lifecycle.preStopDrain.enabled` both define a preStop hook, and a container
+> can only have one. Setting both fails the render rather than silently
+> dropping either — see [Message journal lifecycle](#message-journal-lifecycle)
+> for what the chart-managed drain does.
+
+### Extra objects
+
+Anything the chart does not model can be deployed alongside it with
+`extraObjects`. Entries share the release lifecycle — installed, upgraded and
+deleted with the chart — and are templated, so they can reference the release:
+
+```yaml
+# extra-objects.yaml
+extraObjects:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: '{{ include "graylog.fullname" . }}-metrics'
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: '{{ .Release.Name }}'
+          app.kubernetes.io/component: server
+      endpoints:
+        - port: metrics
+```
+
+Entries may also be given as strings, which is the practical form when the
+manifest itself contains Helm syntax that must survive to render time:
+
+```yaml
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "graylog.fullname" . }}-extra
+    data:
+      namespace: {{ .Release.Namespace }}
+```
+
+`global.commonLabels` and `global.commonAnnotations` are merged into every extra
+object; anything set on the object itself wins.
+
 ## Add inputs
 
 First, define your inputs in a small YAML file like this one:
@@ -812,6 +969,7 @@ stern statefulset/graylog-datanode -n graylog
 | `version`          | Override Graylog and Graylog Data Node version (optional).       | `""`    |
 | `nameOverride`     | Override the `app.kubernetes.io/name` label value (optional).    | `""`    |
 | `fullnameOverride` | Override the fully qualified name of the application (optional). | `""`    |
+| `extraObjects`     | Arbitrary manifests rendered with the release; each entry is templated. | `[]` |
 
 ## Global
 These values affect Graylog, DataNode, and MongoDB.
@@ -821,6 +979,16 @@ These values affect Graylog, DataNode, and MongoDB.
 | `global.existingSecretName` | Reference to an existing Kubernetes secret. | `""`    |
 | `global.imagePullSecrets`   | Image pull secrets for private registries.  | `[]`    |
 | `global.storageClass`       | Storage class to use for PVCs.              | `""`    |
+| `global.commonLabels`       | Labels added to every object deployed by this chart.      | `{}` |
+| `global.commonAnnotations`  | Annotations added to every object deployed by this chart. | `{}` |
+
+> [!NOTE]
+> `global.commonLabels` and `global.commonAnnotations` are applied to *every*
+> object the chart renders. The chart's own identity labels
+> (`app.kubernetes.io/*`, `helm.sh/chart`, `app`) and its Helm hook/resource-policy
+> annotations always win, so they cannot be overwritten by accident. Per-object
+> `labels`/`annotations` values (e.g. `graylog.service.annotations`) take
+> precedence over the global ones.
 
 
 ## Graylog application
@@ -832,6 +1000,8 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.replicas`                                                    | Number of Graylog server replicas.                          | `2`                             |
 | `graylog.service.nameOverride`                                        | Override for service name.                                  | `""`                            |
 | `graylog.service.type`                                                | Kubernetes service type.                                    | `ClusterIP`                     |
+| `graylog.service.annotations`                                         | Annotations for the Graylog Service.                        | `{}`                            |
+| `graylog.service.labels`                                              | Labels for the Graylog Service.                             | `{}`                            |
 | `graylog.service.ports.app`                                           | Graylog web UI port.                                        | `9000`                          |
 | `graylog.service.ports.metrics`                                       | Metrics endpoint port.                                      | `9833`                          |
 | `graylog.service.metrics.enabled`                                     | Enable metrics collection.                                  | `true`                          |
@@ -930,6 +1100,8 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.persistence.size`                                            | Size of the persistent volume.                              | `""`                            |
 | `graylog.persistence.annotations`                                     | Annotations for the persistent volume claim.                | `{}`                            |
 | `graylog.persistence.labels`                                          | Labels for the persistent volume claim.                     | `{}`                            |
+| `graylog.persistence.selector`                                        | Selector for the persistent volume.                         | `{}`                            |
+| `graylog.persistence.dataSource`                                      | Data source to restore the volume from (e.g. a snapshot).   | `{}`                            |
 | `graylog.livenessProbe.enabled`                                       | Enable liveness probe.                                      | `true`                          |
 | `graylog.livenessProbe.initialDelaySeconds`                           | Initial delay for liveness probe.                           | `60`                            |
 | `graylog.livenessProbe.periodSeconds`                                 | Period between liveness probe checks.                       | `10`                            |
@@ -943,6 +1115,8 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.readinessProbe.failureThreshold`                             | Failure threshold for the readiness probe.                  | `6`                             |
 | `graylog.readinessProbe.successThreshold`                             | Success threshold for the readiness probe.                  | `1`                             |
 | `graylog.terminationGracePeriodSeconds`                               | Shutdown budget before SIGKILL. Covers the preStop hook and Graylog's own graceful shutdown. | `300`  |
+| `graylog.lifecycle.postStart`                                         | Your own postStart hook on the graylog-app container.       | `{}`                            |
+| `graylog.lifecycle.preStop`                                           | Your own preStop hook. Mutually exclusive with `preStopDrain.enabled`. | `{}`                  |
 | `graylog.lifecycle.preStopDrain.enabled`                              | Hold termination while the journal drains. See [Message Journal Lifecycle](#message-journal-lifecycle). | `false` |
 | `graylog.lifecycle.preStopDrain.endpointPropagationDelaySeconds`      | Wait for EndpointSlice removal to reach kube-proxy before sampling. | `15`                     |
 | `graylog.lifecycle.preStopDrain.pollIntervalSeconds`                  | Seconds between journal-depth samples.                      | `2`                             |
@@ -956,11 +1130,30 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.persistence.retentionPolicy.whenScaled`                       | PVC fate when scaled in. `Delete` is refused — it destroys a scaled-in node's journal. | `Retain` |
 | `graylog.podDisruptionBudget.enabled`                                 | Enable PodDisruptionBudget.                                 | `false`                         |
 | `graylog.podDisruptionBudget.minAvailable`                            | Minimum available pods during disruption.                   | `1`                             |
+| `graylog.podDisruptionBudget.annotations`                             | Annotations for the PodDisruptionBudget.                    | `{}`                            |
+| `graylog.podDisruptionBudget.labels`                                  | Labels for the PodDisruptionBudget.                         | `{}`                            |
+| `graylog.annotations`                                                 | Annotations for the Graylog StatefulSet, ConfigMaps and Secrets. | `{}`                       |
+| `graylog.labels`                                                      | Labels for the Graylog StatefulSet, ConfigMaps and Secrets.      | `{}`                       |
 | `graylog.podAnnotations`                                              | Additional pod annotations.                                 | `{}`                            |
+| `graylog.podLabels`                                                   | Additional pod labels.                                      | `{}`                            |
 | `graylog.nodeSelector`                                                | Node selector for scheduling.                               | `{}`                            |
 | `graylog.tolerations`                                                 | Tolerations for scheduling.                                 | `[]`                            |
 | `graylog.affinity`                                                    | Affinity rules for scheduling.                              | `{}`                            |
+| `graylog.topologySpreadConstraints`                                   | Topology spread constraints for the pods.                   | `[]`                            |
+| `graylog.priorityClassName`                                           | PriorityClass for the pods.                                 | `""`                            |
+| `graylog.schedulerName`                                               | Custom scheduler for the pods.                              | `""`                            |
+| `graylog.runtimeClassName`                                            | RuntimeClass for the pods.                                  | `""`                            |
+| `graylog.terminationGracePeriodSeconds`                               | Grace period before pods are force-killed.                  | `nil`                           |
+| `graylog.dnsPolicy`                                                   | Pod DNS policy.                                             | `ClusterFirst`                  |
+| `graylog.dnsConfig`                                                   | Pod DNS configuration.                                      | `{}`                            |
+| `graylog.hostAliases`                                                 | Additional `/etc/hosts` entries for the pods.               | `[]`                            |
+| `graylog.lifecycle`                                                   | Lifecycle hooks for the `graylog-app` container.            | `{}`                            |
 | `graylog.extraEnv`                                                    | Custom EnvVar environment variables.                        | `[]`                            |
+| `graylog.extraVolumes`                                                | Additional volumes for the Graylog pods.                    | `[]`                            |
+| `graylog.extraVolumeMounts`                                           | Additional volume mounts for the `graylog-app` container.   | `[]`                            |
+| `graylog.extraInitVolumeMounts`                                       | Additional volume mounts for the `copy-data` init container. | `[]`                           |
+| `graylog.extraInitContainers`                                         | Additional init containers.                                 | `[]`                            |
+| `graylog.extraContainers`                                             | Additional sidecar containers.                              | `[]`                            |
 
 
 ### Graylog inputs
@@ -995,6 +1188,8 @@ These values affect Graylog, DataNode, and MongoDB.
 |--------------------------------------------------------|-------------------------------------------------|-------------------|
 | `datanode.enabled`                                     | Enable Graylog datanode.                        | `true`            |
 | `datanode.replicas`                                    | Number of datanode replicas.                    | `3`               |
+| `datanode.service.annotations`                         | Annotations for the Data Node Service.          | `{}`              |
+| `datanode.service.labels`                              | Labels for the Data Node Service.               | `{}`              |
 | `datanode.service.ports.api`                           | API communication port.                         | `8999`            |
 | `datanode.service.ports.data`                          | Data communication port.                        | `9200`            |
 | `datanode.service.ports.config`                        | Configuration communication port.               | `9300`            |
@@ -1033,6 +1228,10 @@ These values affect Graylog, DataNode, and MongoDB.
 | `datanode.persistence.nativeLibs.mountPath`            | Mount path for native libs volume.              | `""`              |
 | `datanode.persistence.nativeLibs.accessModes`          | Access modes for native libs PVC.               | `[]`              |
 | `datanode.persistence.nativeLibs.size`                 | Size of the native libs volume.                 | `"2Gi"`           |
+| `datanode.persistence.nativeLibs.annotations`          | Annotations for native libs PVC.                | `{}`              |
+| `datanode.persistence.nativeLibs.labels`               | Labels for native libs PVC.                     | `{}`              |
+| `datanode.persistence.nativeLibs.selector`             | Selector for native libs PVC.                   | `{}`              |
+| `datanode.persistence.nativeLibs.dataSource`           | Data source for native libs PVC.                | `{}`              |
 | `datanode.livenessProbe.enabled`                       | Enable liveness probe.                          | `true`            |
 | `datanode.livenessProbe.initialDelaySeconds`           | Initial delay for liveness probe.               | `30`              |
 | `datanode.livenessProbe.periodSeconds`                 | Period between liveness probe checks.           | `10`              |
@@ -1047,11 +1246,29 @@ These values affect Graylog, DataNode, and MongoDB.
 | `datanode.readinessProbe.successThreshold`             | Success threshold for the readiness probe.      | `1`               |
 | `datanode.podDisruptionBudget.enabled`                 | Enable PodDisruptionBudget.                     | `false`           |
 | `datanode.podDisruptionBudget.minAvailable`            | Minimum available pods during disruption.       | `2`               |
+| `datanode.podDisruptionBudget.annotations`             | Annotations for the PodDisruptionBudget.        | `{}`              |
+| `datanode.podDisruptionBudget.labels`                  | Labels for the PodDisruptionBudget.             | `{}`              |
+| `datanode.annotations`                                 | Annotations for the Data Node StatefulSet, ConfigMap and Secret. | `{}` |
+| `datanode.labels`                                      | Labels for the Data Node StatefulSet, ConfigMap and Secret.      | `{}` |
 | `datanode.podAnnotations`                              | Additional pod annotations.                     | `{}`              |
+| `datanode.podLabels`                                   | Additional pod labels.                          | `{}`              |
 | `datanode.nodeSelector`                                | Node selector for scheduling datanode pods.     | `{}`              |
 | `datanode.tolerations`                                 | Tolerations for scheduling.                     | `[]`              |
 | `datanode.affinity`                                    | Affinity rules for scheduling.                  | `{}`              |
+| `datanode.topologySpreadConstraints`                   | Topology spread constraints for the pods.       | `[]`              |
+| `datanode.priorityClassName`                           | PriorityClass for the pods.                     | `""`              |
+| `datanode.schedulerName`                               | Custom scheduler for the pods.                  | `""`              |
+| `datanode.runtimeClassName`                            | RuntimeClass for the pods.                      | `""`              |
+| `datanode.terminationGracePeriodSeconds`               | Grace period before pods are force-killed.      | `nil`             |
+| `datanode.dnsPolicy`                                   | Pod DNS policy.                                 | `ClusterFirst`    |
+| `datanode.dnsConfig`                                   | Pod DNS configuration.                          | `{}`              |
+| `datanode.hostAliases`                                 | Additional `/etc/hosts` entries for the pods.   | `[]`              |
+| `datanode.lifecycle`                                   | Lifecycle hooks for the `graylog-datanode` container. | `{}`        |
 | `datanode.extraEnv`                                    | Custom EnvVar environment variables.            | `[]`              |
+| `datanode.extraVolumes`                                | Additional volumes for the Data Node pods.      | `[]`              |
+| `datanode.extraVolumeMounts`                           | Additional volume mounts for the `graylog-datanode` container. | `[]` |
+| `datanode.extraInitContainers`                         | Additional init containers.                     | `[]`              |
+| `datanode.extraContainers`                             | Additional sidecar containers.                  | `[]`              |
 
 
 ## OpenSearch
@@ -1079,9 +1296,12 @@ Mutually exclusive with `datanode.enabled`. See [Bring Your Own OpenSearch](#bri
 | `serviceAccount.create`       | Create a new service account.                           | `true`  |
 | `serviceAccount.automount`    | Automount service account token.                        | `true`  |
 | `serviceAccount.annotations`  | Annotations for service account.                        | `{}`    |
+| `serviceAccount.labels`       | Labels for service account.                             | `{}`    |
 | `serviceAccount.nameOverride` | Override name of service account.                       | `""`    |
 | `serviceAccount.role.create`  | Create a new role to bind to this service account.      | `false` |
 | `serviceAccount.role.rules`   | Rules for the new role to bind to this service account. | `[]`    |
+| `serviceAccount.role.annotations` | Annotations for the Role and RoleBinding.           | `{}`    |
+| `serviceAccount.role.labels`  | Labels for the Role and RoleBinding.                    | `{}`    |
 
 
 ## Ingress
@@ -1092,6 +1312,8 @@ Mutually exclusive with `datanode.enabled`. See [Bring Your Own OpenSearch](#bri
 | `ingress.config.defaultBackend.enabled`         | Enable default backend for ingress.              | `true`  |
 | `ingress.config.tls.clusterIssuer.existingName` | Name of existing ClusterIssuer for TLS.          | `""`    |
 | `ingress.config.tls.issuer.existingName`        | Name of existing Issuer for TLS.                 | `""`    |
+| `ingress.config.tls.issuer.annotations`         | Annotations for the chart-managed Issuer.        | `{}`    |
+| `ingress.config.tls.issuer.labels`              | Labels for the chart-managed Issuer.             | `{}`    |
 | `ingress.config.tls.issuer.managed.enabled`     | Enable auto-issuing of TLS certificates.         | `false` |
 | `ingress.config.tls.issuer.managed.staging`     | Use staging environment for auto-issued certs.   | `true`  |
 
@@ -1102,6 +1324,7 @@ Mutually exclusive with `datanode.enabled`. See [Bring Your Own OpenSearch](#bri
 | `ingress.web.enabled`                    | Enable ingress for Graylog Web.    | `false`                  |
 | `ingress.web.className`                  | Ingress class name.                | `""`                     |
 | `ingress.web.annotations`                | Annotations for ingress resource.  | `{}`                     |
+| `ingress.web.labels`                     | Labels for ingress resource.       | `{}`                     |
 | `ingress.web.hosts[0].host`              | Hostname for ingress (optional).   | `""`                     |
 | `ingress.web.hosts[0].paths[0].path`     | Path for routing.                  | `/`                      |
 | `ingress.web.hosts[0].paths[0].pathType` | Path matching type.                | `ImplementationSpecific` |
@@ -1149,6 +1372,7 @@ The listener is configured by attributes **on that input**, not through `server.
 | `ingress.forwarder.messageChannel.enabled`                    | Expose the message channel (port `13301`).      | `true`                   |
 | `ingress.forwarder.messageChannel.className`                  | Ingress class name.                             | `""`                     |
 | `ingress.forwarder.messageChannel.annotations`                | Annotations for ingress resource.               | `{}`                     |
+| `ingress.forwarder.messageChannel.labels`                     | Labels for ingress resource.                    | `{}`                     |
 | `ingress.forwarder.messageChannel.hosts[0].host`              | Hostname for ingress (optional).                | `""`                     |
 | `ingress.forwarder.messageChannel.hosts[0].paths[0].path`     | Path for routing.                               | `/`                      |
 | `ingress.forwarder.messageChannel.hosts[0].paths[0].pathType` | Path matching type.                             | `ImplementationSpecific` |
@@ -1156,6 +1380,7 @@ The listener is configured by attributes **on that input**, not through `server.
 | `ingress.forwarder.configChannel.enabled`                     | Expose the configuration channel (port `13302`).| `true`                   |
 | `ingress.forwarder.configChannel.className`                   | Ingress class name.                             | `""`                     |
 | `ingress.forwarder.configChannel.annotations`                 | Annotations for ingress resource.               | `{}`                     |
+| `ingress.forwarder.configChannel.labels`                      | Labels for ingress resource.                    | `{}`                     |
 | `ingress.forwarder.configChannel.hosts[0].host`               | Hostname for ingress (optional).                | `""`                     |
 | `ingress.forwarder.configChannel.hosts[0].paths[0].path`      | Path for routing.                               | `/`                      |
 | `ingress.forwarder.configChannel.hosts[0].paths[0].pathType`  | Path matching type.                             | `ImplementationSpecific` |
@@ -1174,12 +1399,22 @@ Requires the MCK Operator: https://github.com/mongodb/mongodb-kubernetes/tree/ma
 | `mongodb.version`                     | MongoDB server version for the replica set.                 | `"7.0.25"`                                                                                                                                                                                                             |
 | `mongodb.replicas`                    | Number of data-bearing replica set members.                 | `2`                                                                                                                                                                                                                    |
 | `mongodb.arbiters`                    | Number of arbiter nodes to deploy.                          | `1`                                                                                                                                                                                                                    |
+| `mongodb.annotations`                 | Annotations for the `MongoDBCommunity` object.              | `{}`                                                                                                                                                                                                                   |
+| `mongodb.labels`                      | Labels for the `MongoDBCommunity` object.                   | `{}`                                                                                                                                                                                                                   |
+| `mongodb.podAnnotations`              | Annotations for the MongoDB pods.                           | `{}`                                                                                                                                                                                                                   |
+| `mongodb.podLabels`                   | Labels for the MongoDB pods.                                | `{}`                                                                                                                                                                                                                   |
+| `mongodb.users`                       | Additional MongoDB users, appended to the chart-managed ones. | `[]`                                                                                                                                                                                                                 |
 | `mongodb.persistence.storageClass`    | StorageClass to use for persistent volumes.                 | `""`                                                                                                                                                                                                                   |
 | `mongodb.persistence.size.data`       | Persistent volume size for data storage.                    | `"10G"`                                                                                                                                                                                                                |
 | `mongodb.persistence.size.logs`       | Persistent volume size for MongoDB logs.                    | `"2G"`                                                                                                                                                                                                                 |
+| `mongodb.persistence.annotations`     | Annotations for the MongoDB volume claim templates.         | `{}`                                                                                                                                                                                                                   |
+| `mongodb.persistence.labels`          | Labels for the MongoDB volume claim templates.              | `{}`                                                                                                                                                                                                                   |
 | `mongodb.serviceAccount.create`       | Create a new service account for MongoDB workloads.         | `true`                                                                                                                                                                                                                 |
 | `mongodb.serviceAccount.automount`    | Automount service account token.                            | `true`                                                                                                                                                                                                                 |
 | `mongodb.serviceAccount.annotations`  | Annotations for service account.                            | `{}`                                                                                                                                                                                                                   |
+| `mongodb.serviceAccount.labels`       | Labels for service account.                                 | `{}`                                                                                                                                                                                                                   |
 | `mongodb.serviceAccount.nameOverride` | Override name of service account.                           | `""`                                                                                                                                                                                                                   |
 | `mongodb.serviceAccount.role.create`  | Create a new role to bind to this service account.          | `true`                                                                                                                                                                                                                 |
+| `mongodb.serviceAccount.role.annotations` | Annotations for the Role and RoleBinding.               | `{}`                                                                                                                                                                                                                   |
+| `mongodb.serviceAccount.role.labels`  | Labels for the Role and RoleBinding.                        | `{}`                                                                                                                                                                                                                   |
 | `mongodb.serviceAccount.role.rules`   | Rules for the new role to bind to this service account.     | <pre><code>rules:&#10;  - apiGroups: [ "" ]&#10;    resources: [ "secrets" ]&#10;    verbs: [ "get" ]&#10;  - apiGroups: [ "" ]&#10;    resources: [ "pods" ]&#10;    verbs: [ "get", "patch", "delete" ]</code></pre> |

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -555,6 +555,14 @@ ingress:
       tier: edge
 ```
 
+> [!NOTE]
+> MongoDB pods are the one exception. `mongodb.labels` / `mongodb.annotations`
+> apply to the `MongoDBCommunity` object, but there is no `mongodb.podLabels` —
+> the MongoDB Community operator owns the pod template of the StatefulSet it
+> manages, labels it `app: <release>-mongo-rs-svc` and discards anything the
+> chart puts there. Pod-level metadata for MongoDB has to come from the
+> operator's own API.
+
 Precedence, lowest to highest: `global.common*`, the per-object value, then the
 chart's own identity labels (`app.kubernetes.io/*`, `helm.sh/chart`, `app`) and
 its Helm hook and resource-policy annotations. Chart-owned values always win, so
@@ -565,6 +573,31 @@ custom metadata can never break release lifecycle handling.
 > once created. They land on the object and on the pod template only, so labels
 > can safely be added to a release that is already running — `helm upgrade` will
 > not fail on a changed selector.
+
+#### Immutable fields are deliberately left alone
+
+Kubernetes accepts updates to only six StatefulSet `spec` fields: `replicas`,
+`ordinals`, `template`, `updateStrategy`, `persistentVolumeClaimRetentionPolicy`
+and `minReadySeconds`. Anything else — `selector` and `volumeClaimTemplates` in
+particular — is rejected on update.
+
+So the chart injects nothing into those fields. `global.commonLabels` and
+`global.commonAnnotations` reach every object's own metadata and every pod
+template, but they stop at `volumeClaimTemplates`. Were it otherwise, simply
+upgrading to a chart version that added a label would fail for every existing
+release, and would keep failing on each release after that, because the identity
+labels include `helm.sh/chart` and `app.kubernetes.io/version`.
+
+You can still label a volume claim explicitly with
+`graylog.persistence.labels`, `datanode.persistence.data.labels`,
+`datanode.persistence.nativeLibs.labels` or `mongodb.persistence.labels`. That is
+safe on a fresh install. On a release that already exists it is a one-way door —
+the StatefulSet has to be recreated, which `kubectl delete statefulset <name>
+--cascade=orphan` does without touching the running pods or the PVCs.
+
+This rule is enforced by `tests/selector_immutability_test.yaml`. If you add an
+object or a metadata call site, extend that suite; for anything immutable use
+the `graylog.claim.metadata` helper, never `graylog.metadata.labels`.
 
 ### Extra volumes, mounts and containers
 
@@ -1221,6 +1254,8 @@ These values affect Graylog, DataNode, and MongoDB.
 | `datanode.persistence.data.mountPath`                  | Mount path for data volume.                     | `""`              |
 | `datanode.persistence.data.accessModes`                | Access modes for data PVC.                      | `[]`              |
 | `datanode.persistence.data.size`                       | Size of the data volume.                        | `"8Gi"`           |
+| `datanode.persistence.data.annotations`                | Annotations for the data PVC (globals do not apply). | `{}`         |
+| `datanode.persistence.data.labels`                     | Labels for the data PVC (globals do not apply). | `{}`              |
 | `datanode.persistence.nativeLibs.enabled`              | Enable persistence for native libraries.        | `false`           |
 | `datanode.persistence.nativeLibs.storageClass`         | Storage class for native libs PVC.              | `""`              |
 | `datanode.persistence.nativeLibs.mountPath`            | Mount path for native libs volume.              | `""`              |
@@ -1397,8 +1432,6 @@ Requires the MCK Operator: https://github.com/mongodb/mongodb-kubernetes/tree/ma
 | `mongodb.arbiters`                    | Number of arbiter nodes to deploy.                          | `1`                                                                                                                                                                                                                    |
 | `mongodb.annotations`                 | Annotations for the `MongoDBCommunity` object.              | `{}`                                                                                                                                                                                                                   |
 | `mongodb.labels`                      | Labels for the `MongoDBCommunity` object.                   | `{}`                                                                                                                                                                                                                   |
-| `mongodb.podAnnotations`              | Annotations for the MongoDB pods.                           | `{}`                                                                                                                                                                                                                   |
-| `mongodb.podLabels`                   | Labels for the MongoDB pods.                                | `{}`                                                                                                                                                                                                                   |
 | `mongodb.persistence.storageClass`    | StorageClass to use for persistent volumes.                 | `""`                                                                                                                                                                                                                   |
 | `mongodb.persistence.size.data`       | Persistent volume size for data storage.                    | `"10G"`                                                                                                                                                                                                                |
 | `mongodb.persistence.size.logs`       | Persistent volume size for MongoDB logs.                    | `"2G"`                                                                                                                                                                                                                 |

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -1100,8 +1100,6 @@ These values affect Graylog, DataNode, and MongoDB.
 | `graylog.persistence.size`                                            | Size of the persistent volume.                              | `""`                            |
 | `graylog.persistence.annotations`                                     | Annotations for the persistent volume claim.                | `{}`                            |
 | `graylog.persistence.labels`                                          | Labels for the persistent volume claim.                     | `{}`                            |
-| `graylog.persistence.selector`                                        | Selector for the persistent volume.                         | `{}`                            |
-| `graylog.persistence.dataSource`                                      | Data source to restore the volume from (e.g. a snapshot).   | `{}`                            |
 | `graylog.livenessProbe.enabled`                                       | Enable liveness probe.                                      | `true`                          |
 | `graylog.livenessProbe.initialDelaySeconds`                           | Initial delay for liveness probe.                           | `60`                            |
 | `graylog.livenessProbe.periodSeconds`                                 | Period between liveness probe checks.                       | `10`                            |
@@ -1230,8 +1228,6 @@ These values affect Graylog, DataNode, and MongoDB.
 | `datanode.persistence.nativeLibs.size`                 | Size of the native libs volume.                 | `"2Gi"`           |
 | `datanode.persistence.nativeLibs.annotations`          | Annotations for native libs PVC.                | `{}`              |
 | `datanode.persistence.nativeLibs.labels`               | Labels for native libs PVC.                     | `{}`              |
-| `datanode.persistence.nativeLibs.selector`             | Selector for native libs PVC.                   | `{}`              |
-| `datanode.persistence.nativeLibs.dataSource`           | Data source for native libs PVC.                | `{}`              |
 | `datanode.livenessProbe.enabled`                       | Enable liveness probe.                          | `true`            |
 | `datanode.livenessProbe.initialDelaySeconds`           | Initial delay for liveness probe.               | `30`              |
 | `datanode.livenessProbe.periodSeconds`                 | Period between liveness probe checks.           | `10`              |
@@ -1403,7 +1399,6 @@ Requires the MCK Operator: https://github.com/mongodb/mongodb-kubernetes/tree/ma
 | `mongodb.labels`                      | Labels for the `MongoDBCommunity` object.                   | `{}`                                                                                                                                                                                                                   |
 | `mongodb.podAnnotations`              | Annotations for the MongoDB pods.                           | `{}`                                                                                                                                                                                                                   |
 | `mongodb.podLabels`                   | Labels for the MongoDB pods.                                | `{}`                                                                                                                                                                                                                   |
-| `mongodb.users`                       | Additional MongoDB users, appended to the chart-managed ones. | `[]`                                                                                                                                                                                                                 |
 | `mongodb.persistence.storageClass`    | StorageClass to use for persistent volumes.                 | `""`                                                                                                                                                                                                                   |
 | `mongodb.persistence.size.data`       | Persistent volume size for data storage.                    | `"10G"`                                                                                                                                                                                                                |
 | `mongodb.persistence.size.logs`       | Persistent volume size for MongoDB logs.                    | `"2G"`                                                                                                                                                                                                                 |

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -42,7 +42,13 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{/*
+Common annotations
+*/}}
 {{- define "graylog.annotations" -}}
+{{- with .Values.global.commonAnnotations }}
+{{- toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -52,6 +58,59 @@ Selector labels
 app.kubernetes.io/name: {{ include "graylog.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Object metadata labels block.
+Merges, from lowest to highest precedence: global.commonLabels, the object's own
+labels from values, the common chart labels, and chart-owned labels that must not
+be overridden.
+The block is indented by "indent" spaces and brings its own leading newline, so
+call it left-trimmed ({{- include ... }}) and it lines up on its own.
+Usage:
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app" "graylog-app") "indent" 2) }}
+*/}}
+{{- define "graylog.metadata.labels" -}}
+{{- $ctx := .context -}}
+{{- $indent := .indent | default 2 | toString | atoi -}}
+{{- $subIndent := add $indent 2 | toString | atoi -}}
+{{- $merged := merge (dict) (.fixed | default dict) (include "graylog.labels" $ctx | fromYaml) (.labels | default dict) ($ctx.Values.global.commonLabels | default dict) -}}
+{{- printf "labels:" | nindent $indent -}}
+{{- toYaml $merged | nindent $subIndent -}}
+{{- end -}}
+
+{{/*
+Object metadata annotations block. Renders nothing when there is nothing to set.
+Merges, from lowest to highest precedence: global.commonAnnotations, the object's
+own annotations from values, and chart-owned annotations that must not be
+overridden (Helm hooks, resource policies).
+Usage:
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "indent" 2) }}
+*/}}
+{{- define "graylog.metadata.annotations" -}}
+{{- $ctx := .context -}}
+{{- $indent := .indent | default 2 | toString | atoi -}}
+{{- $subIndent := add $indent 2 | toString | atoi -}}
+{{- $merged := merge (dict) (.fixed | default dict) (.annotations | default dict) ($ctx.Values.global.commonAnnotations | default dict) -}}
+{{- with $merged -}}
+{{- printf "annotations:" | nindent $indent -}}
+{{- toYaml . | nindent $subIndent -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Pod template labels block. Same precedence rules as "graylog.metadata.labels",
+but built on the selector labels so pods always match their workload selector.
+Usage:
+  {{- include "graylog.pod.labels" (dict "context" $ "labels" .Values.graylog.podLabels "fixed" (dict "app" "graylog-app") "indent" 6) }}
+*/}}
+{{- define "graylog.pod.labels" -}}
+{{- $ctx := .context -}}
+{{- $indent := .indent | default 2 | toString | atoi -}}
+{{- $subIndent := add $indent 2 | toString | atoi -}}
+{{- $merged := merge (dict) (.fixed | default dict) (include "graylog.selectorLabels" $ctx | fromYaml) (.labels | default dict) ($ctx.Values.global.commonLabels | default dict) -}}
+{{- printf "labels:" | nindent $indent -}}
+{{- toYaml $merged | nindent $subIndent -}}
+{{- end -}}
 
 {{/*
 Init script ConfigMap name

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -113,6 +113,38 @@ Usage:
 {{- end -}}
 
 {{/*
+Metadata block for an IMMUTABLE object, i.e. a StatefulSet volumeClaimTemplate.
+
+Deliberately NOT "graylog.metadata.labels". A StatefulSet's volumeClaimTemplates
+cannot be changed after creation - Kubernetes only accepts updates to replicas,
+ordinals, template, updateStrategy, persistentVolumeClaimRetentionPolicy and
+minReadySeconds. Injecting the chart's identity labels here would rewrite that
+field on every existing release and make `helm upgrade` fail, and because those
+labels carry helm.sh/chart and app.kubernetes.io/version it would fail again on
+every subsequent version bump.
+
+So only what the user explicitly asked for is rendered: no chart labels and no
+global.commonLabels/commonAnnotations. Setting these values on a release that
+already exists is still a breaking change, but it is then an explicit,
+one-time choice by the operator rather than something the chart does to them.
+
+Usage:
+  {{- include "graylog.claim.metadata" (dict "labels" .Values.graylog.persistence.labels "annotations" .Values.graylog.persistence.annotations "indent" 8) }}
+*/}}
+{{- define "graylog.claim.metadata" -}}
+{{- $indent := .indent | default 2 | toString | atoi -}}
+{{- $subIndent := add $indent 2 | toString | atoi -}}
+{{- with .labels -}}
+{{- printf "labels:" | nindent $indent -}}
+{{- toYaml . | nindent $subIndent -}}
+{{- end -}}
+{{- with .annotations -}}
+{{- printf "annotations:" | nindent $indent -}}
+{{- toYaml . | nindent $subIndent -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Init script ConfigMap name
 */}}
 {{- define "graylog.cm.init.name" }}
@@ -573,13 +605,13 @@ Resolve OpenSearch basic-auth credentials as "user:pass" (empty string if none).
 Inline values win; otherwise read from opensearch.auth.existingSecret via lookup.
 */}}
 {{- define "graylog.opensearch.credentials" -}}
-{{- $u := .Values.opensearch.auth.username | default "" -}}
-{{- $p := .Values.opensearch.auth.password | default "" -}}
+{{- $u := .Values.opensearch.auth.username | default "" | urlquery -}}
+{{- $p := .Values.opensearch.auth.password | default "" | urlquery -}}
 {{- if and (not $u) .Values.opensearch.auth.existingSecret -}}
   {{- $s := lookup "v1" "Secret" .Release.Namespace .Values.opensearch.auth.existingSecret -}}
   {{- if $s -}}
-    {{- $u = index $s.data .Values.opensearch.auth.usernameKey | default "" | b64dec -}}
-    {{- $p = index $s.data .Values.opensearch.auth.passwordKey | default "" | b64dec -}}
+    {{- $u = index $s.data .Values.opensearch.auth.usernameKey | default "" | b64dec | urlquery -}}
+    {{- $p = index $s.data .Values.opensearch.auth.passwordKey | default "" | b64dec | urlquery -}}
   {{- end -}}
 {{- end -}}
 {{- if $u -}}

--- a/charts/graylog/templates/auth/mongo-sa.yaml
+++ b/charts/graylog/templates/auth/mongo-sa.yaml
@@ -3,12 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "graylog.mongodb.serviceAccountName" . }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  {{- with .Values.mongodb.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.serviceAccount.labels "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.serviceAccount.annotations "indent" 2) }}
 automountServiceAccountToken: {{ if eq (.Values.mongodb.serviceAccount.automount | toString) "false" }}false{{ else }}true{{ end }}
 {{- if empty .Values.mongodb.serviceAccount.role.rules | not | and .Values.mongodb.serviceAccount.role.create }}
 {{- $roleName := include "graylog.mongodb.serviceAccountName" . | printf "%s-role" }}
@@ -17,16 +13,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $roleName }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.serviceAccount.role.labels "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.serviceAccount.role.annotations "indent" 2) }}
 rules: {{ .Values.mongodb.serviceAccount.role.rules | toYaml | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "graylog.mongodb.serviceAccountName" . | printf "%s-rb" }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.serviceAccount.role.labels "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.serviceAccount.role.annotations "indent" 2) }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "graylog.mongodb.serviceAccountName" . }}

--- a/charts/graylog/templates/auth/sa.yaml
+++ b/charts/graylog/templates/auth/sa.yaml
@@ -3,12 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "graylog.serviceAccountName" . }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.serviceAccount.labels "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.serviceAccount.annotations "indent" 2) }}
 automountServiceAccountToken: {{ dig "automount" true .Values.serviceAccount }}
 {{- if empty .Values.serviceAccount.role.rules | not | and .Values.serviceAccount.role.create }}
 {{- $roleName := include "graylog.serviceAccountName" . | printf "%s-role" }}
@@ -17,16 +13,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $roleName }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.serviceAccount.role.labels "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.serviceAccount.role.annotations "indent" 2) }}
 rules: {{ .Values.serviceAccount.role.rules | toYaml | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "graylog.serviceAccountName" . | printf "%s-rb" }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.serviceAccount.role.labels "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.serviceAccount.role.annotations "indent" 2) }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "graylog.serviceAccountName" . }}

--- a/charts/graylog/templates/config/datanode.yaml
+++ b/charts/graylog/templates/config/datanode.yaml
@@ -3,9 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.datanode.configmap.name" . }}
-  labels:
-    app.kubernetes.io/component: datanode
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.labels "fixed" (dict "app.kubernetes.io/component" "datanode" "app" "graylog-datanode") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.annotations "indent" 2) }}
 data:
   JAVA_OPTS: {{ .Values.datanode.config.javaOpts | quote }}
   GRAYLOG_DATANODE_NODE_ID_FILE: {{ .Values.datanode.config.nodeIdFile | default "/var/lib/graylog-datanode/node-id" | quote }}

--- a/charts/graylog/templates/config/fallback.yaml
+++ b/charts/graylog/templates/config/fallback.yaml
@@ -3,9 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.fallback.name" . | printf "%s-config" }}
-  labels:
-    app.kubernetes.io/component: default-backend
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "fixed" (dict "app.kubernetes.io/component" "default-backend") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "indent" 2) }}
 data:
   httpd.conf: |
     H:/var/www/html
@@ -16,9 +15,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.fallback.name" . | printf "%s-content" }}
-  labels:
-    app.kubernetes.io/component: default-backend
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "fixed" (dict "app.kubernetes.io/component" "default-backend") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "indent" 2) }}
 data:
   healthz: "ok"
   livez: "ok"

--- a/charts/graylog/templates/config/geoip-sidecar-entrypoint.yaml
+++ b/charts/graylog/templates/config/geoip-sidecar-entrypoint.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.fullname" . }}-geoip-entrypoint
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app" "graylog-app") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "indent" 2) }}
 data:
   entrypoint.sh: |
     #!/bin/sh

--- a/charts/graylog/templates/config/graylog.yaml
+++ b/charts/graylog/templates/config/graylog.yaml
@@ -2,9 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.configmap.name" . }}
-  labels:
-    app.kubernetes.io/component: server
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app.kubernetes.io/component" "server" "app" "graylog-app") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "indent" 2) }}
 data:
   GRAYLOG_PROMETHEUS_EXPORTER_ENABLED: {{ .Values.graylog.service.metrics.enabled | ternary true false | quote }}
   {{- if .Values.opensearch.enabled }}

--- a/charts/graylog/templates/config/init-graylog.yaml
+++ b/charts/graylog/templates/config/init-graylog.yaml
@@ -115,8 +115,15 @@ data:
       keytool -storepasswd -keystore "${CACERTS_TMP}" -storepass changeit -new "${TRUSTSTORE_PASS}" || { echo "Error: failed to set the truststore password."; exit 1; }
     fi
     {{- if and .Values.graylog.config.tls.enabled .Values.graylog.config.tls.updateKeyStore }}
-    keytool -importcert -noprompt -alias byoc -file "/mnt/tls/tls.crt" -keystore "${CACERTS_TMP}" -storepass "${TRUSTSTORE_PASS}"
-    [ -n "${ROOT_CA}" ] && echo "Adding root CA..." && keytool -importcert -noprompt -alias byoc-ca -file "${ROOT_CA}" -keystore "${CACERTS_TMP}" -storepass "${TRUSTSTORE_PASS}"
+    # Every import is fatal. A store that was built but is missing one of our
+    # certificates is worse than no store at all: the JVM is pointed at it with
+    # -Djavax.net.ssl.trustStore, so the failure surfaces later as unexplained
+    # TLS errors rather than here, where the cause is obvious.
+    keytool -importcert -noprompt -alias byoc -file "/mnt/tls/tls.crt" -keystore "${CACERTS_TMP}" -storepass "${TRUSTSTORE_PASS}" || { echo "Error: failed to import the Graylog certificate from /mnt/tls/tls.crt."; exit 1; }
+    if [ -n "${ROOT_CA}" ]; then
+      echo "Adding root CA..."
+      keytool -importcert -noprompt -alias byoc-ca -file "${ROOT_CA}" -keystore "${CACERTS_TMP}" -storepass "${TRUSTSTORE_PASS}" || { echo "Error: failed to import the root CA from ${ROOT_CA}."; exit 1; }
+    fi
     {{- end }}
     {{- if and .Values.opensearch.enabled .Values.opensearch.tls.enabled .Values.opensearch.tls.caSecret }}
     # trust the BYO OpenSearch CA

--- a/charts/graylog/templates/config/init-graylog.yaml
+++ b/charts/graylog/templates/config/init-graylog.yaml
@@ -69,45 +69,66 @@ data:
         echo "The certificate passed does not contain a root CA. Only this certificate will be added to the truststore."
         echo "Make sure to add a new certificate when performing certificate rotation."
       fi
-      # Update Java keystore for BYO Graylog application certs
-      CACERTS_SRC="/usr/share/graylog/data/cacerts"
-      CACERTS_DST="/mnt/data/cacerts"
-      mkdir -p "${CACERTS_SRC}" "${CACERTS_DST}"
-      JAVA_HOME_LOCAL=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | grep '/.*' -o)
-      cp "${JAVA_HOME_LOCAL}/lib/security/cacerts" "${CACERTS_SRC}/graylog.jks"
-      chown graylog:graylog "${CACERTS_SRC}/graylog.jks"
-      keytool -importcert -noprompt -alias byoc -file "/mnt/tls/tls.crt" -keystore "${CACERTS_SRC}/graylog.jks" -storepass {{ .Values.graylog.config.tls.keyStorePass | default "changeit" }}
-      [ -n "${ROOT_CA}" ] && echo "Adding root CA..." && keytool -importcert -noprompt -alias byoc-ca -file "${ROOT_CA}" -keystore "${CACERTS_SRC}/graylog.jks" -storepass {{ .Values.graylog.config.tls.keyStorePass | default "changeit" }}
-      if [ ! -e "${CACERTS_DST}/graylog.jks" ] || ! cmp -s "${CACERTS_SRC}/graylog.jks" "${CACERTS_DST}/graylog.jks"; then
-        cp "${CACERTS_SRC}/graylog.jks" "${CACERTS_DST}/graylog.jks"
-        echo "Updated Java Key Store."
-      else
-        echo "Java Key Store has not been modified, nothing to do."
-      fi
     {{- else }}
-      echo "The Java Key Store remains unchanged. Ensure that the CA that signed your certificates is trusted by default."
+      echo "The Graylog certificate will not be added to the Java Key Store. Ensure that the CA that signed your certificates is trusted by default."
     {{- end }}
     fi
+    {{- end }}
+    {{- if eq (include "graylog.truststore.enabled" .) "true" }}
+    # Build the Graylog Java truststore.
+    # It is always rebuilt from the JDK truststore shipped in the Graylog image so the CAs
+    # trusted by default are preserved and our certificates are only ever ADDED on top.
+    # Rebuilding (instead of mutating the copy on the data volume) also means removed or
+    # rotated certificates disappear and image upgrades pick up JDK CA bundle updates.
+    CACERTS_DST="/mnt/data/cacerts"
+    CACERTS_TMP="${CACERTS_DST}/graylog.jks.tmp"
+    TRUSTSTORE_PASS={{ .Values.graylog.config.tls.keyStorePass | default "changeit" | squote }}
+    mkdir -p "${CACERTS_DST}"
+    # Locate the JDK truststore WITHOUT executing `java`.
+    #
+    # The java binary in the Graylog image carries a file capability
+    # (cap_net_bind_service=ep), and this init container runs with
+    # allowPrivilegeEscalation: false, which sets no_new_privs. The kernel
+    # refuses to execve a file with capabilities under no_new_privs, so asking
+    # the JVM to print its own settings dies with "Operation not permitted"
+    # (exit 126) and any path derived that way comes back empty. keytool
+    # carries no file capability and runs fine, so only the lookup has to
+    # avoid starting a JVM.
+    JAVA_HOME_LOCAL="${JAVA_HOME}"
+    if [ -z "${JAVA_HOME_LOCAL}" ] || [ ! -f "${JAVA_HOME_LOCAL}/lib/security/cacerts" ]; then
+      for candidate in /opt/java/openjdk /usr/share/graylog/jvm /usr/lib/jvm/default-jvm /usr/lib/jvm/java; do
+        if [ -f "${candidate}/lib/security/cacerts" ]; then
+          JAVA_HOME_LOCAL="${candidate}"
+          break
+        fi
+      done
+    fi
+    if [ -z "${JAVA_HOME_LOCAL}" ] || [ ! -f "${JAVA_HOME_LOCAL}/lib/security/cacerts" ]; then
+      echo "Error: unable to locate the JDK truststore in the Graylog image. Refusing to build a truststore that would drop the CAs trusted by default."
+      echo "Looked at JAVA_HOME (${JAVA_HOME:-unset}) and the usual JDK locations. Set JAVA_HOME on the Graylog container via graylog.extraEnv if the image places it elsewhere."
+      exit 1
+    fi
+    rm -f "${CACERTS_TMP}"
+    cp "${JAVA_HOME_LOCAL}/lib/security/cacerts" "${CACERTS_TMP}" || { echo "Error: failed to copy the JDK truststore."; exit 1; }
+    # the JDK truststore ships with the default password, so re-key it before importing
+    if [ "${TRUSTSTORE_PASS}" != "changeit" ]; then
+      keytool -storepasswd -keystore "${CACERTS_TMP}" -storepass changeit -new "${TRUSTSTORE_PASS}" || { echo "Error: failed to set the truststore password."; exit 1; }
+    fi
+    {{- if and .Values.graylog.config.tls.enabled .Values.graylog.config.tls.updateKeyStore }}
+    keytool -importcert -noprompt -alias byoc -file "/mnt/tls/tls.crt" -keystore "${CACERTS_TMP}" -storepass "${TRUSTSTORE_PASS}"
+    [ -n "${ROOT_CA}" ] && echo "Adding root CA..." && keytool -importcert -noprompt -alias byoc-ca -file "${ROOT_CA}" -keystore "${CACERTS_TMP}" -storepass "${TRUSTSTORE_PASS}"
     {{- end }}
     {{- if and .Values.opensearch.enabled .Values.opensearch.tls.enabled .Values.opensearch.tls.caSecret }}
-    # Trust the BYO OpenSearch CA. The truststore must live on the data volume
-    # (/mnt/data here, /usr/share/graylog/data in the main container) and is seeded
-    # from the JDK CA bundle so public CAs (license checks, GeoIP, notifications)
-    # stay trusted. Built in a temp file and mv'd so a failed init can't leave a
-    # half-built store behind.
-    CACERTS_DST="/mnt/data/cacerts"
-    mkdir -p "${CACERTS_DST}"
-    TRUSTSTORE_TMP="${CACERTS_DST}/graylog.jks.tmp"
-    if [ -f "${CACERTS_DST}/graylog.jks" ]; then
-      cp "${CACERTS_DST}/graylog.jks" "${TRUSTSTORE_TMP}"
+    # trust the BYO OpenSearch CA
+    keytool -importcert -noprompt -alias byo-opensearch-ca -file "/mnt/os-tls/{{ .Values.opensearch.tls.caKey }}" -keystore "${CACERTS_TMP}" -storepass "${TRUSTSTORE_PASS}" || { echo "Error: failed to import the OpenSearch CA."; exit 1; }
+    {{- end }}
+    if [ ! -e "${CACERTS_DST}/graylog.jks" ] || ! cmp -s "${CACERTS_TMP}" "${CACERTS_DST}/graylog.jks"; then
+      mv "${CACERTS_TMP}" "${CACERTS_DST}/graylog.jks"
+      echo "Updated Java Key Store."
     else
-      cp "${JAVA_HOME}/lib/security/cacerts" "${TRUSTSTORE_TMP}"
+      rm -f "${CACERTS_TMP}"
+      echo "Java Key Store has not been modified, nothing to do."
     fi
-    # delete-then-import so a rotated CA is picked up on pod restart
-    keytool -delete -alias byo-opensearch-ca -keystore "${TRUSTSTORE_TMP}" -storepass {{ .Values.graylog.config.tls.keyStorePass | default "changeit" }} >/dev/null 2>&1 || true
-    keytool -importcert -noprompt -alias byo-opensearch-ca -file "/mnt/os-tls/{{ .Values.opensearch.tls.caKey }}" -keystore "${TRUSTSTORE_TMP}" -storepass {{ .Values.graylog.config.tls.keyStorePass | default "changeit" }}
-    mv "${TRUSTSTORE_TMP}" "${CACERTS_DST}/graylog.jks"
-    echo "Imported OpenSearch CA into Graylog truststore."
     {{- end }}
     {{- if .Values.graylog.config.plugins.enabled }}
     # copy plugins

--- a/charts/graylog/templates/config/init-graylog.yaml
+++ b/charts/graylog/templates/config/init-graylog.yaml
@@ -3,9 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "graylog.cm.init.name" . }}
-  labels:
-    app.kubernetes.io/component: server
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app.kubernetes.io/component" "server" "app" "graylog-app") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "indent" 2) }}
 data:
   init-script.sh: |
     #!/bin/sh

--- a/charts/graylog/templates/config/sc/aws-gp3.yaml
+++ b/charts/graylog/templates/config/sc/aws-gp3.yaml
@@ -3,11 +3,9 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ include "graylog.provider.storageClassName" . }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-10"
+  {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
+  {{- $hooks := dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-weight" "-10" }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp3

--- a/charts/graylog/templates/config/secret/datanode.yaml
+++ b/charts/graylog/templates/config/secret/datanode.yaml
@@ -3,10 +3,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "graylog.datanode.secretsName" . }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    {{- include "graylog.annotations" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.labels "fixed" (dict "app" "graylog-datanode") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.annotations "indent" 2) }}
 data:
   {{- with .Values.datanode.config.s3ClientDefaultSecretKey }}
   GRAYLOG_DATANODE_S3_CLIENT_DEFAULT_SECRET_KEY: {{ . | b64enc }}

--- a/charts/graylog/templates/config/secret/opensearch.yaml
+++ b/charts/graylog/templates/config/secret/opensearch.yaml
@@ -8,10 +8,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "graylog.opensearch.secretName" . }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    {{- include "graylog.annotations" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "fixed" (dict "app.kubernetes.io/component" "server") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "indent" 2) }}
 data:
   GRAYLOG_ELASTICSEARCH_HOSTS: {{ include "graylog.opensearch.hosts" . | b64enc }}
 {{- end }}

--- a/charts/graylog/templates/config/secret/secrets.yaml
+++ b/charts/graylog/templates/config/secret/secrets.yaml
@@ -55,11 +55,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $backupName }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    {{- include "graylog.annotations" . | nindent 4 }}
-    helm.sh/resource-policy: keep
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app" "graylog-app") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "fixed" (dict "helm.sh/resource-policy" "keep") "indent" 2) }}
 data:
   {{- if empty .Values.graylog.config.mongodb.customUri }}
   mongodb-root-password: {{ $mongoRootPassword }}
@@ -91,10 +88,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    {{- include "graylog.annotations" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app" "graylog-app") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "indent" 2) }}
 data:
   GRAYLOG_MONGODB_URI: {{ $mongoUri | required "ERROR: empty MongoDB URI. Please set it using graylog.config.mongodb.customUri" }}
   GRAYLOG_ROOT_USERNAME: {{ .Values.graylog.config.rootUsername | default "admin" | b64enc }}

--- a/charts/graylog/templates/custom/extra-objects.yaml
+++ b/charts/graylog/templates/custom/extra-objects.yaml
@@ -1,0 +1,38 @@
+{{/*
+Arbitrary user-supplied manifests, rendered as part of this release.
+
+The escape hatch for anything the chart does not model: a ServiceMonitor, an
+ExternalSecret, a VirtualService, a NetworkPolicy. Keeping them here means they
+share the release's lifecycle — installed, upgraded and deleted with the chart —
+instead of needing a wrapper chart or a second `kubectl apply`.
+
+Each entry is passed through `tpl`, so values may reference the release context
+({{ .Release.Name }}, {{ include "graylog.fullname" . }}, ...). Entries can be
+given as a mapping or as a string; a string is the practical form when the
+manifest itself contains Helm syntax.
+
+global.commonLabels and global.commonAnnotations are merged in, so extra objects
+carry the same ownership metadata as everything else the chart renders. Anything
+set on the object itself wins.
+*/}}
+{{- range $index, $object := .Values.extraObjects }}
+{{- $rendered := $object }}
+{{- if kindIs "string" $object }}
+{{- $rendered = tpl $object $ | fromYaml }}
+{{- else }}
+{{- $rendered = tpl (toYaml $object) $ | fromYaml }}
+{{- end }}
+{{- if not $rendered.kind }}
+{{- fail (printf "extraObjects[%d] does not render to a Kubernetes object: no 'kind' field found.\n  Each entry must be a complete manifest with apiVersion, kind and metadata.name.\n  If the entry is a string, check that it is valid YAML after templating." $index) }}
+{{- end }}
+{{- $meta := $rendered.metadata | default dict }}
+{{- $_ := set $rendered "metadata" $meta }}
+{{- if $.Values.global.commonLabels }}
+{{- $_ := set $meta "labels" (merge (dict) ($meta.labels | default dict) $.Values.global.commonLabels) }}
+{{- end }}
+{{- if $.Values.global.commonAnnotations }}
+{{- $_ := set $meta "annotations" (merge (dict) ($meta.annotations | default dict) $.Values.global.commonAnnotations) }}
+{{- end }}
+---
+{{ toYaml $rendered }}
+{{- end }}

--- a/charts/graylog/templates/custom/issuer.yaml
+++ b/charts/graylog/templates/custom/issuer.yaml
@@ -11,8 +11,8 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "graylog.cert-manager.issuer.name" . }}
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.ingress.config.tls.issuer.labels "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.ingress.config.tls.issuer.annotations "indent" 2) }}
 spec:
   acme:
     server: {{ .Values.ingress.config.tls.issuer.managed.staging | ternary "-staging" "" | printf "https://acme%s-v02.api.letsencrypt.org/directory" }}

--- a/charts/graylog/templates/custom/mongo-rs.yaml
+++ b/charts/graylog/templates/custom/mongo-rs.yaml
@@ -57,9 +57,22 @@ spec:
   statefulSet:
     spec:
       template:
-        metadata:
-          {{- include "graylog.pod.labels" (dict "context" $ "labels" .Values.mongodb.podLabels "fixed" (dict "app.kubernetes.io/component" "mongodb" "app" "graylog-mongodb") "indent" 10) }}
-          {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.podAnnotations "indent" 10) }}
+        {{/*
+        No metadata block here on purpose.
+
+        The MongoDB Community operator owns the pod template of the StatefulSet
+        it manages: it sets `app: <crName>-svc` and nothing else, and that label
+        is also its (immutable) selector. Labels set here are discarded - the
+        chart used to render them and the resulting StatefulSet never carried
+        them - so exposing mongodb.podLabels/podAnnotations would promise
+        customization the operator cannot deliver. Worse, had the operator
+        honoured an `app` override, the pods would no longer have matched the
+        selector.
+
+        Pod-level metadata for MongoDB has to come from the operator's own API,
+        not from this chart. The MongoDBCommunity object itself still takes
+        mongodb.labels / mongodb.annotations.
+        */}}
         spec:
           serviceAccountName: {{ include "graylog.mongodb.serviceAccountName" . }}
           affinity:
@@ -77,8 +90,7 @@ spec:
       volumeClaimTemplates:
         - metadata:
             name: data-volume
-            {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.persistence.labels "fixed" (dict "app.kubernetes.io/component" "mongodb") "indent" 12) }}
-            {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.persistence.annotations "indent" 12) }}
+            {{- include "graylog.claim.metadata" (dict "labels" .Values.mongodb.persistence.labels "annotations" .Values.mongodb.persistence.annotations "indent" 12) }}
           spec:
             accessModes: ["ReadWriteOnce"]
             {{- with (include "graylog.mongodb.storageClassName" .) }}
@@ -89,8 +101,7 @@ spec:
                 storage: {{ .Values.mongodb.persistence.size.data | default "10G" | quote }}
         - metadata:
             name: logs-volume
-            {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.persistence.labels "fixed" (dict "app.kubernetes.io/component" "mongodb") "indent" 12) }}
-            {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.persistence.annotations "indent" 12) }}
+            {{- include "graylog.claim.metadata" (dict "labels" .Values.mongodb.persistence.labels "annotations" .Values.mongodb.persistence.annotations "indent" 12) }}
           spec:
             accessModes: [ "ReadWriteOnce" ]
             {{- with (include "graylog.mongodb.storageClassName" .) }}

--- a/charts/graylog/templates/custom/mongo-rs.yaml
+++ b/charts/graylog/templates/custom/mongo-rs.yaml
@@ -11,9 +11,8 @@ apiVersion: mongodbcommunity.mongodb.com/v1
 kind: MongoDBCommunity
 metadata:
   name: {{ include "graylog.mongodb.crName" . }}
-  labels:
-    app.kubernetes.io/component: mongodb
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.labels "fixed" (dict "app.kubernetes.io/component" "mongodb" "app" "graylog-mongodb") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.annotations "indent" 2) }}
 spec:
   {{- $replicas := .Values.mongodb.replicas | default 2 | int }}
   {{- $arbiters := .Values.mongodb.arbiters | default 0 | int }}
@@ -61,6 +60,9 @@ spec:
   statefulSet:
     spec:
       template:
+        metadata:
+          {{- include "graylog.pod.labels" (dict "context" $ "labels" .Values.mongodb.podLabels "fixed" (dict "app.kubernetes.io/component" "mongodb" "app" "graylog-mongodb") "indent" 10) }}
+          {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.podAnnotations "indent" 10) }}
         spec:
           serviceAccountName: {{ include "graylog.mongodb.serviceAccountName" . }}
           affinity:
@@ -78,6 +80,8 @@ spec:
       volumeClaimTemplates:
         - metadata:
             name: data-volume
+            {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.persistence.labels "fixed" (dict "app.kubernetes.io/component" "mongodb") "indent" 12) }}
+            {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.persistence.annotations "indent" 12) }}
           spec:
             accessModes: ["ReadWriteOnce"]
             {{- with (include "graylog.mongodb.storageClassName" .) }}
@@ -88,6 +92,8 @@ spec:
                 storage: {{ .Values.mongodb.persistence.size.data | default "10G" | quote }}
         - metadata:
             name: logs-volume
+            {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.mongodb.persistence.labels "fixed" (dict "app.kubernetes.io/component" "mongodb") "indent" 12) }}
+            {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.mongodb.persistence.annotations "indent" 12) }}
           spec:
             accessModes: [ "ReadWriteOnce" ]
             {{- with (include "graylog.mongodb.storageClassName" .) }}

--- a/charts/graylog/templates/custom/mongo-rs.yaml
+++ b/charts/graylog/templates/custom/mongo-rs.yaml
@@ -54,9 +54,6 @@ spec:
         - name: readWrite
           db: {{ include "graylog.mongodb.crDatabase" . }}
       scramCredentialsSecretName: {{ printf "%s-%s" (include "graylog.mongodb.crName" .) (include "graylog.mongodb.crUsername" .) }}
-    {{- with .Values.mongodb.users }}
-      {{- . | toYaml | nindent 4 }}
-    {{- end }}
   statefulSet:
     spec:
       template:

--- a/charts/graylog/templates/policy/pdb/datanode.yaml
+++ b/charts/graylog/templates/policy/pdb/datanode.yaml
@@ -5,10 +5,8 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "graylog.fullname" . | printf "%s-pdb-datanode" }}
   namespace: {{ .Release.Namespace }}
-  labels:
-    app: graylog-datanode
-    app.kubernetes.io/component: datanode
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.podDisruptionBudget.labels "fixed" (dict "app.kubernetes.io/component" "datanode" "app" "graylog-datanode") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.podDisruptionBudget.annotations "indent" 2) }}
 spec:
   minAvailable: {{ .Values.datanode.podDisruptionBudget.minAvailable | default 3 | int }}
   selector:

--- a/charts/graylog/templates/policy/pdb/graylog.yaml
+++ b/charts/graylog/templates/policy/pdb/graylog.yaml
@@ -5,10 +5,8 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "graylog.fullname" . | printf "%s-pdb" }}
   namespace: {{ .Release.Namespace }}
-  labels:
-    app: graylog-app
-    app.kubernetes.io/component: server
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.podDisruptionBudget.labels "fixed" (dict "app.kubernetes.io/component" "server" "app" "graylog-app") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.podDisruptionBudget.annotations "indent" 2) }}
 spec:
   minAvailable: {{ .Values.graylog.podDisruptionBudget.minAvailable | default 1 | int }}
   selector:

--- a/charts/graylog/templates/service/datanode.yaml
+++ b/charts/graylog/templates/service/datanode.yaml
@@ -3,12 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "graylog.datanode.service.name" . }}
-  labels:
-    app.kubernetes.io/component: datanode
-    # Deprecated: kept for backward compatibility with external selectors
-    # (e.g. ServiceMonitors); use app.kubernetes.io/component instead.
-    app.kubernetes.io/app-name: graylog-datanode
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{/* app.kubernetes.io/app-name is deprecated: kept for backward compatibility
+       with external selectors (e.g. ServiceMonitors); use
+       app.kubernetes.io/component instead. */}}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.service.labels "fixed" (dict "app.kubernetes.io/component" "datanode" "app.kubernetes.io/app-name" "graylog-datanode") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.service.annotations "indent" 2) }}
 spec:
   clusterIP: None
   ports:

--- a/charts/graylog/templates/service/fallback.yaml
+++ b/charts/graylog/templates/service/fallback.yaml
@@ -3,9 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "graylog.fallback.name" . }}
-  labels:
-    app.kubernetes.io/component: default-backend
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "fixed" (dict "app.kubernetes.io/component" "default-backend" "graylog-app" (include "graylog.fallback.name" .)) "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "indent" 2) }}
 spec:
   selector:
     graylog-app: {{ include "graylog.fallback.name" . }}

--- a/charts/graylog/templates/service/graylog.yaml
+++ b/charts/graylog/templates/service/graylog.yaml
@@ -3,9 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "graylog.service.name" . }}
-  labels:
-    app.kubernetes.io/component: server
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.service.labels "fixed" (dict "app.kubernetes.io/component" "server") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.service.annotations "indent" 2) }}
 spec:
   type: {{ .Values.graylog.service.type | default "ClusterIP" }}
   ports:

--- a/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
+++ b/charts/graylog/templates/service/ingress/graylog-forwarder.yaml
@@ -24,13 +24,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
-  labels:
-    app.kubernetes.io/component: forwarder
-    {{- include "graylog.labels" $root | nindent 4 }}
-  {{- with $channel.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "graylog.metadata.labels" (dict "context" $root "labels" $channel.labels "fixed" (dict "app.kubernetes.io/component" "forwarder") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $root "annotations" $channel.annotations "indent" 2) }}
 spec:
   {{- with $channel.className }}
   ingressClassName: {{ . }}

--- a/charts/graylog/templates/service/ingress/graylog.yaml
+++ b/charts/graylog/templates/service/ingress/graylog.yaml
@@ -8,24 +8,20 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "graylog.ingress.web.name" . }}
-  labels:
-    app.kubernetes.io/component: server
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.ingress.web.labels "fixed" (dict "app.kubernetes.io/component" "server") "indent" 2) }}
+  {{- $fixed := dict }}
   {{- $clusterissuer := .Values.ingress.config.tls.clusterIssuer.existingName }}
   {{- if or $clusterissuer .Values.ingress.config.tls.issuer.existingName .Values.ingress.config.tls.issuer.managed.enabled | and .Values.ingress.web.tls }}
     {{- if $clusterissuer }}
-    cert-manager.io/cluster-issuer: {{ $clusterissuer }}
+    {{- $_ := set $fixed "cert-manager.io/cluster-issuer" $clusterissuer }}
     {{- else }}
-    cert-manager.io/issuer: {{ include "graylog.cert-manager.issuer.name" . | coalesce .Values.ingress.config.tls.issuer.existingName }}
+    {{- $_ := set $fixed "cert-manager.io/issuer" (include "graylog.cert-manager.issuer.name" . | coalesce .Values.ingress.config.tls.issuer.existingName) }}
     {{- end }}
   {{- end }}
   {{- if eq .Values.ingress.web.className "nginx" | and .Values.ingress.config.defaultBackend.enabled }}
-    nginx.ingress.kubernetes.io/default-backend: {{ include "graylog.fallback.name" . }}
+  {{- $_ := set $fixed "nginx.ingress.kubernetes.io/default-backend" (include "graylog.fallback.name" .) }}
   {{- end }}
-  {{- with .Values.ingress.web.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.ingress.web.annotations "fixed" $fixed "indent" 2) }}
 spec:
   {{- if .Values.ingress.config.defaultBackend.enabled }}
   defaultBackend:

--- a/charts/graylog/templates/tests/test-credentials-secret.yaml
+++ b/charts/graylog/templates/tests/test-credentials-secret.yaml
@@ -3,12 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "graylog.fullname" . }}-test-credentials
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+  {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
+  {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-weight" "-5" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed" }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}
 type: Opaque
 data:
   GRAYLOG_ROOT_USERNAME: {{ .Values.graylog.config.rootUsername | default "admin" | b64enc }}

--- a/charts/graylog/templates/tests/test-datanode-registration.yaml
+++ b/charts/graylog/templates/tests/test-datanode-registration.yaml
@@ -3,11 +3,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "graylog.fullname" . }}-test-datanode-registration
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
+  {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}
 spec:
   containers:
     - name: test-datanode-registration

--- a/charts/graylog/templates/tests/test-graylog-api-health.yaml
+++ b/charts/graylog/templates/tests/test-graylog-api-health.yaml
@@ -3,11 +3,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "graylog.fullname" . }}-test-api-health
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
+  {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}
 spec:
   containers:
     - name: test-api-health

--- a/charts/graylog/templates/tests/test-graylog-cluster-status.yaml
+++ b/charts/graylog/templates/tests/test-graylog-cluster-status.yaml
@@ -3,11 +3,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "graylog.fullname" . }}-test-cluster-status
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
+  {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}
 spec:
   containers:
     - name: test-cluster-status

--- a/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
+++ b/charts/graylog/templates/tests/test-mongodb-connectivity.yaml
@@ -3,11 +3,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "graylog.fullname" . }}-test-mongodb
-  labels:
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- include "graylog.metadata.labels" (dict "context" $ "indent" 2) }}
+  {{- $hooks := dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "fixed" $hooks "indent" 2) }}
 spec:
   containers:
     - name: test-mongodb

--- a/charts/graylog/templates/workload/containers/_prestop-drain.tpl
+++ b/charts/graylog/templates/workload/containers/_prestop-drain.tpl
@@ -2,7 +2,8 @@
 Graylog preStop journal drain — token-free variant.
 
 Renders the `lifecycle:` block for the graylog-app container. Nothing is emitted
-unless graylog.lifecycle.preStopDrain.enabled is true.
+unless graylog.lifecycle.preStopDrain.enabled is true, or the user supplied their
+own hooks in graylog.lifecycle.postStart / graylog.lifecycle.preStop.
 
 Why this exists: a StatefulSet guarantees identity, not data migration. Graylog's
 graceful shutdown flushes in-memory buffers *into* the journal; it never drains
@@ -20,6 +21,24 @@ the token-based variant for what that buys.
 Call with: {{ include "graylog.lifecycle" . | nindent 10 }}
 */}}
 {{- define "graylog.lifecycle" -}}
+{{- $userPostStart := .Values.graylog.lifecycle.postStart }}
+{{- $userPreStop := .Values.graylog.lifecycle.preStop }}
+{{- if and $userPreStop .Values.graylog.lifecycle.preStopDrain.enabled }}
+{{- fail "graylog.lifecycle.preStop and graylog.lifecycle.preStopDrain.enabled=true both define a preStop hook, and a container can only have one.\n  Either:\n    Drop graylog.lifecycle.preStop and let the chart's journal drain run\n    Or set graylog.lifecycle.preStopDrain.enabled=false and drain from your own hook (see the scale-in runbook in docs/graylog-message-handling.md)." }}
+{{- end }}
+{{- if or $userPostStart $userPreStop }}
+{{- if not .Values.graylog.lifecycle.preStopDrain.enabled }}
+lifecycle:
+  {{- with $userPostStart }}
+  postStart:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $userPreStop }}
+  preStop:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- if .Values.graylog.lifecycle.preStopDrain.enabled }}
 {{- $drain := .Values.graylog.lifecycle.preStopDrain }}
 {{- $grace := .Values.graylog.terminationGracePeriodSeconds | int }}
@@ -43,6 +62,10 @@ Call with: {{ include "graylog.lifecycle" . | nindent 10 }}
 {{/* pollIntervalSeconds >= 1 is enforced by values.schema.json; only the
      cross-field constraints need a template-time guard. */}}
 lifecycle:
+  {{- with $userPostStart }}
+  postStart:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   preStop:
     exec:
       command:

--- a/charts/graylog/templates/workload/fallback.yaml
+++ b/charts/graylog/templates/workload/fallback.yaml
@@ -3,9 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "graylog.fallback.name" . }}
-  labels:
-    app.kubernetes.io/component: default-backend
-    {{- include "graylog.labels" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "fixed" (dict "app.kubernetes.io/component" "default-backend" "graylog-app" (include "graylog.fallback.name" .)) "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "indent" 2) }}
 spec:
   replicas: 1
   selector:
@@ -13,10 +12,8 @@ spec:
       graylog-app: {{ include "graylog.fallback.name" . }}
   template:
     metadata:
-      labels:
-        graylog-app: {{ include "graylog.fallback.name" . }}
-        app.kubernetes.io/component: default-backend
-        {{- include "graylog.selectorLabels" . | nindent 8 }}
+      {{- include "graylog.pod.labels" (dict "context" $ "fixed" (dict "app.kubernetes.io/component" "default-backend" "graylog-app" (include "graylog.fallback.name" .)) "indent" 6) }}
+      {{- include "graylog.metadata.annotations" (dict "context" $ "indent" 6) }}
     spec:
       containers:
         - name: busybox

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -229,14 +229,6 @@ spec:
         {{- with (include "graylog.datanode.data.storageClassName" . ) }}
         storageClassName: {{ . | quote }}
         {{- end }}
-        {{- with .Values.datanode.persistence.data.selector }}
-        selector:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.datanode.persistence.data.dataSource }}
-        dataSource:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         resources:
           requests:
             storage: {{ .Values.datanode.persistence.data.size | default "8Gi" | quote }}
@@ -257,14 +249,6 @@ spec:
         {{- end }}
         {{- with (include "graylog.datanode.nativeLibs.storageClassName" . ) }}
         storageClassName: {{ . | quote }}
-        {{- end }}
-        {{- with .Values.datanode.persistence.nativeLibs.selector }}
-        selector:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.datanode.persistence.nativeLibs.dataSource }}
-        dataSource:
-          {{- toYaml . | nindent 10 }}
         {{- end }}
         resources:
           requests:

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -215,8 +215,7 @@ spec:
     {{- if .Values.datanode.persistence.data.enabled }}
     - metadata:
         name: data
-        {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.persistence.data.labels "indent" 8) }}
-        {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.persistence.data.annotations "indent" 8) }}
+        {{- include "graylog.claim.metadata" (dict "labels" .Values.datanode.persistence.data.labels "annotations" .Values.datanode.persistence.data.annotations "indent" 8) }}
       spec:
         accessModes:
         {{- if .Values.datanode.persistence.data.accessModes }}
@@ -236,8 +235,7 @@ spec:
     {{- if .Values.datanode.persistence.nativeLibs.enabled }}
     - metadata:
         name: native-libs
-        {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.persistence.nativeLibs.labels "indent" 8) }}
-        {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.persistence.nativeLibs.annotations "indent" 8) }}
+        {{- include "graylog.claim.metadata" (dict "labels" .Values.datanode.persistence.nativeLibs.labels "annotations" .Values.datanode.persistence.nativeLibs.annotations "indent" 8) }}
       spec:
         accessModes:
         {{- if .Values.datanode.persistence.nativeLibs.accessModes }}

--- a/charts/graylog/templates/workload/statefulsets/datanode.yaml
+++ b/charts/graylog/templates/workload/statefulsets/datanode.yaml
@@ -3,12 +3,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "graylog.datanode.name" . }}
-  labels:
-    app: graylog-datanode
-    app.kubernetes.io/component: datanode
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    {{- include "graylog.annotations" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.labels "fixed" (dict "app" "graylog-datanode" "app.kubernetes.io/component" "datanode") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.annotations "indent" 2) }}
 spec:
   replicas: {{ include "graylog.datanode.replicas" . | int }}
   serviceName: {{ include "graylog.datanode.service.name" . }}
@@ -32,24 +28,41 @@ spec:
     whenScaled: {{ $dnRet.whenScaled | default "Retain" }}
   template:
     metadata:
-      labels:
-        app: graylog-datanode
-        app.kubernetes.io/component: datanode
-        {{- include "graylog.selectorLabels" . | nindent 8 }}
-      annotations:
-        checksum/config: {{ include "graylog.datanode.configChecksum" . }}
-        checksum/secret: {{ include "graylog.secretsChecksum" . }}
-      {{- with .Values.datanode.podAnnotations }}
+      {{- include "graylog.pod.labels" (dict "context" $ "labels" .Values.datanode.podLabels "fixed" (dict "app" "graylog-datanode" "app.kubernetes.io/component" "datanode") "indent" 6) }}
+      {{- $podAnnotations := dict "checksum/config" (include "graylog.datanode.configChecksum" .) "checksum/secret" (include "graylog.secretsChecksum" .) }}
+      {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.podAnnotations "fixed" $podAnnotations "indent" 6) }}
+    spec:
+      dnsPolicy: {{ .Values.datanode.dnsPolicy | default "ClusterFirst" }}
+      {{- with .Values.datanode.dnsConfig }}
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    spec:
-      dnsPolicy: ClusterFirst
+      {{- with .Values.datanode.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.datanode.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.datanode.schedulerName }}
+      schedulerName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.datanode.runtimeClassName }}
+      runtimeClassName: {{ . | quote }}
+      {{- end }}
+      {{- if not (kindIs "invalid" .Values.datanode.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.datanode.terminationGracePeriodSeconds | int }}
+      {{- end }}
       {{- with .Values.datanode.image.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.datanode.nodeSelector }}
       nodeSelector: {{ . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.datanode.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.nameOverride }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}
@@ -58,6 +71,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.datanode.sysctlInit.enabled .Values.datanode.extraInitContainers }}
       initContainers:
         {{- if .Values.datanode.sysctlInit.enabled }}
         - name: sysctl-init
@@ -72,6 +86,10 @@ spec:
             - -c
             - sysctl -w vm.max_map_count={{ .Values.datanode.sysctlInit.vmMaxMapCount }}
         {{- end }}
+        {{- with .Values.datanode.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: graylog-datanode
           image: {{ include "graylog.datanode.image" . }}
@@ -120,6 +138,13 @@ spec:
               mountPath: {{ .Values.datanode.persistence.data.mountPath | default "/var/lib/graylog-datanode" | quote }}
             - name: native-libs
               mountPath: {{ .Values.datanode.persistence.nativeLibs.mountPath | default "/native_libs" | quote }}
+            {{- with .Values.datanode.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.datanode.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.datanode.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
@@ -144,6 +169,9 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- with .Values.datanode.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       tolerations:
       {{- with .Values.datanode.tolerations }}
         {{- toYaml . | nindent 8 }}
@@ -168,7 +196,7 @@ spec:
                         - graylog-datanode
                 topologyKey: kubernetes.io/hostname
       {{- end }}
-      {{- if and .Values.datanode.persistence.data.enabled .Values.datanode.persistence.nativeLibs.enabled | not }}
+      {{- if or (not (and .Values.datanode.persistence.data.enabled .Values.datanode.persistence.nativeLibs.enabled)) .Values.datanode.extraVolumes }}
       volumes:
         {{- if not .Values.datanode.persistence.nativeLibs.enabled }}
         - name: native-libs
@@ -178,12 +206,17 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- with .Values.datanode.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
   {{- if or .Values.datanode.persistence.data.enabled .Values.datanode.persistence.nativeLibs.enabled }}
   volumeClaimTemplates:
     {{- if .Values.datanode.persistence.data.enabled }}
     - metadata:
         name: data
+        {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.persistence.data.labels "indent" 8) }}
+        {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.persistence.data.annotations "indent" 8) }}
       spec:
         accessModes:
         {{- if .Values.datanode.persistence.data.accessModes }}
@@ -196,6 +229,14 @@ spec:
         {{- with (include "graylog.datanode.data.storageClassName" . ) }}
         storageClassName: {{ . | quote }}
         {{- end }}
+        {{- with .Values.datanode.persistence.data.selector }}
+        selector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.datanode.persistence.data.dataSource }}
+        dataSource:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.datanode.persistence.data.size | default "8Gi" | quote }}
@@ -203,6 +244,8 @@ spec:
     {{- if .Values.datanode.persistence.nativeLibs.enabled }}
     - metadata:
         name: native-libs
+        {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.datanode.persistence.nativeLibs.labels "indent" 8) }}
+        {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.datanode.persistence.nativeLibs.annotations "indent" 8) }}
       spec:
         accessModes:
         {{- if .Values.datanode.persistence.nativeLibs.accessModes }}
@@ -214,6 +257,14 @@ spec:
         {{- end }}
         {{- with (include "graylog.datanode.nativeLibs.storageClassName" . ) }}
         storageClassName: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.datanode.persistence.nativeLibs.selector }}
+        selector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.datanode.persistence.nativeLibs.dataSource }}
+        dataSource:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         resources:
           requests:

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -312,8 +312,7 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: {{ include "graylog.volume.name" . }}
-        {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.persistence.labels "indent" 8) }}
-        {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.persistence.annotations "indent" 8) }}
+        {{- include "graylog.claim.metadata" (dict "labels" .Values.graylog.persistence.labels "annotations" .Values.graylog.persistence.annotations "indent" 8) }}
       spec:
         {{- with (include "graylog.storageClassName" .) }}
         storageClassName: {{ . | quote }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -4,12 +4,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "graylog.fullname" . }}
-  labels:
-    app: graylog-app
-    app.kubernetes.io/component: server
-    {{- include "graylog.labels" . | nindent 4 }}
-  annotations:
-    {{- include "graylog.annotations" . | nindent 4 }}
+  {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.labels "fixed" (dict "app" "graylog-app" "app.kubernetes.io/component" "server") "indent" 2) }}
+  {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.annotations "indent" 2) }}
 spec:
   replicas: {{ include "graylog.replicas" . | default 2 | int }}
   serviceName: {{ include "graylog.service.name" . }}
@@ -35,20 +31,30 @@ spec:
     whenScaled: {{ $ret.whenScaled | default "Retain" }}
   template:
     metadata:
-      labels:
-        app: graylog-app
-        app.kubernetes.io/component: server
-        {{- include "graylog.selectorLabels" . | nindent 8 }}
-      annotations:
-        checksum/config: {{ include "graylog.configChecksum" . }}
-        checksum/secret: {{ include "graylog.secretsChecksum" . }}
-      {{- with .Values.graylog.podAnnotations }}
+      {{- include "graylog.pod.labels" (dict "context" $ "labels" .Values.graylog.podLabels "fixed" (dict "app" "graylog-app" "app.kubernetes.io/component" "server") "indent" 6) }}
+      {{- $podAnnotations := dict "checksum/config" (include "graylog.configChecksum" .) "checksum/secret" (include "graylog.secretsChecksum" .) }}
+      {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.podAnnotations "fixed" $podAnnotations "indent" 6) }}
+    spec:
+      dnsPolicy: {{ .Values.graylog.dnsPolicy | default "ClusterFirst" }}
+      {{- with .Values.graylog.dnsConfig }}
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    spec:
-      dnsPolicy: ClusterFirst
-      {{- with .Values.graylog.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ int . }}
+      {{- with .Values.graylog.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graylog.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.graylog.schedulerName }}
+      schedulerName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.graylog.runtimeClassName }}
+      runtimeClassName: {{ . | quote }}
+      {{- end }}
+      {{- if not (kindIs "invalid" .Values.graylog.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.graylog.terminationGracePeriodSeconds | int }}
       {{- end }}
       {{- with .Values.graylog.image.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
@@ -56,6 +62,10 @@ spec:
       {{- end }}
       {{- with .Values.graylog.nodeSelector }}
       nodeSelector: {{ . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graylog.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.nameOverride }}
       serviceAccountName: {{ include "graylog.serviceAccountName" . }}
@@ -103,6 +113,9 @@ spec:
               mountPath: /mnt/os-tls
               readOnly: true
             {{- end }}
+            {{- with .Values.graylog.extraInitVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- if .Values.graylog.config.plugins.enabled }}
             - name: init-plugins
               mountPath: /mnt/plugins
@@ -129,6 +142,9 @@ spec:
               mountPath: /mnt/plugins
         {{- end }}
         {{- end }}
+        {{- end }}
+        {{- with .Values.graylog.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
         - name: graylog-app
@@ -211,7 +227,15 @@ spec:
             - name: init-plugins
               mountPath: /usr/share/graylog/plugin
             {{- end }}
-        {{- include "graylog.geolocation.sidecar" . | nindent 8 }}
+            {{- with .Values.graylog.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with (include "graylog.geolocation.sidecar" . | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.graylog.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       tolerations:
       {{- with .Values.graylog.tolerations }}
         {{- toYaml . | nindent 8 }}
@@ -241,6 +265,9 @@ spec:
         configMap:
           name: {{ include "graylog.cm.init.name" . }}
           defaultMode: 0755
+      {{- with .Values.graylog.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- if and .Values.graylog.config.geolocation.enabled .Values.graylog.config.geolocation.sidecar.enabled }}
       - name: geoip-entrypoint
         configMap:
@@ -285,17 +312,19 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: {{ include "graylog.volume.name" . }}
-        {{- with .Values.graylog.persistence.annotations }}
-        annotations:
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.graylog.persistence.labels }}
-        labels:
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "graylog.metadata.labels" (dict "context" $ "labels" .Values.graylog.persistence.labels "indent" 8) }}
+        {{- include "graylog.metadata.annotations" (dict "context" $ "annotations" .Values.graylog.persistence.annotations "indent" 8) }}
       spec:
         {{- with (include "graylog.storageClassName" .) }}
         storageClassName: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.graylog.persistence.selector }}
+        selector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.graylog.persistence.dataSource }}
+        dataSource:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         accessModes:
         {{- if .Values.graylog.persistence.accessModes }}

--- a/charts/graylog/templates/workload/statefulsets/graylog.yaml
+++ b/charts/graylog/templates/workload/statefulsets/graylog.yaml
@@ -318,14 +318,6 @@ spec:
         {{- with (include "graylog.storageClassName" .) }}
         storageClassName: {{ . | quote }}
         {{- end }}
-        {{- with .Values.graylog.persistence.selector }}
-        selector:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.graylog.persistence.dataSource }}
-        dataSource:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         accessModes:
         {{- if .Values.graylog.persistence.accessModes }}
         {{- range .Values.graylog.persistence.accessModes }}

--- a/charts/graylog/tests/byo_opensearch_test.yaml
+++ b/charts/graylog/tests/byo_opensearch_test.yaml
@@ -5,6 +5,7 @@ templates:
   - config/secret/opensearch.yaml
   - config/graylog.yaml
   - config/datanode.yaml
+  - config/init-graylog.yaml
 
 tests:
   # --- connection wiring -----------------------------------------------------
@@ -99,6 +100,39 @@ tests:
       - matchRegex:
           path: data.GRAYLOG_SERVER_JAVA_OPTS
           pattern: -Djavax\.net\.ssl\.trustStore=/usr/share/graylog/data/cacerts/graylog\.jks
+
+  - it: adds the OpenSearch CA on top of the truststore shipped in the image
+    template: config/init-graylog.yaml
+    set:
+      datanode.enabled: false
+      opensearch.enabled: true
+      opensearch.hosts: ["https://os.ns.svc:9200"]
+      opensearch.tls.enabled: true
+      opensearch.tls.caSecret: my-os-ca
+    asserts:
+      # the image truststore is the base, the OpenSearch CA is only ever added to it
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'cp "\$\{JAVA_HOME_LOCAL\}/lib/security/cacerts" "\$\{CACERTS_TMP\}"'
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'keytool -importcert -noprompt -alias byo-opensearch-ca -file "/mnt/os-tls/ca\.crt" -keystore "\$\{CACERTS_TMP\}"'
+      # the Graylog server certificate is not imported when Graylog TLS is off
+      - notMatchRegex:
+          path: data["init-script.sh"]
+          pattern: 'alias byoc'
+
+  - it: does not build a truststore when the OpenSearch CA secret is not set
+    template: config/init-graylog.yaml
+    set:
+      datanode.enabled: false
+      opensearch.enabled: true
+      opensearch.hosts: ["https://os.ns.svc:9200"]
+      opensearch.tls.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["init-script.sh"]
+          pattern: 'CACERTS_TMP'
 
   - it: does not mount the OpenSearch CA when tls is disabled
     template: workload/statefulsets/graylog.yaml

--- a/charts/graylog/tests/customization_test.yaml
+++ b/charts/graylog/tests/customization_test.yaml
@@ -142,11 +142,12 @@ tests:
           path: spec.volumeClaimTemplates[0].metadata.labels.tier
           value: backend
       - equal:
-          path: spec.volumeClaimTemplates[0].metadata.labels.env
-          value: dev
-      - equal:
           path: spec.volumeClaimTemplates[0].metadata.annotations.note
           value: graylog-data
+      # volumeClaimTemplates are immutable, so globals deliberately stop here —
+      # see tests/selector_immutability_test.yaml.
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels.env
 
   - it: adds extra volumes, mounts and containers to the Datanode pods
     set:
@@ -228,9 +229,9 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[1].metadata.annotations.note
           value: native-libs
-      - equal:
+      # As above: global.commonAnnotations must not reach an immutable field.
+      - notExists:
           path: spec.volumeClaimTemplates[1].metadata.annotations.owner
-          value: platform-team
 
   - it: keeps extra volumes on the Datanode when both persistent volumes are enabled
     set:

--- a/charts/graylog/tests/customization_test.yaml
+++ b/charts/graylog/tests/customization_test.yaml
@@ -1,0 +1,354 @@
+suite: workload customization
+templates:
+  - workload/statefulsets/graylog.yaml
+  - workload/statefulsets/datanode.yaml
+  # The StatefulSets' checksum helpers `include` these templates by path, so
+  # helm-unittest's template filter has to list them for the includes to resolve.
+  - config/graylog.yaml
+  - config/datanode.yaml
+  - config/secret/secrets.yaml
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  - it: adds extra volumes and volume mounts to the Graylog pods
+    set:
+      graylog.extraVolumes:
+        - name: custom-ca
+          secret:
+            secretName: custom-ca
+      graylog.extraVolumeMounts:
+        - name: custom-ca
+          mountPath: /etc/ssl/custom
+          readOnly: true
+      graylog.extraInitVolumeMounts:
+        - name: custom-ca
+          mountPath: /mnt/ca
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-ca
+            secret:
+              secretName: custom-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-ca
+            mountPath: /etc/ssl/custom
+            readOnly: true
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: custom-ca
+            mountPath: /mnt/ca
+
+  - it: adds extra containers and init containers to the Graylog pods
+    set:
+      graylog.extraContainers:
+        - name: log-shipper
+          image: busybox:1.37
+      graylog.extraInitContainers:
+        - name: wait-for-dns
+          image: busybox:1.37
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: log-shipper
+            image: busybox:1.37
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: wait-for-dns
+            image: busybox:1.37
+
+  - it: renders Graylog pod scheduling and runtime overrides
+    set:
+      graylog.priorityClassName: high-priority
+      graylog.schedulerName: custom-scheduler
+      graylog.runtimeClassName: gvisor
+      graylog.terminationGracePeriodSeconds: 120
+      graylog.dnsPolicy: None
+      graylog.dnsConfig:
+        nameservers: ["10.0.0.10"]
+      graylog.hostAliases:
+        - hostnames: ["mongo.internal"]
+      graylog.topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      graylog.lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "sleep 10"]
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+      - equal:
+          path: spec.template.spec.schedulerName
+          value: custom-scheduler
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: gvisor
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 120
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: None
+      - equal:
+          path: spec.template.spec.dnsConfig.nameservers[0]
+          value: 10.0.0.10
+      - equal:
+          path: spec.template.spec.hostAliases[0].hostnames[0]
+          value: mongo.internal
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          value: sleep 10
+
+  - it: keeps Graylog pod defaults when no overrides are set
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirst
+      - notExists:
+          path: spec.template.spec.priorityClassName
+      # Not absent by default: the preStop journal drain budget is derived from
+      # it, so the chart sets it explicitly rather than taking the Kubernetes
+      # default of 30s.
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 300
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+
+  - it: renders the Graylog volume claim metadata, selector and dataSource
+    set:
+      graylog.persistence.labels.tier: backend
+      graylog.persistence.annotations.note: graylog-data
+      global.commonLabels.env: dev
+      graylog.persistence.selector:
+        matchLabels:
+          disk: fast
+      graylog.persistence.dataSource:
+        name: graylog-snapshot
+        kind: VolumeSnapshot
+        apiGroup: snapshot.storage.k8s.io
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels.tier
+          value: backend
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels.env
+          value: dev
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.annotations.note
+          value: graylog-data
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.selector.matchLabels.disk
+          value: fast
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.dataSource.name
+          value: graylog-snapshot
+
+  - it: adds extra volumes, mounts and containers to the Datanode pods
+    set:
+      datanode.extraVolumes:
+        - name: scratch
+          emptyDir: {}
+      datanode.extraVolumeMounts:
+        - name: scratch
+          mountPath: /scratch
+      datanode.extraContainers:
+        - name: exporter
+          image: busybox:1.37
+      datanode.extraInitContainers:
+        - name: warmup
+          image: busybox:1.37
+      datanode.lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "sleep 5"]
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: scratch
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: scratch
+            mountPath: /scratch
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: exporter
+            image: busybox:1.37
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: warmup
+            image: busybox:1.37
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          value: sleep 5
+
+  - it: omits initContainers on the Datanode when nothing needs them
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: renders the Datanode volume claim metadata, selector and dataSource
+    set:
+      datanode.persistence.data.labels.tier: storage
+      datanode.persistence.data.annotations.note: hot
+      datanode.persistence.data.selector:
+        matchLabels:
+          disk: nvme
+      datanode.persistence.data.dataSource:
+        name: datanode-snapshot
+        kind: VolumeSnapshot
+        apiGroup: snapshot.storage.k8s.io
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels.tier
+          value: storage
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.annotations.note
+          value: hot
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.selector.matchLabels.disk
+          value: nvme
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.dataSource.name
+          value: datanode-snapshot
+
+  - it: renders the Datanode native-libs volume claim metadata, selector and dataSource
+    set:
+      datanode.persistence.nativeLibs.enabled: true
+      datanode.persistence.nativeLibs.labels.tier: storage
+      datanode.persistence.nativeLibs.annotations.note: native-libs
+      global.commonAnnotations.owner: platform-team
+      datanode.persistence.nativeLibs.selector:
+        matchLabels:
+          disk: ssd
+      datanode.persistence.nativeLibs.dataSource:
+        name: native-libs-snapshot
+        kind: VolumeSnapshot
+        apiGroup: snapshot.storage.k8s.io
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[1].metadata.name
+          value: native-libs
+      - equal:
+          path: spec.volumeClaimTemplates[1].metadata.labels.tier
+          value: storage
+      - equal:
+          path: spec.volumeClaimTemplates[1].metadata.annotations.note
+          value: native-libs
+      - equal:
+          path: spec.volumeClaimTemplates[1].metadata.annotations.owner
+          value: platform-team
+      - equal:
+          path: spec.volumeClaimTemplates[1].spec.selector.matchLabels.disk
+          value: ssd
+      - equal:
+          path: spec.volumeClaimTemplates[1].spec.dataSource.name
+          value: native-libs-snapshot
+
+  - it: keeps extra volumes on the Datanode when both persistent volumes are enabled
+    set:
+      datanode.persistence.data.enabled: true
+      datanode.persistence.nativeLibs.enabled: true
+      datanode.extraVolumes:
+        - name: scratch
+          emptyDir: {}
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: scratch
+            emptyDir: {}
+
+  - it: omits the Datanode volumes block when nothing needs it
+    set:
+      datanode.persistence.data.enabled: true
+      datanode.persistence.nativeLibs.enabled: true
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+
+  - it: renders Datanode pod scheduling and runtime overrides
+    set:
+      datanode.priorityClassName: high-priority
+      datanode.schedulerName: custom-scheduler
+      datanode.runtimeClassName: gvisor
+      datanode.terminationGracePeriodSeconds: 180
+      datanode.dnsPolicy: None
+      datanode.dnsConfig:
+        searches: ["graylog.svc.cluster.local"]
+      datanode.hostAliases:
+        - hostnames: ["mongo.internal"]
+      datanode.topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+      - equal:
+          path: spec.template.spec.schedulerName
+          value: custom-scheduler
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: gvisor
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 180
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: None
+      - equal:
+          path: spec.template.spec.dnsConfig.searches[0]
+          value: graylog.svc.cluster.local
+      - equal:
+          path: spec.template.spec.hostAliases[0].hostnames[0]
+          value: mongo.internal
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: DoNotSchedule
+
+  - it: keeps Datanode pod defaults when no overrides are set
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirst
+      - notExists:
+          path: spec.template.spec.priorityClassName
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+      - notExists:
+          path: spec.template.spec.runtimeClassName

--- a/charts/graylog/tests/customization_test.yaml
+++ b/charts/graylog/tests/customization_test.yaml
@@ -131,18 +131,11 @@ tests:
       - notExists:
           path: spec.template.spec.runtimeClassName
 
-  - it: renders the Graylog volume claim metadata, selector and dataSource
+  - it: renders the Graylog volume claim metadata
     set:
       graylog.persistence.labels.tier: backend
       graylog.persistence.annotations.note: graylog-data
       global.commonLabels.env: dev
-      graylog.persistence.selector:
-        matchLabels:
-          disk: fast
-      graylog.persistence.dataSource:
-        name: graylog-snapshot
-        kind: VolumeSnapshot
-        apiGroup: snapshot.storage.k8s.io
     template: workload/statefulsets/graylog.yaml
     asserts:
       - equal:
@@ -154,12 +147,6 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].metadata.annotations.note
           value: graylog-data
-      - equal:
-          path: spec.volumeClaimTemplates[0].spec.selector.matchLabels.disk
-          value: fast
-      - equal:
-          path: spec.volumeClaimTemplates[0].spec.dataSource.name
-          value: graylog-snapshot
 
   - it: adds extra volumes, mounts and containers to the Datanode pods
     set:
@@ -211,17 +198,10 @@ tests:
       - notExists:
           path: spec.template.spec.initContainers
 
-  - it: renders the Datanode volume claim metadata, selector and dataSource
+  - it: renders the Datanode volume claim metadata
     set:
       datanode.persistence.data.labels.tier: storage
       datanode.persistence.data.annotations.note: hot
-      datanode.persistence.data.selector:
-        matchLabels:
-          disk: nvme
-      datanode.persistence.data.dataSource:
-        name: datanode-snapshot
-        kind: VolumeSnapshot
-        apiGroup: snapshot.storage.k8s.io
     template: workload/statefulsets/datanode.yaml
     asserts:
       - equal:
@@ -230,26 +210,13 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].metadata.annotations.note
           value: hot
-      - equal:
-          path: spec.volumeClaimTemplates[0].spec.selector.matchLabels.disk
-          value: nvme
-      - equal:
-          path: spec.volumeClaimTemplates[0].spec.dataSource.name
-          value: datanode-snapshot
 
-  - it: renders the Datanode native-libs volume claim metadata, selector and dataSource
+  - it: renders the Datanode native-libs volume claim metadata
     set:
       datanode.persistence.nativeLibs.enabled: true
       datanode.persistence.nativeLibs.labels.tier: storage
       datanode.persistence.nativeLibs.annotations.note: native-libs
       global.commonAnnotations.owner: platform-team
-      datanode.persistence.nativeLibs.selector:
-        matchLabels:
-          disk: ssd
-      datanode.persistence.nativeLibs.dataSource:
-        name: native-libs-snapshot
-        kind: VolumeSnapshot
-        apiGroup: snapshot.storage.k8s.io
     template: workload/statefulsets/datanode.yaml
     asserts:
       - equal:
@@ -264,12 +231,6 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[1].metadata.annotations.owner
           value: platform-team
-      - equal:
-          path: spec.volumeClaimTemplates[1].spec.selector.matchLabels.disk
-          value: ssd
-      - equal:
-          path: spec.volumeClaimTemplates[1].spec.dataSource.name
-          value: native-libs-snapshot
 
   - it: keeps extra volumes on the Datanode when both persistent volumes are enabled
     set:

--- a/charts/graylog/tests/extra_objects_test.yaml
+++ b/charts/graylog/tests/extra_objects_test.yaml
@@ -1,0 +1,131 @@
+suite: extraObjects
+# The escape hatch for manifests the chart does not model. What matters here is
+# that entries are templated against the release context, that both the mapping
+# and string forms work, and that the chart's global metadata reaches them.
+templates:
+  - custom/extra-objects.yaml
+release:
+  name: graylog
+  namespace: graylog
+
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a mapping entry and templates the release context
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{ include "graylog.fullname" . }}-extra'
+          data:
+            release: '{{ .Release.Name }}'
+            namespace: '{{ .Release.Namespace }}'
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: graylog-extra
+      - equal:
+          path: data.release
+          value: graylog
+      - equal:
+          path: data.namespace
+          value: graylog
+
+  - it: renders a string entry, which keeps Helm syntax intact until render time
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: {{ include "graylog.fullname" . }}-string-form
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: graylog-string-form
+
+  - it: renders several entries at once
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: first
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: second
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: merges global.commonLabels and commonAnnotations into extra objects
+    set:
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: extra
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  - it: lets the object's own metadata win over the globals
+    set:
+      global.commonLabels.env: dev
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: extra
+            labels:
+              env: staging
+              tier: custom
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: staging
+      - equal:
+          path: metadata.labels.tier
+          value: custom
+
+  - it: adds no metadata block when no globals are set
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: extra
+    asserts:
+      - notExists:
+          path: metadata.labels
+      - notExists:
+          path: metadata.annotations
+
+  - it: fails with an actionable message when an entry has no kind
+    set:
+      extraObjects:
+        - apiVersion: v1
+          metadata:
+            name: oops
+    asserts:
+      - failedTemplate:
+          errorPattern: "must be a complete manifest with apiVersion, kind and metadata.name"

--- a/charts/graylog/tests/init_graylog_test.yaml
+++ b/charts/graylog/tests/init_graylog_test.yaml
@@ -82,6 +82,70 @@ tests:
           path: data["init-script.sh"]
           pattern: 'keytool -importcert'
 
+  - it: seeds the truststore from the image JDK truststore before importing certificates
+    set:
+      graylog.config.tls.enabled: true
+      graylog.config.tls.updateKeyStore: true
+    asserts:
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'cp "\$\{JAVA_HOME_LOCAL\}/lib/security/cacerts" "\$\{CACERTS_TMP\}"'
+      # never mutate the truststore already on the data volume, it may be a truncated
+      # keystore written by an older chart version
+      - notMatchRegex:
+          path: data["init-script.sh"]
+          pattern: 'keytool -importcert.*\$\{CACERTS_DST\}'
+
+  - it: locates the JDK truststore without executing java
+    # The java binary in the Graylog image carries a file capability
+    # (cap_net_bind_service=ep) and the init container runs with
+    # allowPrivilegeEscalation: false, which sets no_new_privs. The kernel then
+    # refuses to execve it: "java: Operation not permitted", exit 126. Deriving
+    # the JDK path by running java therefore always yields an empty string and
+    # fails the init container. Resolve it from ${JAVA_HOME} instead.
+    set:
+      graylog.config.tls.enabled: true
+      graylog.config.tls.updateKeyStore: true
+    asserts:
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'JAVA_HOME_LOCAL="\$\{JAVA_HOME\}"'
+      # No invocation of the java binary anywhere in the script.
+      - notMatchRegex:
+          path: data["init-script.sh"]
+          pattern: '\$\(java '
+      - notMatchRegex:
+          path: data["init-script.sh"]
+          pattern: 'java -XshowSettings'
+
+  - it: fails the init container when the image JDK truststore cannot be found
+    set:
+      graylog.config.tls.enabled: true
+      graylog.config.tls.updateKeyStore: true
+    asserts:
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'if \[ -z "\$\{JAVA_HOME_LOCAL\}" \] \|\| \[ ! -f "\$\{JAVA_HOME_LOCAL\}/lib/security/cacerts" \]; then'
+
+  - it: re-keys the seeded truststore when a custom keyStorePass is set
+    set:
+      graylog.config.tls.enabled: true
+      graylog.config.tls.updateKeyStore: true
+      graylog.config.tls.keyStorePass: s3cr3t
+    asserts:
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: "TRUSTSTORE_PASS='s3cr3t'"
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'keytool -storepasswd -keystore "\$\{CACERTS_TMP\}" -storepass changeit -new "\$\{TRUSTSTORE_PASS\}"'
+
+  - it: builds no truststore when neither Graylog TLS nor a BYO OpenSearch CA needs one
+    asserts:
+      - notMatchRegex:
+          path: data["init-script.sh"]
+          pattern: 'CACERTS_TMP'
+
   - it: skips TLS setup entirely when TLS is disabled
     set:
       graylog.config.tls.enabled: false

--- a/charts/graylog/tests/init_graylog_test.yaml
+++ b/charts/graylog/tests/init_graylog_test.yaml
@@ -140,6 +140,43 @@ tests:
           path: data["init-script.sh"]
           pattern: 'keytool -storepasswd -keystore "\$\{CACERTS_TMP\}" -storepass changeit -new "\$\{TRUSTSTORE_PASS\}"'
 
+  - it: fails the init container when a certificate import fails
+    # An import that fails silently still leaves a truststore behind for the mv
+    # below, and the JVM is pointed at it with -Djavax.net.ssl.trustStore. The
+    # missing certificate then surfaces as unexplained TLS failures at runtime
+    # instead of here. Every import is fatal.
+    set:
+      graylog.config.tls.enabled: true
+      graylog.config.tls.updateKeyStore: true
+    asserts:
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'keytool -importcert -noprompt -alias byoc -file "/mnt/tls/tls.crt".*\|\| \{ echo "Error: failed to import the Graylog certificate'
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'keytool -importcert -noprompt -alias byoc-ca .*\|\| \{ echo "Error: failed to import the root CA'
+      # The root CA import must be gated by an if, not chained onto the
+      # [ -n "${ROOT_CA}" ] test: with `&&` the whole line reports failure
+      # whenever ROOT_CA is empty, so an `|| exit 1` there would abort every
+      # deployment whose certificate carries no root CA.
+      - notMatchRegex:
+          path: data["init-script.sh"]
+          pattern: '\[ -n "\$\{ROOT_CA\}" \] &&'
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'if \[ -n "\$\{ROOT_CA\}" \]; then'
+
+  - it: fails the init container when the BYO OpenSearch CA import fails
+    set:
+      graylog.config.tls.enabled: false
+      opensearch.enabled: true
+      opensearch.tls.enabled: true
+      opensearch.tls.caSecret: os-ca
+    asserts:
+      - matchRegex:
+          path: data["init-script.sh"]
+          pattern: 'keytool -importcert -noprompt -alias byo-opensearch-ca .*\|\| \{ echo "Error: failed to import the OpenSearch CA'
+
   - it: builds no truststore when neither Graylog TLS nor a BYO OpenSearch CA needs one
     asserts:
       - notMatchRegex:

--- a/charts/graylog/tests/metadata_coverage_test.yaml
+++ b/charts/graylog/tests/metadata_coverage_test.yaml
@@ -270,12 +270,10 @@ tests:
           value: least-privilege
         documentIndex: 2
 
-  - it: labels and annotates the MongoDBCommunity object, its pods and its volume claims
+  - it: labels and annotates the MongoDBCommunity object and its volume claims
     set:
       mongodb.labels.tier: database
       mongodb.annotations.note: replica-set
-      mongodb.podLabels.tier: database
-      mongodb.podAnnotations.note: mongod
       mongodb.persistence.labels.tier: database
       mongodb.persistence.annotations.note: mongo-data
       global.commonLabels.env: dev
@@ -297,15 +295,11 @@ tests:
       - equal:
           path: metadata.annotations.owner
           value: platform-team
-      - equal:
-          path: spec.statefulSet.spec.template.metadata.labels.tier
-          value: database
-      - equal:
-          path: spec.statefulSet.spec.template.metadata.labels.env
-          value: dev
-      - equal:
-          path: spec.statefulSet.spec.template.metadata.annotations.note
-          value: mongod
+      # The operator owns the pod template of the StatefulSet it manages and
+      # discards anything the chart puts there, so the chart renders no pod
+      # metadata at all rather than promising customization it cannot deliver.
+      - notExists:
+          path: spec.statefulSet.spec.template.metadata
       - equal:
           path: spec.statefulSet.spec.volumeClaimTemplates[0].metadata.labels.tier
           value: database

--- a/charts/graylog/tests/metadata_coverage_test.yaml
+++ b/charts/graylog/tests/metadata_coverage_test.yaml
@@ -319,26 +319,6 @@ tests:
           path: spec.statefulSet.spec.volumeClaimTemplates[1].metadata.annotations.note
           value: mongo-data
 
-  - it: appends extra MongoDB users to the chart-managed ones
-    set:
-      mongodb.users:
-        - name: reporting
-          db: graylog
-          passwordSecretRef:
-            name: reporting-secret
-          roles:
-            - name: read
-              db: graylog
-          scramCredentialsSecretName: reporting-scram
-    template: custom/mongo-rs.yaml
-    asserts:
-      - lengthEqual:
-          path: spec.users
-          count: 3
-      - equal:
-          path: spec.users[2].name
-          value: reporting
-
   - it: labels the web Ingress and keeps the chart's own annotations
     set:
       ingress.enabled: true

--- a/charts/graylog/tests/metadata_coverage_test.yaml
+++ b/charts/graylog/tests/metadata_coverage_test.yaml
@@ -1,0 +1,581 @@
+suite: object labels and annotations coverage
+# Companion to metadata_test.yaml. That suite pins the precedence rules on a few
+# representative objects; this one walks every remaining object the chart renders
+# so a new template can never ship without the metadata helpers.
+templates:
+  - auth/mongo-sa.yaml
+  - config/datanode.yaml
+  - config/init-graylog.yaml
+  - config/geoip-sidecar-entrypoint.yaml
+  - config/sc/aws-gp3.yaml
+  - config/secret/datanode.yaml
+  - config/secret/opensearch.yaml
+  - config/secret/secrets.yaml
+  - custom/issuer.yaml
+  - custom/mongo-rs.yaml
+  - policy/pdb/datanode.yaml
+  - service/ingress/graylog.yaml
+  - service/ingress/graylog-forwarder.yaml
+  - tests/test-graylog-api-health.yaml
+  - tests/test-graylog-cluster-status.yaml
+  - tests/test-mongodb-connectivity.yaml
+  - tests/test-datanode-registration.yaml
+  - config/fallback.yaml
+  - service/fallback.yaml
+  - workload/fallback.yaml
+  # The StatefulSets' checksum helpers `include` these templates by path, so
+  # helm-unittest's template filter has to list them for the includes to resolve.
+  - config/graylog.yaml
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  - it: applies global.commonLabels and commonAnnotations to the ConfigMaps and Secrets
+    set:
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: config/datanode.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: config/datanode.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: config/init-graylog.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: config/init-graylog.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: config/secret/datanode.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: config/secret/datanode.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: config/secret/secrets.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: config/secret/secrets.yaml
+        documentIndex: 1
+
+  - it: renders per-object labels and annotations on the ConfigMaps and Secrets
+    set:
+      graylog.labels.tier: backend
+      graylog.annotations.note: primary
+      datanode.labels.tier: storage
+      datanode.annotations.note: search
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: backend
+        template: config/init-graylog.yaml
+      - equal:
+          path: metadata.annotations.note
+          value: primary
+        template: config/init-graylog.yaml
+      - equal:
+          path: metadata.labels.app
+          value: graylog-app
+        template: config/init-graylog.yaml
+      - equal:
+          path: metadata.labels.tier
+          value: storage
+        template: config/datanode.yaml
+      - equal:
+          path: metadata.annotations.note
+          value: search
+        template: config/datanode.yaml
+      - equal:
+          path: metadata.labels.app
+          value: graylog-datanode
+        template: config/datanode.yaml
+      - equal:
+          path: metadata.labels.tier
+          value: storage
+        template: config/secret/datanode.yaml
+      - equal:
+          path: metadata.annotations.note
+          value: search
+        template: config/secret/datanode.yaml
+
+  - it: keeps the resource-policy annotation on the backup secret when custom annotations are set
+    set:
+      graylog.annotations:
+        helm.sh/resource-policy: delete
+        note: primary
+      global.commonAnnotations.owner: platform-team
+    template: config/secret/secrets.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: metadata.annotations.note
+          value: primary
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  - it: labels and annotates the GeoIP sidecar entrypoint ConfigMap
+    set:
+      global.existingSecretName: graylog-external-secret
+      graylog.config.mongodb.customUri: mongodb://mongo:27017/graylog
+      mongodb.communityResource.enabled: false
+      graylog.config.geolocation.enabled: true
+      graylog.config.geolocation.sidecar.enabled: true
+      graylog.labels.tier: backend
+      graylog.annotations.note: primary
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    template: config/geoip-sidecar-entrypoint.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: backend
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.labels.app
+          value: graylog-app
+      - equal:
+          path: metadata.annotations.note
+          value: primary
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  - it: labels the provider StorageClass and keeps its Helm hook annotations
+    set:
+      provider: aws
+      global.commonLabels.env: dev
+      global.commonAnnotations:
+        helm.sh/hook: post-install
+        owner: platform-team
+    template: config/sc/aws-gp3.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  - it: labels and annotates the chart-managed cert-manager Issuer
+    set:
+      ingress.enabled: true
+      ingress.config.tls.issuer.managed.enabled: true
+      ingress.config.tls.issuer.labels.tier: edge
+      ingress.config.tls.issuer.annotations.note: letsencrypt
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    template: custom/issuer.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: edge
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.annotations.note
+          value: letsencrypt
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  - it: labels and annotates the Datanode PodDisruptionBudget
+    set:
+      datanode.podDisruptionBudget.enabled: true
+      datanode.podDisruptionBudget.labels.tier: storage
+      datanode.podDisruptionBudget.annotations.note: keep-two
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    template: policy/pdb/datanode.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: storage
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.labels.app
+          value: graylog-datanode
+      - equal:
+          path: metadata.annotations.note
+          value: keep-two
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  - it: labels and annotates the MongoDB ServiceAccount, Role and RoleBinding
+    set:
+      mongodb.serviceAccount.labels.tier: identity
+      mongodb.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/mongodb
+      mongodb.serviceAccount.role.labels.tier: rbac
+      mongodb.serviceAccount.role.annotations.note: least-privilege
+      global.commonLabels.env: dev
+    template: auth/mongo-sa.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: identity
+        documentIndex: 0
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789012:role/mongodb
+        documentIndex: 0
+      - equal:
+          path: metadata.labels.tier
+          value: rbac
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations.note
+          value: least-privilege
+        documentIndex: 1
+      - equal:
+          path: metadata.labels.tier
+          value: rbac
+        documentIndex: 2
+      - equal:
+          path: metadata.annotations.note
+          value: least-privilege
+        documentIndex: 2
+
+  - it: labels and annotates the MongoDBCommunity object, its pods and its volume claims
+    set:
+      mongodb.labels.tier: database
+      mongodb.annotations.note: replica-set
+      mongodb.podLabels.tier: database
+      mongodb.podAnnotations.note: mongod
+      mongodb.persistence.labels.tier: database
+      mongodb.persistence.annotations.note: mongo-data
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    template: custom/mongo-rs.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: database
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.labels.app
+          value: graylog-mongodb
+      - equal:
+          path: metadata.annotations.note
+          value: replica-set
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+      - equal:
+          path: spec.statefulSet.spec.template.metadata.labels.tier
+          value: database
+      - equal:
+          path: spec.statefulSet.spec.template.metadata.labels.env
+          value: dev
+      - equal:
+          path: spec.statefulSet.spec.template.metadata.annotations.note
+          value: mongod
+      - equal:
+          path: spec.statefulSet.spec.volumeClaimTemplates[0].metadata.labels.tier
+          value: database
+      - equal:
+          path: spec.statefulSet.spec.volumeClaimTemplates[0].metadata.annotations.note
+          value: mongo-data
+      - equal:
+          path: spec.statefulSet.spec.volumeClaimTemplates[1].metadata.labels.tier
+          value: database
+      - equal:
+          path: spec.statefulSet.spec.volumeClaimTemplates[1].metadata.annotations.note
+          value: mongo-data
+
+  - it: appends extra MongoDB users to the chart-managed ones
+    set:
+      mongodb.users:
+        - name: reporting
+          db: graylog
+          passwordSecretRef:
+            name: reporting-secret
+          roles:
+            - name: read
+              db: graylog
+          scramCredentialsSecretName: reporting-scram
+    template: custom/mongo-rs.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.users
+          count: 3
+      - equal:
+          path: spec.users[2].name
+          value: reporting
+
+  - it: labels the web Ingress and keeps the chart's own annotations
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.web.className: nginx
+      ingress.web.labels.tier: edge
+      ingress.web.annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: 100m
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    template: service/ingress/graylog.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: edge
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+          value: 100m
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/default-backend"]
+          value: graylog-waiting-room
+
+  - it: does not let custom annotations override the cert-manager issuer annotation
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.web.tls:
+        - secretName: graylog-tls
+          hosts: ["graylog.example.com"]
+      ingress.config.tls.clusterIssuer.existingName: letsencrypt-prod
+      ingress.web.annotations:
+        cert-manager.io/cluster-issuer: hijacked
+    template: service/ingress/graylog.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+
+  # Each forwarder gRPC channel renders its own Ingress, so per-object labels
+  # and annotations are set per channel; the globals land on both.
+  - it: labels and annotates the forwarder message-channel Ingress
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.configChannel.enabled: false
+      ingress.forwarder.messageChannel.labels.tier: edge
+      ingress.forwarder.messageChannel.annotations.note: forwarder
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    template: service/ingress/graylog-forwarder.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: edge
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: forwarder
+      - equal:
+          path: metadata.annotations.note
+          value: forwarder
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  - it: labels and annotates the forwarder config-channel Ingress
+    set:
+      ingress.enabled: true
+      ingress.forwarder.enabled: true
+      ingress.forwarder.messageChannel.enabled: false
+      ingress.forwarder.configChannel.labels.tier: edge
+      ingress.forwarder.configChannel.annotations.note: forwarder-config
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    template: service/ingress/graylog-forwarder.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: edge
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.annotations.note
+          value: forwarder-config
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  # The waiting-room objects are internal and deliberately have no per-object
+  # values surface, but the chart-wide globals still have to reach them.
+  - it: applies the global metadata to the ingress waiting-room objects
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.web.className: nginx
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: config/fallback.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: config/fallback.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: config/fallback.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: service/fallback.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: service/fallback.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: workload/fallback.yaml
+      - equal:
+          path: spec.template.metadata.labels.env
+          value: dev
+        template: workload/fallback.yaml
+      - equal:
+          path: spec.template.metadata.annotations.owner
+          value: platform-team
+        template: workload/fallback.yaml
+
+  - it: keeps the waiting-room selector matching its pods
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.web.className: nginx
+      global.commonLabels:
+        graylog-app: hijacked
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["graylog-app"]
+          value: graylog-waiting-room
+        template: workload/fallback.yaml
+      - equal:
+          path: spec.template.metadata.labels["graylog-app"]
+          value: graylog-waiting-room
+        template: workload/fallback.yaml
+      - equal:
+          path: spec.selector["graylog-app"]
+          value: graylog-waiting-room
+        template: service/fallback.yaml
+      - equal:
+          path: metadata.labels["graylog-app"]
+          value: graylog-waiting-room
+        template: service/fallback.yaml
+
+  - it: labels the helm test hooks and keeps their hook annotations
+    set:
+      global.commonLabels.env: dev
+      global.commonAnnotations:
+        helm.sh/hook: pre-install
+        owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: tests/test-graylog-api-health.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+        template: tests/test-graylog-api-health.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: tests/test-graylog-api-health.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: tests/test-graylog-cluster-status.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+        template: tests/test-graylog-cluster-status.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: tests/test-mongodb-connectivity.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+        template: tests/test-mongodb-connectivity.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: tests/test-datanode-registration.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+        template: tests/test-datanode-registration.yaml
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+        template: tests/test-datanode-registration.yaml
+
+  # The external-OpenSearch secret is only rendered in the BYO-OpenSearch
+  # topology, so it misses any assertion made under the default values.
+  - it: labels and annotates the external OpenSearch Secret
+    set:
+      datanode.enabled: false
+      opensearch.enabled: true
+      opensearch.hosts:
+        - https://os.example.com:9200
+      opensearch.auth.username: admin
+      opensearch.auth.password: opensearch-admin-pw
+      opensearch.tls.enabled: false
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+    template: config/secret/opensearch.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: server

--- a/charts/graylog/tests/metadata_test.yaml
+++ b/charts/graylog/tests/metadata_test.yaml
@@ -1,0 +1,304 @@
+suite: object labels and annotations
+templates:
+  - workload/statefulsets/graylog.yaml
+  - workload/statefulsets/datanode.yaml
+  - service/graylog.yaml
+  - service/datanode.yaml
+  - config/graylog.yaml
+  - auth/sa.yaml
+  - policy/pdb/graylog.yaml
+  - tests/test-credentials-secret.yaml
+  # The StatefulSets' checksum helpers `include` these templates by path, so
+  # helm-unittest's template filter has to list them for the includes to resolve.
+  - config/datanode.yaml
+  - config/secret/secrets.yaml
+release:
+  name: graylog
+  namespace: graylog
+tests:
+  - it: applies global.commonLabels to every object
+    set:
+      global.commonLabels:
+        env: dev
+        team: observability
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: metadata.labels.team
+          value: observability
+        template: workload/statefulsets/datanode.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: service/graylog.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: service/datanode.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: config/graylog.yaml
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: auth/sa.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.labels.env
+          value: dev
+        template: tests/test-credentials-secret.yaml
+
+  - it: applies global.commonAnnotations to every object
+    set:
+      global.commonAnnotations:
+        owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: workload/statefulsets/datanode.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: service/graylog.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: config/graylog.yaml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+        template: auth/sa.yaml
+        documentIndex: 0
+
+  - it: applies global.commonLabels and commonAnnotations to the PodDisruptionBudget
+    set:
+      graylog.podDisruptionBudget.enabled: true
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+      graylog.podDisruptionBudget.labels.tier: critical
+      graylog.podDisruptionBudget.annotations.note: keep-two
+    template: policy/pdb/graylog.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: dev
+      - equal:
+          path: metadata.labels.tier
+          value: critical
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+      - equal:
+          path: metadata.annotations.note
+          value: keep-two
+      - equal:
+          path: metadata.labels.app
+          value: graylog-app
+
+  - it: omits the annotations block entirely when nothing is set
+    template: service/graylog.yaml
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: renders per-object labels and annotations on the Graylog StatefulSet
+    set:
+      graylog.labels.tier: backend
+      graylog.annotations.note: primary
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: backend
+      - equal:
+          path: metadata.annotations.note
+          value: primary
+
+  - it: renders per-object labels and annotations on the Datanode StatefulSet
+    set:
+      datanode.labels.tier: storage
+      datanode.annotations.note: search
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: storage
+      - equal:
+          path: metadata.annotations.note
+          value: search
+
+  - it: renders service labels and annotations
+    set:
+      graylog.service.labels.tier: frontend
+      graylog.service.annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      datanode.service.labels.tier: storage
+      datanode.service.annotations.note: headless
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: frontend
+        template: service/graylog.yaml
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-internal"]
+          value: "true"
+        template: service/graylog.yaml
+      - equal:
+          path: metadata.labels.tier
+          value: storage
+        template: service/datanode.yaml
+      - equal:
+          path: metadata.annotations.note
+          value: headless
+        template: service/datanode.yaml
+
+  - it: lets per-object values override global.commonLabels and commonAnnotations
+    set:
+      global.commonLabels.tier: unset
+      global.commonAnnotations.note: unset
+      graylog.labels.tier: backend
+      graylog.annotations.note: primary
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: backend
+      - equal:
+          path: metadata.annotations.note
+          value: primary
+
+  - it: does not let custom labels override the chart's own identity labels
+    set:
+      graylog.labels:
+        app.kubernetes.io/name: hijacked
+        app: hijacked
+      global.commonLabels:
+        app.kubernetes.io/managed-by: hijacked
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: graylog
+      - equal:
+          path: metadata.labels.app
+          value: graylog-app
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+
+  - it: keeps Helm hook annotations when custom annotations are set
+    set:
+      global.commonAnnotations:
+        helm.sh/hook: pre-install
+        owner: platform-team
+    template: tests/test-credentials-secret.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+
+  - it: renders pod labels and annotations alongside the config checksums
+    set:
+      graylog.podLabels.tier: backend
+      graylog.podAnnotations.note: primary
+      datanode.podLabels.tier: storage
+      datanode.podAnnotations.note: search
+      global.commonLabels.env: dev
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.tier
+          value: backend
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: spec.template.metadata.labels.env
+          value: dev
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: graylog-app
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: spec.template.metadata.annotations.note
+          value: primary
+        template: workload/statefulsets/graylog.yaml
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+        template: workload/statefulsets/graylog.yaml
+      - exists:
+          path: spec.template.metadata.annotations["checksum/secret"]
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: spec.template.metadata.labels.tier
+          value: storage
+        template: workload/statefulsets/datanode.yaml
+      - equal:
+          path: spec.template.metadata.annotations.note
+          value: search
+        template: workload/statefulsets/datanode.yaml
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+        template: workload/statefulsets/datanode.yaml
+
+  - it: does not let custom pod labels break the workload selector
+    set:
+      graylog.podLabels:
+        app.kubernetes.io/instance: hijacked
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: graylog
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: graylog
+
+  - it: labels and annotates the Role and RoleBinding
+    set:
+      serviceAccount.role.create: true
+      serviceAccount.role.rules:
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["get"]
+      serviceAccount.role.labels.tier: rbac
+      serviceAccount.role.annotations.note: least-privilege
+      serviceAccount.labels.tier: identity
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/graylog
+    template: auth/sa.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789012:role/graylog
+        documentIndex: 0
+      - equal:
+          path: metadata.labels.tier
+          value: identity
+        documentIndex: 0
+      - equal:
+          path: metadata.labels.tier
+          value: rbac
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations.note
+          value: least-privilege
+        documentIndex: 1
+      - equal:
+          path: metadata.labels.tier
+          value: rbac
+        documentIndex: 2
+      - equal:
+          path: metadata.annotations.note
+          value: least-privilege
+        documentIndex: 2

--- a/charts/graylog/tests/prestop_drain_test.yaml
+++ b/charts/graylog/tests/prestop_drain_test.yaml
@@ -657,3 +657,43 @@ tests:
       - notMatchRegex:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
           pattern: 'sleep [0-9]'
+
+  # User-supplied hooks share graylog.lifecycle with the chart-managed drain.
+  - it: renders a user-supplied preStop hook when the drain is off
+    set:
+      graylog.lifecycle.preStop:
+        exec:
+          command: ["/bin/sh", "-c", "sleep 10"]
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          value: sleep 10
+
+  - it: renders a user-supplied postStart hook alongside the drain
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.lifecycle.postStart:
+        exec:
+          command: ["/bin/sh", "-c", "echo started"]
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
+          value: echo started
+      # The drain still owns preStop.
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+
+  - it: fails when a user preStop hook collides with the drain
+    set:
+      graylog.lifecycle.preStopDrain.enabled: true
+      graylog.lifecycle.preStop:
+        exec:
+          command: ["/bin/sh", "-c", "sleep 10"]
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      # helm-unittest matches a later portion of a multi-line fail message, not
+      # its opening sentence — anchor on one of the remedy lines.
+      - failedTemplate:
+          errorPattern: "Drop graylog\\.lifecycle\\.preStop and let the chart's journal drain run"

--- a/charts/graylog/tests/selector_immutability_test.yaml
+++ b/charts/graylog/tests/selector_immutability_test.yaml
@@ -1,16 +1,28 @@
-suite: selector immutability under custom labels
-# A StatefulSet's spec.selector is immutable. If global.commonLabels or a
-# workload's podLabels ever leaked into it, adding a label to an existing
-# release would make `helm upgrade` fail outright — the one customization bug
-# that cannot be worked around without deleting and recreating the workload.
+suite: immutable fields under custom labels
+# Kubernetes accepts updates to only six StatefulSet spec fields: replicas,
+# ordinals, template, updateStrategy, persistentVolumeClaimRetentionPolicy and
+# minReadySeconds. Everything else — spec.selector and spec.volumeClaimTemplates
+# in particular — is rejected on update.
+#
+# That makes customization uniquely dangerous here: any chart-injected metadata
+# that reaches an immutable field rewrites it on every existing release and
+# makes `helm upgrade` fail outright, with no fix short of recreating the
+# workload. Worse, the chart's identity labels carry helm.sh/chart and
+# app.kubernetes.io/version, so the failure would recur on every version bump.
 #
 # The contract these tests pin:
 #   1. spec.selector.matchLabels contains ONLY the chart's fixed identity
 #      labels, whatever the user sets.
 #   2. spec.template.metadata.labels is a strict superset of it, so pods still
-#      match after custom labels are added.
-# The same applies to Service and PodDisruptionBudget selectors, which must
-# keep matching pods that were created before the labels were added.
+#      match after custom labels are added. (template IS mutable.)
+#   3. spec.volumeClaimTemplates carries NO metadata unless the user explicitly
+#      asked for it — no chart labels, no global.commonLabels/commonAnnotations.
+# The same reasoning applies to Service and PodDisruptionBudget selectors, which
+# must keep matching pods created before the labels were added.
+#
+# If you add a new object or a new metadata call site, extend this suite. The
+# helper to use for anything immutable is "graylog.claim.metadata", never
+# "graylog.metadata.labels".
 templates:
   - workload/statefulsets/graylog.yaml
   - workload/statefulsets/datanode.yaml
@@ -18,6 +30,7 @@ templates:
   - service/datanode.yaml
   - policy/pdb/graylog.yaml
   - policy/pdb/datanode.yaml
+  - custom/mongo-rs.yaml
   # The StatefulSets' checksum helpers `include` these templates by path, so
   # helm-unittest's template filter has to list them for the includes to resolve.
   - config/graylog.yaml
@@ -157,3 +170,74 @@ tests:
             app.kubernetes.io/name: graylog
             app.kubernetes.io/instance: graylog
         template: workload/statefulsets/datanode.yaml
+
+  # --- volumeClaimTemplates: immutable, so chart metadata must never appear ---
+
+  - it: keeps chart and global metadata off the Graylog volume claim template
+    set:
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+      graylog.labels.tier: backend
+      graylog.annotations.note: primary
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      # Nothing at all by default: adding any of these to a live release would
+      # make `helm upgrade` fail on an immutable field.
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.annotations
+
+  - it: keeps chart and global metadata off the Datanode volume claim templates
+    set:
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+      datanode.labels.tier: storage
+      datanode.persistence.nativeLibs.enabled: true
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.annotations
+      - notExists:
+          path: spec.volumeClaimTemplates[1].metadata.labels
+      - notExists:
+          path: spec.volumeClaimTemplates[1].metadata.annotations
+
+  - it: keeps chart and global metadata off the MongoDB volume claim templates
+    # The operator propagates these into the StatefulSet it manages, so the same
+    # immutability rule applies one level removed.
+    set:
+      global.commonLabels.env: dev
+      global.commonAnnotations.owner: platform-team
+      mongodb.labels.tier: database
+    template: custom/mongo-rs.yaml
+    asserts:
+      - notExists:
+          path: spec.statefulSet.spec.volumeClaimTemplates[0].metadata.labels
+      - notExists:
+          path: spec.statefulSet.spec.volumeClaimTemplates[0].metadata.annotations
+      - notExists:
+          path: spec.statefulSet.spec.volumeClaimTemplates[1].metadata.labels
+      - notExists:
+          path: spec.statefulSet.spec.volumeClaimTemplates[1].metadata.annotations
+
+  - it: still renders volume claim metadata the operator explicitly asked for
+    # Opt-in remains supported — it is then the operator's own one-time choice,
+    # not something the chart does to every existing release.
+    set:
+      global.commonLabels.env: dev
+      graylog.persistence.labels.tier: backend
+      graylog.persistence.annotations.note: graylog-data
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels.tier
+          value: backend
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.annotations.note
+          value: graylog-data
+      # ...and the globals still do not ride along.
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.labels.env

--- a/charts/graylog/tests/selector_immutability_test.yaml
+++ b/charts/graylog/tests/selector_immutability_test.yaml
@@ -1,0 +1,159 @@
+suite: selector immutability under custom labels
+# A StatefulSet's spec.selector is immutable. If global.commonLabels or a
+# workload's podLabels ever leaked into it, adding a label to an existing
+# release would make `helm upgrade` fail outright — the one customization bug
+# that cannot be worked around without deleting and recreating the workload.
+#
+# The contract these tests pin:
+#   1. spec.selector.matchLabels contains ONLY the chart's fixed identity
+#      labels, whatever the user sets.
+#   2. spec.template.metadata.labels is a strict superset of it, so pods still
+#      match after custom labels are added.
+# The same applies to Service and PodDisruptionBudget selectors, which must
+# keep matching pods that were created before the labels were added.
+templates:
+  - workload/statefulsets/graylog.yaml
+  - workload/statefulsets/datanode.yaml
+  - service/graylog.yaml
+  - service/datanode.yaml
+  - policy/pdb/graylog.yaml
+  - policy/pdb/datanode.yaml
+  # The StatefulSets' checksum helpers `include` these templates by path, so
+  # helm-unittest's template filter has to list them for the includes to resolve.
+  - config/graylog.yaml
+  - config/datanode.yaml
+  - config/secret/secrets.yaml
+release:
+  name: graylog
+  namespace: graylog
+
+tests:
+  - it: keeps custom labels out of the Graylog StatefulSet selector
+    set:
+      global.commonLabels.env: dev
+      global.commonLabels.team: platform
+      graylog.labels.tier: backend
+      graylog.podLabels.custom: "yes"
+    template: workload/statefulsets/graylog.yaml
+    asserts:
+      # The selector is exactly the chart's identity labels — nothing else.
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: graylog-app
+            app.kubernetes.io/name: graylog
+            app.kubernetes.io/instance: graylog
+      - notExists:
+          path: spec.selector.matchLabels.env
+      - notExists:
+          path: spec.selector.matchLabels.team
+      - notExists:
+          path: spec.selector.matchLabels.custom
+      - notExists:
+          path: spec.selector.matchLabels.tier
+      # ... while the pods carry them, and still match the selector.
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: graylog-app
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: graylog
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: graylog
+      - equal:
+          path: spec.template.metadata.labels.env
+          value: dev
+      - equal:
+          path: spec.template.metadata.labels.custom
+          value: "yes"
+
+  - it: keeps custom labels out of the Datanode StatefulSet selector
+    set:
+      global.commonLabels.env: dev
+      datanode.labels.tier: storage
+      datanode.podLabels.custom: "yes"
+    template: workload/statefulsets/datanode.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: graylog-datanode
+            app.kubernetes.io/name: graylog
+            app.kubernetes.io/instance: graylog
+      - notExists:
+          path: spec.selector.matchLabels.env
+      - notExists:
+          path: spec.selector.matchLabels.custom
+      - equal:
+          path: spec.template.metadata.labels.env
+          value: dev
+      - equal:
+          path: spec.template.metadata.labels.custom
+          value: "yes"
+
+  - it: keeps custom labels out of the Service selectors
+    set:
+      global.commonLabels.env: dev
+      graylog.service.labels.tier: edge
+      datanode.service.labels.tier: storage
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app: graylog-app
+            app.kubernetes.io/name: graylog
+            app.kubernetes.io/instance: graylog
+        template: service/graylog.yaml
+      - equal:
+          path: spec.selector
+          value:
+            app: graylog-datanode
+            app.kubernetes.io/name: graylog
+            app.kubernetes.io/instance: graylog
+        template: service/datanode.yaml
+      # The custom label still lands on the object itself.
+      - equal:
+          path: metadata.labels.tier
+          value: edge
+        template: service/graylog.yaml
+
+  - it: keeps custom labels out of the PodDisruptionBudget selectors
+    set:
+      global.commonLabels.env: dev
+      graylog.podDisruptionBudget.labels.tier: backend
+      datanode.podDisruptionBudget.labels.tier: storage
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: graylog-app
+            app.kubernetes.io/name: graylog
+            app.kubernetes.io/instance: graylog
+        template: policy/pdb/graylog.yaml
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: graylog-datanode
+            app.kubernetes.io/name: graylog
+            app.kubernetes.io/instance: graylog
+        template: policy/pdb/datanode.yaml
+
+  - it: leaves selectors identical whether or not custom labels are set
+    # Belt and braces: the default render, asserted against the same literal
+    # selector as the customized renders above.
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: graylog-app
+            app.kubernetes.io/name: graylog
+            app.kubernetes.io/instance: graylog
+        template: workload/statefulsets/graylog.yaml
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: graylog-datanode
+            app.kubernetes.io/name: graylog
+            app.kubernetes.io/instance: graylog
+        template: workload/statefulsets/datanode.yaml

--- a/charts/graylog/values.schema.json
+++ b/charts/graylog/values.schema.json
@@ -670,7 +670,13 @@
                 "storageClass": { "type": "string" },
                 "mountPath": { "type": "string" },
                 "accessModes": { "type": "array" },
-                "size": { "type": "string" }
+                "size": { "type": "string" },
+                "annotations": {
+                  "type": "object"
+                },
+                "labels": {
+                  "type": "object"
+                }
               }
             },
             "nativeLibs": {
@@ -936,9 +942,6 @@
         "arbiters": { "type": "integer" },
         "annotations": { "type": "object", "description": "Annotations for the MongoDBCommunity object" },
         "labels": { "type": "object", "description": "Labels for the MongoDBCommunity object" },
-        "podAnnotations": { "type": "object" },
-        "podLabels": { "type": "object" },
-        "users": { "type": "array", "items": { "type": "object" } },
         "persistence": {
           "type": "object",
           "properties": {

--- a/charts/graylog/values.schema.json
+++ b/charts/graylog/values.schema.json
@@ -27,6 +27,11 @@
       "type": "string",
       "description": "Override the fully qualified app name."
     },
+    "extraObjects": {
+      "type": "array",
+      "description": "Arbitrary manifests rendered as part of this release (ServiceMonitor, ExternalSecret, NetworkPolicy, ...). Each entry is templated and may be given as a mapping or as a string.",
+      "items": { "type": [ "object", "string" ] }
+    },
     "global": {
       "type": "object",
       "properties": {
@@ -39,7 +44,9 @@
           }
         },
         "storageClass": { "type": "string" },
-        "existingSecretName": { "type": "string", "description": "Name of existing Graylog secret containing GRAYLOG_MONGODB_URI, GRAYLOG_ROOT_USERNAME, GRAYLOG_PASSWORD_SECRET, and GRAYLOG_ROOT_PASSWORD_SHA2" }
+        "existingSecretName": { "type": "string", "description": "Name of existing Graylog secret containing GRAYLOG_MONGODB_URI, GRAYLOG_ROOT_USERNAME, GRAYLOG_PASSWORD_SECRET, and GRAYLOG_ROOT_PASSWORD_SHA2" },
+        "commonLabels": { "type": "object", "description": "Labels added to every object deployed by this chart" },
+        "commonAnnotations": { "type": "object", "description": "Annotations added to every object deployed by this chart" }
       }
     },
     "graylog": {
@@ -54,6 +61,8 @@
           "properties": {
             "nameOverride": { "type": "string" },
             "type": { "type": "string" },
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" },
             "ports": {
               "type": "object",
               "properties": {
@@ -396,6 +405,12 @@
             },
             "labels": {
               "type": "object"
+            },
+            "selector": {
+              "type": "object"
+            },
+            "dataSource": {
+              "type": "object"
             }
           }
         },
@@ -428,7 +443,10 @@
         },
         "lifecycle": {
           "type": "object",
+          "description": "Lifecycle hooks for the graylog-app container. postStart/preStop are user-supplied; preStopDrain is the chart-managed journal drain.",
           "properties": {
+            "postStart": { "type": "object", "description": "User-supplied postStart hook." },
+            "preStop": { "type": "object", "description": "User-supplied preStop hook. Mutually exclusive with preStopDrain.enabled — a container can only have one preStop hook." },
             "preStopDrain": {
               "type": "object",
               "description": "Hold pod termination while the on-disk journal drains, so scaling in does not strand unprocessed messages. Requires graylog.service.metrics.enabled.",
@@ -450,7 +468,9 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
-            "minAvailable": { "type": "integer" }
+            "minAvailable": { "type": "integer" },
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" }
           }
         },
         "podSecurityContext": {
@@ -465,9 +485,12 @@
           "type": ["object", "null"],
           "description": "Container securityContext applied to the graylog-app container. Set to null to omit it entirely ({} is coalesced back to the chart defaults)."
         },
+        "annotations": { "type": "object", "description": "Annotations for the StatefulSet object" },
+        "labels": { "type": "object", "description": "Labels for the StatefulSet object" },
         "podAnnotations": {
           "type": "object"
         },
+        "podLabels": { "type": "object" },
         "nodeSelector": {
           "type": "object"
         },
@@ -478,10 +501,48 @@
         "affinity": {
           "type": "object"
         },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "priorityClassName": { "type": [ "string", "null" ] },
+        "schedulerName": { "type": [ "string", "null" ] },
+        "runtimeClassName": { "type": [ "string", "null" ] },
+        "dnsPolicy": { "type": [ "string", "null" ] },
+        "dnsConfig": { "type": "object" },
+        "hostAliases": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
         "extraEnv": {
           "type": "array",
           "items": { "type": "object" },
           "description": "Full EnvVar objects (supports valueFrom)"
+        },
+        "extraVolumes": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional volumes for the pod"
+        },
+        "extraVolumeMounts": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional volume mounts for the main container"
+        },
+        "extraInitVolumeMounts": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional volume mounts for the chart's copy-data init container"
+        },
+        "extraInitContainers": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional init containers, rendered after the chart's own init containers"
+        },
+        "extraContainers": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional sidecar containers"
         }
       }
     },
@@ -494,6 +555,8 @@
         "service": {
           "type": "object",
           "properties": {
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" },
             "ports": {
               "type": "object",
               "properties": {
@@ -623,7 +686,19 @@
                 "storageClass": { "type": "string" },
                 "mountPath": { "type": "string" },
                 "accessModes": { "type": "array" },
-                "size": { "type": "string" }
+                "size": { "type": "string" },
+                "annotations": {
+                  "type": "object"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "selector": {
+                  "type": "object"
+                },
+                "dataSource": {
+                  "type": "object"
+                }
               }
             }
           }
@@ -654,7 +729,9 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
-            "minAvailable": { "type": "integer" }
+            "minAvailable": { "type": "integer" },
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" }
           }
         },
         "podSecurityContext": {
@@ -665,9 +742,12 @@
           "type": ["object", "null"],
           "description": "Container securityContext applied to the graylog-datanode container. Set to null to omit it entirely ({} is coalesced back to the chart defaults)."
         },
+        "annotations": { "type": "object", "description": "Annotations for the StatefulSet object" },
+        "labels": { "type": "object", "description": "Labels for the StatefulSet object" },
         "podAnnotations": {
           "type": "object"
         },
+        "podLabels": { "type": "object" },
         "nodeSelector": {
           "type": "object"
         },
@@ -678,10 +758,45 @@
         "affinity": {
           "type": "object"
         },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "priorityClassName": { "type": [ "string", "null" ] },
+        "schedulerName": { "type": [ "string", "null" ] },
+        "runtimeClassName": { "type": [ "string", "null" ] },
+        "terminationGracePeriodSeconds": { "type": [ "integer", "null" ] },
+        "dnsPolicy": { "type": [ "string", "null" ] },
+        "dnsConfig": { "type": "object" },
+        "hostAliases": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "lifecycle": { "type": "object", "description": "Lifecycle hooks for the main container" },
         "extraEnv": {
           "type": "array",
           "items": { "type": "object" },
           "description": "Full EnvVar objects (supports valueFrom)"
+        },
+        "extraVolumes": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional volumes for the pod"
+        },
+        "extraVolumeMounts": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional volume mounts for the main container"
+        },
+        "extraInitContainers": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional init containers, rendered after the chart's own init containers"
+        },
+        "extraContainers": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Additional sidecar containers"
         }
       }
     },
@@ -724,11 +839,14 @@
         "create": { "type": "boolean" },
         "automount": { "type": "boolean" },
         "annotations": { "type": "object" },
+        "labels": { "type": "object" },
         "nameOverride": { "type": "string" },
         "role": {
           "type": "object",
           "properties": {
             "create": { "type": "boolean" },
+            "annotations": { "type": "object", "description": "Annotations for the Role and RoleBinding objects" },
+            "labels": { "type": "object", "description": "Labels for the Role and RoleBinding objects" },
             "rules": { "type": "array" }
           }
         }
@@ -760,6 +878,8 @@
                   "type": "object",
                   "properties": {
                     "existingName": { "type": ["string", "null"] },
+                    "annotations": { "type": "object", "description": "Annotations for the chart-managed cert-manager Issuer" },
+                    "labels": { "type": "object", "description": "Labels for the chart-managed cert-manager Issuer" },
                     "managed": {
                       "type": "object",
                       "properties": {
@@ -779,6 +899,7 @@
             "enabled": { "type": "boolean" },
             "className": { "type": "string" },
             "annotations": { "type": "object" },
+            "labels": { "type": "object" },
             "hosts": {
               "type": "array",
               "items": {
@@ -803,30 +924,11 @@
         },
         "forwarder": {
           "type": "object",
+          "description": "Forwarder ingest. Each gRPC channel becomes its own Ingress: the message channel (13301) and the configuration channel (13302).",
           "properties": {
             "enabled": { "type": "boolean" },
-            "className": { "type": "string" },
-            "annotations": { "type": "object" },
-            "hosts": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "host": { "type": "string" },
-                  "paths": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "path": { "type": "string" },
-                        "pathType": { "type": "string" }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "tls": { "type": "array" }
+            "messageChannel": { "$ref": "#/$defs/forwarderChannel" },
+            "configChannel": { "$ref": "#/$defs/forwarderChannel" }
           }
         }
       }
@@ -844,6 +946,11 @@
         "version": { "type": "string" },
         "replicas": { "type": "integer" },
         "arbiters": { "type": "integer" },
+        "annotations": { "type": "object", "description": "Annotations for the MongoDBCommunity object" },
+        "labels": { "type": "object", "description": "Labels for the MongoDBCommunity object" },
+        "podAnnotations": { "type": "object" },
+        "podLabels": { "type": "object" },
+        "users": { "type": "array", "items": { "type": "object" } },
         "persistence": {
           "type": "object",
           "properties": {
@@ -854,7 +961,9 @@
                 "data": { "type": "string" },
                 "logs": { "type": "string" }
               }
-            }
+            },
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" }
           }
         },
         "serviceAccount": {
@@ -863,16 +972,51 @@
             "create": { "type": "boolean" },
             "automount": { "type": "boolean" },
             "annotations": { "type": "object" },
+            "labels": { "type": "object" },
             "nameOverride": { "type": "string" },
             "role": {
               "type": "object",
               "properties": {
                 "create": { "type": "boolean" },
+                "annotations": { "type": "object", "description": "Annotations for the Role and RoleBinding objects" },
+                "labels": { "type": "object", "description": "Labels for the Role and RoleBinding objects" },
                 "rules": { "type": "array" }
               }
             }
           }
         }
+      }
+    }
+  },
+  "$defs": {
+    "forwarderChannel": {
+      "type": "object",
+      "description": "One forwarder gRPC channel, rendered as its own Ingress.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "labels": { "type": "object" },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": { "type": "string" },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": { "type": "string" },
+                    "pathType": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": { "type": "array" }
       }
     }
   }

--- a/charts/graylog/values.schema.json
+++ b/charts/graylog/values.schema.json
@@ -405,12 +405,6 @@
             },
             "labels": {
               "type": "object"
-            },
-            "selector": {
-              "type": "object"
-            },
-            "dataSource": {
-              "type": "object"
             }
           }
         },
@@ -691,12 +685,6 @@
                   "type": "object"
                 },
                 "labels": {
-                  "type": "object"
-                },
-                "selector": {
-                  "type": "object"
-                },
-                "dataSource": {
                   "type": "object"
                 }
               }

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -343,10 +343,6 @@ graylog:
     size:
     annotations: {}
     labels: {}
-    # selector restricts which PersistentVolume can back the claim.
-    selector: {}
-    # dataSource populates the volume from an existing snapshot or PVC.
-    dataSource: {}
   # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
   # for the Graylog container (TCP checks against the app port).
   livenessProbe:
@@ -624,10 +620,6 @@ datanode:
       size: "2Gi"
       annotations: {}
       labels: {}
-      # selector restricts which PersistentVolume can back the claim.
-      selector: {}
-      # dataSource populates the volume from an existing snapshot or PVC.
-      dataSource: {}
   # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
   # for the Datanode container.
   livenessProbe:
@@ -869,8 +861,6 @@ mongodb:
   # to the MongoDB pods it creates.
   podAnnotations: {}
   podLabels: {}
-  # users lists additional MongoDB users, appended to the chart-managed one.
-  users: []
   persistence:
     # storageClass overrides global.storageClass for the MongoDB volumes.
     storageClass: ""

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -16,8 +16,6 @@ nameOverride: ""
 fullnameOverride: ""
 
 # global values are shared by the Graylog, Datanode, and MongoDB workloads.
-
-
 global:
   # imagePullSecrets is applied to the Graylog and Datanode pods unless
   # overridden per image (MongoDB images are pulled by the operator).
@@ -27,6 +25,27 @@ global:
   existingSecretName: ""
   # storageClass is the default StorageClass for all persistent volumes.
   storageClass: ""
+  # commonLabels/commonAnnotations are added to every object the chart renders.
+  # Per-object labels/annotations and the chart's own identity labels take
+  # precedence. commonLabels never reach a workload's selector, so they are
+  # safe to add to an existing release.
+  commonLabels: {}
+  commonAnnotations: {}
+
+# extraObjects renders arbitrary manifests as part of this release — a
+# ServiceMonitor, ExternalSecret, NetworkPolicy, or anything else the chart does
+# not model. Each entry is templated, so it can reference the release context.
+# Entries may be mappings or strings; use a string when the manifest itself
+# contains Helm syntax that must survive to render time.
+#
+# extraObjects:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: '{{ include "graylog.fullname" . }}-extra'
+#     data:
+#       release: "{{ .Release.Name }}"
+extraObjects: []
 
 
 # graylog configures the Graylog server application.
@@ -44,6 +63,8 @@ graylog:
     nameOverride: ""
     # type is the Kubernetes Service type (ClusterIP, NodePort, LoadBalancer).
     type: ClusterIP
+    annotations: {}
+    labels: {}
     ports:
       # app is the port serving the Graylog web interface and REST API.
       app: 9000
@@ -322,6 +343,10 @@ graylog:
     size:
     annotations: {}
     labels: {}
+    # selector restricts which PersistentVolume can back the claim.
+    selector: {}
+    # dataSource populates the volume from an existing snapshot or PVC.
+    dataSource: {}
   # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
   # for the Graylog container (TCP checks against the app port).
   livenessProbe:
@@ -345,6 +370,12 @@ graylog:
   # 30s is not enough under load, which is why this is set explicitly.
   terminationGracePeriodSeconds: 300
   lifecycle:
+    # postStart/preStop are your own hooks on the graylog-app container, in
+    # standard Kubernetes syntax. preStop is mutually exclusive with
+    # preStopDrain below — a container can only have one preStop hook, and the
+    # chart fails the render rather than silently dropping either.
+    postStart: {}
+    preStop: {}
     # Hold pod termination while the on-disk journal is worked off.
     #
     # Scaling in is the case that matters: the ordinal stops existing, so its
@@ -410,6 +441,8 @@ graylog:
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
+    annotations: {}
+    labels: {}
   # podSecurityContext / initContainerSecurityContext / containerSecurityContext
   # expose the standard Kubernetes securityContext fields; defaults follow a
   # non-root, no-privilege-escalation baseline.
@@ -436,8 +469,15 @@ graylog:
       add: ["NET_BIND_SERVICE"]
     seccompProfile:
       type: RuntimeDefault
-  # podAnnotations is added to the Graylog pod template metadata.
+  # annotations/labels are added to the Graylog StatefulSet object itself.
+  # They merge over global.commonAnnotations/global.commonLabels.
+  annotations: {}
+  labels: {}
+  # podAnnotations/podLabels are added to the Graylog pod template metadata.
+  # podLabels never reach the StatefulSet's selector, so they are safe to
+  # change on an existing release.
   podAnnotations: {}
+  podLabels: {}
   # nodeSelector constrains Graylog pods to matching nodes.
   nodeSelector: {}
   # tolerations lets Graylog pods schedule onto tainted nodes.
@@ -445,9 +485,38 @@ graylog:
   # affinity overrides the default anti-affinity that spreads Graylog pods
   # across nodes.
   affinity: {}
+  # topologySpreadConstraints spreads Graylog pods across failure domains.
+  # Unlike the default anti-affinity (which is a soft hostname preference),
+  # these can enforce an even spread across zones. Standard Kubernetes syntax.
+  topologySpreadConstraints: []
+  # priorityClassName sets the scheduling priority of the Graylog pods.
+  priorityClassName: ""
+  # schedulerName selects an alternative scheduler.
+  schedulerName: ""
+  # runtimeClassName selects a container runtime class (e.g. gvisor).
+  runtimeClassName: ""
+  # terminationGracePeriodSeconds for the Graylog pods is set above, next to
+  # the preStop drain whose budget depends on it.
+  # dnsPolicy/dnsConfig control pod DNS resolution.
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
+  # hostAliases adds entries to the pod's /etc/hosts.
+  hostAliases: []
   # extraEnv sets additional environment variables using full EnvVar syntax
   # (supports valueFrom); entries here win over graylog.env keys.
   extraEnv: []
+  # extraVolumes adds volumes to the Graylog pods, using standard Kubernetes
+  # volume syntax.
+  extraVolumes: []
+  # extraVolumeMounts mounts those volumes into the graylog-app container.
+  extraVolumeMounts: []
+  # extraInitVolumeMounts mounts them into the chart's copy-data init
+  # container instead, for assets that must be staged before startup.
+  extraInitVolumeMounts: []
+  # extraInitContainers are rendered after the chart's own init containers.
+  extraInitContainers: []
+  # extraContainers adds sidecar containers to the Graylog pods.
+  extraContainers: []
 
 
 # datanode configures the Graylog Data Node (managed OpenSearch).
@@ -458,6 +527,8 @@ datanode:
   # replicas is the number of Datanode pods.
   replicas: 3
   service:
+    annotations: {}
+    labels: {}
     ports:
       # api is the Datanode REST API port.
       api: 8999
@@ -551,6 +622,12 @@ datanode:
       mountPath: ""
       accessModes: []
       size: "2Gi"
+      annotations: {}
+      labels: {}
+      # selector restricts which PersistentVolume can back the claim.
+      selector: {}
+      # dataSource populates the volume from an existing snapshot or PVC.
+      dataSource: {}
   # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
   # for the Datanode container.
   livenessProbe:
@@ -573,6 +650,8 @@ datanode:
   podDisruptionBudget:
     enabled: true
     minAvailable: 2
+    annotations: {}
+    labels: {}
   podSecurityContext:
     fsGroup: 999
     fsGroupChangePolicy: "OnRootMismatch"
@@ -585,8 +664,15 @@ datanode:
       add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID"]
     seccompProfile:
       type: RuntimeDefault
-  # podAnnotations is added to the Datanode pod template metadata.
+  # annotations/labels are added to the Datanode StatefulSet object itself.
+  # They merge over global.commonAnnotations/global.commonLabels.
+  annotations: {}
+  labels: {}
+  # podAnnotations/podLabels are added to the Datanode pod template metadata.
+  # podLabels never reach the StatefulSet's selector, so they are safe to
+  # change on an existing release.
   podAnnotations: {}
+  podLabels: {}
   # nodeSelector constrains Datanode pods to matching nodes.
   nodeSelector: {}
   # tolerations lets Datanode pods schedule onto tainted nodes.
@@ -594,9 +680,38 @@ datanode:
   # affinity overrides the default anti-affinity that spreads Datanode pods
   # across nodes.
   affinity: {}
+  # topologySpreadConstraints spreads Datanode pods across failure domains.
+  # The default anti-affinity is only a soft hostname preference and does not
+  # guarantee zone spread; set this to enforce one. Standard Kubernetes syntax.
+  topologySpreadConstraints: []
+  # priorityClassName sets the scheduling priority of the Datanode pods.
+  priorityClassName: ""
+  # schedulerName selects an alternative scheduler.
+  schedulerName: ""
+  # runtimeClassName selects a container runtime class (e.g. gvisor).
+  runtimeClassName: ""
+  # terminationGracePeriodSeconds is the shutdown grace period. Leave empty
+  # for the Kubernetes default.
+  terminationGracePeriodSeconds:
+  # dnsPolicy/dnsConfig control pod DNS resolution.
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
+  # hostAliases adds entries to the pod's /etc/hosts.
+  hostAliases: []
+  # lifecycle sets postStart/preStop hooks on the graylog-datanode container.
+  lifecycle: {}
   # extraEnv sets additional environment variables using full EnvVar syntax
   # (supports valueFrom); entries here win over datanode.env keys.
   extraEnv: []
+  # extraVolumes adds volumes to the Datanode pods, using standard Kubernetes
+  # volume syntax.
+  extraVolumes: []
+  # extraVolumeMounts mounts those volumes into the graylog-datanode container.
+  extraVolumeMounts: []
+  # extraInitContainers are rendered after the chart's own init containers.
+  extraInitContainers: []
+  # extraContainers adds sidecar containers to the Datanode pods.
+  extraContainers: []
 
 
 # External OpenSearch
@@ -639,12 +754,16 @@ serviceAccount:
   automount: true
   # annotations is added to the ServiceAccount (e.g. IRSA role ARNs).
   annotations: {}
+  # labels is added to the ServiceAccount.
+  labels: {}
   # nameOverride replaces the generated ServiceAccount name, or names the
   # existing ServiceAccount to use when create=false.
   nameOverride: ""
   # role optionally creates a namespaced Role/RoleBinding with these rules.
   role:
     create: false
+    annotations: {}
+    labels: {}
     rules: []
 #      - apiGroups: [ "" ]
 #        resources: [ "pods" ]
@@ -670,6 +789,9 @@ ingress:
       issuer:
         # existingName references a pre-existing namespaced Issuer.
         existingName:
+        # annotations/labels are added to the chart-managed cert-manager Issuer.
+        annotations: {}
+        labels: {}
         # managed creates a Let's Encrypt ACME Issuer owned by this chart.
         managed:
           enabled: false
@@ -682,6 +804,7 @@ ingress:
     # className is the IngressClass to use.
     className: ""
     annotations: {}
+    labels: {}
     hosts:
       - host: ""
         paths:
@@ -701,7 +824,9 @@ ingress:
     messageChannel:
       enabled: true
       className: ""
+      # annotations/labels are added to this channel's Ingress object.
       annotations: {}
+      labels: {}
       hosts:
         - host: ""
           paths:
@@ -711,7 +836,9 @@ ingress:
     configChannel:
       enabled: true
       className: ""
+      # annotations/labels are added to this channel's Ingress object.
       annotations: {}
+      labels: {}
       hosts:
         - host: ""
           paths:
@@ -735,23 +862,38 @@ mongodb:
   # replicas: 2, arbiters: 1
   replicas: 3
   arbiters: 0
+  # annotations/labels are added to the MongoDBCommunity object itself.
+  annotations: {}
+  labels: {}
+  # podAnnotations/podLabels are passed to the operator, which applies them
+  # to the MongoDB pods it creates.
+  podAnnotations: {}
+  podLabels: {}
+  # users lists additional MongoDB users, appended to the chart-managed one.
+  users: []
   persistence:
     # storageClass overrides global.storageClass for the MongoDB volumes.
     storageClass: ""
     size:
       data: "10G"
       logs: "2G"
+    # annotations/labels are added to the MongoDB volume claim templates.
+    annotations: {}
+    labels: {}
   # serviceAccount configures the ServiceAccount used by the MongoDB pods;
   # fields mirror the top-level serviceAccount block.
   serviceAccount:
     create: true
     automount: true
     annotations: {}
+    labels: {}
     nameOverride: ""
     # role creates the Role/RoleBinding required by the MongoDB operator's
     # readiness/version-upgrade hooks.
     role:
       create: true
+      annotations: {}
+      labels: {}
       rules:
         - apiGroups: [""]
           resources: ["secrets"]

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -341,6 +341,14 @@ graylog:
     accessModes: []
     # size is the requested volume size (default 8Gi).
     size:
+    # annotations/labels for the volume claim template.
+    #
+    # Unlike everywhere else in this chart, global.commonLabels and
+    # global.commonAnnotations deliberately do NOT flow here. A StatefulSet's
+    # volumeClaimTemplates cannot be changed after creation, so injecting them
+    # would rewrite an immutable field and make `helm upgrade` fail on every
+    # existing release. Setting these yourself is safe on a fresh install; on a
+    # live release it needs the StatefulSet recreated (--cascade=orphan).
     annotations: {}
     labels: {}
   # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
@@ -611,6 +619,11 @@ datanode:
       mountPath: ""
       accessModes: []
       size: "8Gi"
+      # annotations/labels for the volume claim template. global.commonLabels
+      # and global.commonAnnotations deliberately do not flow here — see the
+      # note on graylog.persistence.annotations.
+      annotations: {}
+      labels: {}
     # nativeLibs is an optional volume for OpenSearch native libraries.
     nativeLibs:
       enabled: false
@@ -618,6 +631,8 @@ datanode:
       mountPath: ""
       accessModes: []
       size: "2Gi"
+      # As above: the globals stop here because volumeClaimTemplates are
+      # immutable once the StatefulSet exists.
       annotations: {}
       labels: {}
   # livenessProbe/readinessProbe expose the standard Kubernetes probe fields
@@ -857,17 +872,20 @@ mongodb:
   # annotations/labels are added to the MongoDBCommunity object itself.
   annotations: {}
   labels: {}
-  # podAnnotations/podLabels are passed to the operator, which applies them
-  # to the MongoDB pods it creates.
-  podAnnotations: {}
-  podLabels: {}
+  # No podAnnotations/podLabels here: the MongoDB Community operator owns the
+  # pod template of the StatefulSet it manages and discards anything the chart
+  # puts there, so the keys would silently do nothing. annotations/labels above
+  # apply to the MongoDBCommunity object itself and do work.
   persistence:
     # storageClass overrides global.storageClass for the MongoDB volumes.
     storageClass: ""
     size:
       data: "10G"
       logs: "2G"
-    # annotations/labels are added to the MongoDB volume claim templates.
+    # annotations/labels are added to the MongoDB volume claim templates. The
+    # operator copies them onto the StatefulSet it manages, where they become
+    # immutable, so global.commonLabels/commonAnnotations do not flow here —
+    # see the note on graylog.persistence.annotations.
     annotations: {}
     labels: {}
   # serviceAccount configures the ServiceAccount used by the MongoDB pods;


### PR DESCRIPTION
## Summary

Lets users adopt the chart into an existing ecosystem without forking it. Every rendered object accepts custom labels and annotations, both workloads accept arbitrary volumes and containers, pods can be spread across failure domains, and anything the chart does not model can be deployed alongside it via `extraObjects`.


## Details

### Labels and annotations on every object

Three helpers in `_helpers.tpl` — `graylog.metadata.labels`, `graylog.metadata.annotations` and `graylog.pod.labels` — render the metadata block for every object. Each merges, lowest to highest precedence: `global.commonLabels` / `global.commonAnnotations`, the object's own `labels` / `annotations`, then the chart-owned identity labels and Helm hook/resource-policy annotations, which always win.

All 33 rendered objects are covered, including the `MongoDBCommunity` CR, the external-OpenSearch Secret, the Helm test Pods and the waiting-room objects.

### Extra volumes, mounts and containers

`extraVolumes`, `extraVolumeMounts`, `extraInitContainers` and `extraContainers` on both workloads, plus `extraInitVolumeMounts` for the chart's `copy-data` init container. The Datanode's `volumes:` block was previously omitted entirely when both persistent volumes were enabled, so it was restructured to always render when extra volumes are present.

### Pod scheduling and runtime

`topologySpreadConstraints`, `priorityClassName`, `schedulerName`, `runtimeClassName`, `dnsPolicy`, `dnsConfig` and `hostAliases` on both workloads.

`topologySpreadConstraints` is the substantive one. The chart's existing anti-affinity is a *soft* hostname preference — it does not guarantee a spread across zones, so a single-zone failure could take every Data Node replica with it. There was previously no way to express a real multi-AZ layout.

### extraObjects

A top-level list rendered through `tpl`, so entries can reference the release context. Mapping and string forms both work — the string form is what you need when the manifest itself contains Helm syntax. `global.commonLabels` / `commonAnnotations` are merged in; anything set on the object wins. An entry that renders without a `kind` fails the render with an actionable message rather than emitting an invalid manifest.

### Lifecycle hooks

`graylog.lifecycle.postStart` / `preStop` for user-supplied hooks, alongside the chart-managed `preStopDrain` from #147. Setting `preStop` together with `preStopDrain.enabled` fails the render, because a container can only have one preStop hook and silently dropping either would be worse.

### Truststore handling in the init container

The BYO Graylog certificate and the BYO OpenSearch CA each built the Java truststore their own way, and the two paths disagreed about where the JDK bundle lives — the OpenSearch path read `${JAVA_HOME}` while the Graylog path derived it by running `java`. They are now one build, gated by a `graylog.truststore.enabled` helper, always seeded from the JDK bundle in the image so the default CAs survive and our certificates are only ever added on top.

Two defects fell out of that:

- **The lookup could not work in this init container at all.** `java` in the Graylog image carries a file capability (`cap_net_bind_service=ep`), and the init container runs `allowPrivilegeEscalation: false`, which sets `no_new_privs`. The kernel refuses to `execve` a file with capabilities under that flag, so the JVM died with `Operation not permitted` (exit 126) and the derived path came back empty. On `main` that path is unchecked (`init-graylog.yaml:78`): `cp "${JAVA_HOME_LOCAL}/lib/security/cacerts"` degrades to `cp /lib/security/cacerts`, fails silently, and `keytool` then creates a fresh keystore holding *only* the BYO certificate. Since the chart passes `-Djavax.net.ssl.trustStore=/usr/share/graylog/data/cacerts/graylog.jks` to the JVM, that becomes Graylog's entire trust anchor set — every outbound TLS connection to anything not signed by that one certificate would fail. The lookup now reads `${JAVA_HOME}` with a fallback across known JDK paths and never starts a JVM; `keytool` has no file capability and is unaffected.
- **A custom `keyStorePass` could never be applied.** The JDK bundle ships as `changeit`, so importing with a different `-storepass` failed outright. The seeded copy is now re-keyed first.

The store is also only moved into place when its content actually changed, and `keyStorePass` is single-quoted so a password with shell metacharacters is safe.

### Incidental fixes

- `values.schema.json` still described the pre-#147 flat `ingress.forwarder.*` shape. Rewritten to the two-channel form with a shared `$defs/forwarderChannel`.
- Per-channel `labels` added to the forwarder Ingresses (they already had `annotations`).
- `datanode.persistence.data` accepted no `annotations`/`labels`, even though the template already read them and its sibling `nativeLibs` claim exposed them. Gap closed, so all four claim templates behave the same way.
- `mongodb.users` was still declared in `values.schema.json` after the value itself was dropped. Removed.
- External OpenSearch credentials are URL-encoded before being interpolated into the connection URI, so a password containing `@`, `/`, `:` or `?` no longer splits it at the wrong place.
- Empty `annotations:` and `initContainers:` keys are no longer emitted as bare nulls.

## Breaking changes
Verified there are no breaking changes to immutable objects.

## PR Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [x] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog`
- [ ] Helm tests pass: `helm test graylog`

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [x] Upgrade from previous release succeeds — see the caveat below
- [x] Scaling up/down works correctly
- [x] Configuration changes apply correctly

### Specific to this PR

- [x] `helm unittest ./charts/graylog` — 330 tests across 28 suites
- [x] Rendered `origin/main` and this branch with identical values and diffed the output object-by-object; every difference is accounted for above
- [x] Immutability suite mutation-tested both ways (selector leak → 4 of 9 fail; claim-metadata helper swapped out → 3 of 9 fail; both clean on revert)
- [x] Init-container truststore lookup executed inside a pod carrying the real init container's securityContext, uid and envFrom
- [x] MongoDB claim-metadata propagation confirmed against the live operator
- [x] Renders verified across topologies: defaults, external MongoDB, BYO OpenSearch, ingress + forwarder + cert-manager issuer, AWS provider, GeoIP sidecar, preStop drain, `existingSecretName`, `nativeLibs.enabled`
- [x] Deployed to `graylog-helm-1` on `glc-central-dev` with BYO OpenSearch; Graylog pods reached Running through the rebuilt init container
- [ ] Upgrade from a release installed off current `main` (render-diff clean; the live upgrade that was run started from a polluted baseline, see above)
- [ ] `extraObjects` applied against a live cluster with a real CRD (e.g. a ServiceMonitor) — only render-tested so far

## Notes for reviewers

- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable

Two conflict resolutions during the rebase onto #147 are worth a look, since both were judgement calls rather than mechanical merges:

- `templates/service/ingress/graylog-forwarder.yaml` — #147 rewrote this into one Ingress per gRPC channel. The metadata helpers were moved to per-channel and a `labels` key added to each channel, rather than keeping a flat `ingress.forwarder.labels`.
- `templates/workload/statefulsets/graylog.yaml` — kept a `kindIs "invalid"` guard for `terminationGracePeriodSeconds` in preference to `with`, since `with` skips a legitimate value of `0`.

### Known issue, pre-existing, not addressed here

A numeric MaxMind account ID (`--set graylog.config.geolocation.maxmindGeoIp.accountId=1`, unquoted) fails with `b64enc: wrong type for value; expected string; got int64`. Reproduced on `origin/main`, so it is not a regression from this PR. Workaround is `--set-string`. Tracked separately.
