### PR TITLE
docs: fix five broken commands in the chart README

### DIFF
--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -264,7 +264,7 @@ Once an Ingress Controller has been installed and configured, run the following 
 [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resource:
 
 ```sh
-helm upgrade graylog graylog/graylog -n graylog --set ingress.web.enabled="true" --reuse-values
+helm upgrade graylog graylog/graylog -n graylog --set ingress.enabled="true" --set ingress.web.enabled="true" --reuse-values
 ```
 
 ### Alternative: LoadBalancer Service
@@ -489,16 +489,16 @@ mongodb:
 helm upgrade graylog graylog/graylog -n graylog --set graylog.config.timezone="America/Denver" --reuse-values
 
 # set JVM options
-helm upgrade graylog graylog/graylog -n graylog --set graylog.config.serverJavaOpts="-Xms2g -Xmx1g" --reuse-values
+helm upgrade graylog graylog/graylog -n graylog --set graylog.config.serverJavaOpts="-Xms1g -Xmx2g" --reuse-values
 
 # redefine message journal maxAge
 helm upgrade graylog graylog/graylog -n graylog --set graylog.config.messageJournal.maxAge="24h" --reuse-values
 
 # enable CORS headers for HTTP interface
-helm upgrade graylog graylog/graylog -n graylog --set graylog.config.network.enableCors=true --reuse-values
+helm upgrade graylog graylog/graylog -n graylog --set-string graylog.config.network.enableCors=true --reuse-values
 
 # enable email transport and set sender address
-helm upgrade graylog graylog/graylog -n graylog --set graylog.config.email.enabled=true --set graylog.config.email.senderAddress="will@example.com" --reuse-values
+helm upgrade graylog graylog/graylog -n graylog --set-string graylog.config.email.enabled=true --set graylog.config.email.senderAddress="will@example.com" --reuse-values
 ```
 
 ## Customize deployed Kubernetes resources
@@ -987,7 +987,7 @@ helm template graylog graylog -f your-custom-values.yaml | yq
 # Logging
 ```sh
 # Graylog app logs
-stern statefulset/graylog-app -n graylog
+stern statefulset/graylog -n graylog
 # DataNode logs
 stern statefulset/graylog-datanode -n graylog
 ```


### PR DESCRIPTION
## Summary
Five commands in the chart README do not work. This change corrects them.

## Details
- External access: add `ingress.enabled="true"`. The template needs this flag, so the command rendered no Ingress.
- `server.conf` example: change `-Xms2g -Xmx1g` to `-Xms1g -Xmx2g`. The JVM does not start when the start heap is larger than the maximum heap.
- Same example: use `--set-string` for `enableCors` and `email.enabled`. The schema declares both as strings, so `--set` fails.
- Logging: change `statefulset/graylog-app` to `statefulset/graylog`. `graylog-app` is the container name, not the StatefulSet name.

## Linked issues
None.

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

`--validate` needs the MongoDB Operator CRD. The test cluster does not have it. `helm template` without `--validate` passes.

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

This change edits only the README. The installation, functional, and upgrade tests did not run.

### Specific to this PR
- [x] Ran each corrected command. The ingress command renders 1 Ingress. It rendered 0 before.
- [x] The two `--set-string` commands template without an error.
- [x] `statefulset/graylog` is in the rendered output.
- [x] `helm unittest` passes: 332 tests in 28 suites.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
