### PR TITLE
docs: fix the credential and external MongoDB examples

### DIFF
--- a/docs/bring-your-own-mongo.md
+++ b/docs/bring-your-own-mongo.md
@@ -4,7 +4,7 @@ Graylog Helm supports bringing your own Mongo, the only requirement is that it f
 ## Steps
 ### Graylog Secret
 If you want to bring your mongo you will also have to create your own set of secrets for Graylog.
-Create a secret with at least the keys specified in [examples/graylog-secret.yaml](https://github.com/Graylog2/graylog-helm/blob/main/examples/graylog-secret.yaml) using base64 encoded variables.
+Create a secret with the required keys listed in [Graylog Secrets](graylog-secrets.md#required-keys). [examples/graylog-secret.yaml](https://github.com/Graylog2/graylog-helm/blob/main/examples/graylog-secret.yaml) shows the full shape. That example uses `stringData`, so you supply plain text values and Kubernetes encodes them for you.
 This file can be named anything you would like, but it needs to be mentioned in your values.yaml.
 ### Values File
 In your values file you will want your configuration to include at least the following.

--- a/examples/graylog-secret.yaml
+++ b/examples/graylog-secret.yaml
@@ -1,25 +1,35 @@
 # Example Graylog Secret
-# If you wish to generate your own graylog-secret the following keys are required. All values should
-# be base64 encoded before applying to your cluster. Then supply the secret name as 
-# global.existingSecretName: ""
+# WARNING: the values below are placeholders, not working credentials. Replace every
+# <...> value before you apply this file. Never commit real credentials.
+#
+# If you wish to generate your own graylog-secret, supply the secret name as
+# global.existingSecretName: "". GRAYLOG_MONGODB_URI, GRAYLOG_PASSWORD_SECRET, and
+# GRAYLOG_ROOT_PASSWORD_SHA2 are required. GRAYLOG_ROOT_USERNAME is optional and
+# defaults to "admin". The two GEO_IP_MAXMIND keys are necessary only when the
+# GeoIP sidecar is enabled.
+#
+# stringData takes plain text and Kubernetes encodes it for you. Do not base64 encode
+# these values yourself.
 #
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
   name: graylog-secret-example
-data:
-  # Mongo DB URI with valid credentials and location of the Mongo cluster
-  #   To get this value, run: echo -n "mongodb://admin:password@somewhere.local:27017/graylog_2" | base64
-  GRAYLOG_MONGODB_URI: "bW9uZ29kYjovL2FkbWluOnBhc3N3b3JkQHNvbWV3aGVyZS5sb2NhbDoyNzAxNy9ncmF5bG9nXzI="
+stringData:
+  # Mongo DB URI with valid credentials and location of the Mongo cluster.
+  # The URI must contain a username and a password, or Graylog does not start.
+  GRAYLOG_MONGODB_URI: "mongodb://<username>:<password>@<host>:27017/graylog_2"
   # Graylog admin username.
-  #   To get this value, run: echo -n admin | base64
-  GRAYLOG_ROOT_USERNAME: "YWRtaW4="
-  # Graylog admin user's password pepper.
-  #   To get a value similar to this, run: pwgen 96 1 | base64
-  GRAYLOG_PASSWORD_SECRET: "a2U5b0wxZWlnaDF1bjFFZWNoYTJvaEJpZXJlZTBIZWk2S2VpNk9oZmFlNXF1b2FtYWhjaGlwaG9oOXp1OHJhbzVQaWVZaWUyYWVjaTRlZWY4ZWlDaDdBaFBoMm9vbjd1Cg=="
-  # Graylog admin user's password SHA2 value.
-  #   To get this value, run: echo -n admin | shasum -a 256 | cut -d ' ' -f1 | base64
-  GRAYLOG_ROOT_PASSWORD_SHA2: "OGM2OTc2ZTViNTQxMDQxNWJkZTkwOGJkNGRlZTE1ZGZiMTY3YTljODczZmM0YmI4YTgxZjZmMmFiNDQ4YTkxOAo="
+  GRAYLOG_ROOT_USERNAME: "admin"
+  # Graylog admin user's password pepper. Minimum 64 characters.
+  #   To get a value similar to this, run: pwgen 96 1
+  GRAYLOG_PASSWORD_SECRET: "<96-character-random-string>"
+  # Graylog admin user's password SHA2 value: 64 lowercase hex characters.
+  # Use printf, not echo, to keep a trailing newline out of the hash.
+  #   To get this value, run: printf %s '<your-password>' | shasum -a 256 | cut -d ' ' -f1
+  GRAYLOG_ROOT_PASSWORD_SHA2: "<64-character-sha256-hex-digest>"
+  # Only necessary when graylog.config.geolocation.enabled and
+  # graylog.config.geolocation.sidecar.enabled are both true.
   GEO_IP_MAXMIND_ACCOUNT_ID: ""
   GEO_IP_MAXMIND_LICENSE_KEY: ""

--- a/examples/values-existing-secret-external-mongodb.yaml
+++ b/examples/values-existing-secret-external-mongodb.yaml
@@ -3,28 +3,46 @@
 # This example demonstrates the correct configuration for users who want to:
 # - Use GitOps (Argo CD / Flux) with externally-managed secrets
 # - Connect to an external/self-managed MongoDB instance
-# - Avoid Helm-managed secret generation and rotation
+# - Avoid Helm-managed generation and rotation of the Graylog credential Secret
 #
 # Why this pattern?
 # - Global secrets are managed outside Helm (e.g., via sealed-secrets, external-secrets operator)
 # - MongoDB is managed separately (cloud provider, self-managed cluster, etc.)
-# - Helm only orchestrates the Graylog and Data Node workloads
+# - Helm orchestrates the Graylog and Data Node workloads
+#
+# global.existingSecretName replaces the chart-managed Graylog credential Secret
+# and the chart-managed backup Secret. The backup Secret normally carries the
+# pepper and the generated MongoDB passwords, and it survives uninstall. With an
+# external Secret, you own that recovery material: back it up yourself.
+#
+# Other objects still render here, for separate reasons:
+# - The Data Node Secret renders while datanode.enabled is true.
+# - The MongoDB ServiceAccount, Role, and RoleBinding render under the default
+#   mongodb.serviceAccount settings. Set mongodb.serviceAccount.create=false to
+#   disable all three.
 #
 # Prerequisites:
 # 1. A secret named "graylog-managed-secret" (or your chosen name) must exist
-#    with the following required keys:
-#    - GRAYLOG_PASSWORD_SECRET: Base64-encoded pepper string (≥64 chars)
+#    with these three required keys:
+#    - GRAYLOG_PASSWORD_SECRET: pepper string (≥64 chars)
 #    - GRAYLOG_ROOT_PASSWORD_SHA2: SHA256 hash of root password
-#    - GRAYLOG_MONGODB_URI: Base64-encoded MongoDB connection string
-#    - GRAYLOG_ROOT_USERNAME: (optional) defaults to "admin" if not provided
+#    - GRAYLOG_MONGODB_URI: MongoDB connection string, including username and password
+#
+#    One key is optional:
+#    - GRAYLOG_ROOT_USERNAME: defaults to "admin" if not provided
+#
+# Pass all values as plain text. kubectl and Kubernetes encode them for you.
+# Do not base64 encode them yourself.
 #
 # 2. MongoDB must be running and accessible at the configured connection URI
 #
 # Example secret creation:
+# openssl wraps base64 output at 64 columns, so the pepper needs `tr -d` to stay
+# on one line. Use printf, not echo -n, which is not portable to POSIX sh.
 # kubectl create secret generic graylog-managed-secret \
-#   --from-literal=GRAYLOG_PASSWORD_SECRET="$(openssl rand -base64 64)" \
-#   --from-literal=GRAYLOG_ROOT_PASSWORD_SHA2="$(echo -n mypassword | sha256sum | cut -d' ' -f1)" \
-#   --from-literal=GRAYLOG_MONGODB_URI="$(echo -n 'mongodb://graylo[EMAIL_ADDRESS_REDACTED]om:27017/graylog' | base64)" \
+#   --from-literal=GRAYLOG_PASSWORD_SECRET="$(openssl rand -base64 64 | tr -d '\n')" \
+#   --from-literal=GRAYLOG_ROOT_PASSWORD_SHA2="$(printf %s 'mypassword' | sha256sum | cut -d' ' -f1)" \
+#   --from-literal=GRAYLOG_MONGODB_URI='mongodb://graylog:changeme@mongodb.example.com:27017/graylog' \
 #   --from-literal=GRAYLOG_ROOT_USERNAME="admin"
 #
 
@@ -73,16 +91,14 @@ datanode:
       memory: "4Gi"
       cpu: "1000m"
 
-# Disable MongoDB-specific tests (not applicable when MongoDB is external)
-graylog:
-  enabled: true
-
 # Example: Configure ingress for external access
 ingress:
   enabled: true
-  ingressClassName: "nginx"
   web:
     enabled: true
+    # className is the IngressClass. The key is ingress.web.className; a
+    # top-level ingress.ingressClassName is accepted by the schema and ignored.
+    className: "nginx"
     hosts:
       - host: "graylog.example.com"
         paths:


### PR DESCRIPTION
## Summary
Two example files have three faults. A user who copies them gets a broken installation.

## Details
- `examples/graylog-secret.yaml`: use `stringData` in place of `data`. The committed values decoded to 65 and 97 bytes, not 64 and 96. The hash kept a newline from `cut`, and the pepper kept one from `pwgen`. The commands in the file made the same fault for every user. All credential values are now placeholders, and the hash command uses `printf`. `GRAYLOG_ROOT_USERNAME` keeps the value `admin`, and the two MaxMind keys stay empty.
- `examples/values-existing-secret-external-mongodb.yaml`: delete the second `graylog:` key. YAML keeps the last duplicate, so the file discarded its own `replicas: 3` and its resource limits.
- Same file: do not send `GRAYLOG_MONGODB_URI` through `base64` before `--from-literal`. `kubectl` encodes the value, so Graylog got base64 text in place of a URI. The init container then stopped.
- `docs/bring-your-own-mongo.md`: the text said that the example uses base64 encoded variables. This is not correct.

## Linked issues
None.

## PR Checklist
Please check the items that apply to your change.

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

`--validate` needs the MongoDB Operator CRD. The test cluster does not have it. `helm template` without `--validate` passes.

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

This change edits two examples and one document. The installation, functional, and upgrade tests did not run.

### Specific to this PR
- [x] Rendered the external MongoDB example before and after. Before: `replicas=2` and a memory limit of `2Gi`, which are the chart defaults. After: `replicas=3` and a memory limit of `3Gi`, which the file asks for.
- [x] `kubectl apply --dry-run=client -f examples/graylog-secret.yaml` passes.
- [x] The new hash command returns a digest of 64 characters. `cut` still adds a newline, so the command writes 65 bytes. The digest that a reader copies is 64 characters.
- [x] Both example files parse as YAML. `helm unittest` passes: 332 tests in 28 suites.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable
