### PR TITLE
fix(ingress): point defaultBackend at the fallback Service port

### DIFF
--- a/charts/graylog/templates/service/ingress/graylog.yaml
+++ b/charts/graylog/templates/service/ingress/graylog.yaml
@@ -28,7 +28,7 @@ spec:
     service:
       name: {{ include "graylog.fallback.name" . }}
       port:
-        number: 3000
+        number: 80
   {{- end }}
   {{- with .Values.ingress.web.className }}
   ingressClassName: {{ . }}

--- a/charts/graylog/tests/fallback_test.yaml
+++ b/charts/graylog/tests/fallback_test.yaml
@@ -3,6 +3,7 @@ templates:
   - service/fallback.yaml
   - config/fallback.yaml
   - workload/fallback.yaml
+  - service/ingress/graylog.yaml
 release:
   name: graylog
   namespace: graylog
@@ -98,3 +99,46 @@ tests:
       - equal:
           path: spec.selector.matchLabels.graylog-app
           value: graylog-waiting-room
+
+  # --- The Ingress defaultBackend must reference the fallback Service port ---
+  # An Ingress backend addresses a Service port, not a container port. The
+  # fallback Service publishes port 80 and forwards to container port 3000, so
+  # the Ingress must ask for 80. Asking for 3000 leaves the backend unresolved
+  # and the waiting room never answers.
+  - it: fallback Service publishes port 80 for the Ingress backend
+    template: service/fallback.yaml
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.config.defaultBackend.enabled: true
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 3000
+
+  - it: Ingress defaultBackend targets the fallback Service port, not the container port
+    template: service/ingress/graylog.yaml
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.config.defaultBackend.enabled: true
+    asserts:
+      - equal:
+          path: spec.defaultBackend.service.name
+          value: graylog-waiting-room
+      - equal:
+          path: spec.defaultBackend.service.port.number
+          value: 80
+
+  - it: Ingress omits defaultBackend when the waiting room is disabled
+    template: service/ingress/graylog.yaml
+    set:
+      ingress.enabled: true
+      ingress.web.enabled: true
+      ingress.config.defaultBackend.enabled: false
+    asserts:
+      - notExists:
+          path: spec.defaultBackend


### PR DESCRIPTION
## Summary
The Ingress `defaultBackend` points at the container port of the fallback, not at its Service port. The waiting room never answers.

## Details
- `charts/graylog/templates/service/ingress/graylog.yaml`: change `spec.defaultBackend.service.port.number` from `3000` to `80`. An Ingress backend uses a Service port. The fallback Service publishes port `80` and sends traffic to container port `3000`, so `3000` does not resolve.
- `charts/graylog/tests/fallback_test.yaml`: three new tests. The first shows that the fallback Service publishes `80` and targets `3000`. The second shows that `defaultBackend` uses `80`. The third shows that `defaultBackend` is absent when the waiting room is off.

The waiting room is on by default when ingress is on. This fault is on the default ingress path.

## Linked issues
None.

## PR Checklist
Please check the items that apply to your change.

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] This PR includes a new feature
- [x] This PR includes a bugfix
- [ ] This PR includes a refactor

## Testing Checklist

### Static Validation
- [x] Linter check passes: `helm lint ./charts/graylog`
- [ ] Helm renders local template sucessfully: `helm template graylog ./charts/graylog --validate`

`--validate` needs the MongoDB Operator CRD. The test cluster does not have it. `helm template` without `--validate` passes.

### Installation
- [ ] Fresh installation completes successfully: `helm install graylog ./charts/graylog`
- [ ] All pods reach Running state: `kubectl rollout status statefulset/graylog `
- [ ] Helm tests pass: `helm test graylog `

### Functional (if applicable)
- [ ] Web UI accessible and login works
- [ ] DataNodes visible in _System > Cluster Configuration_
- [ ] Inputs can be created and receive data

### Upgrade (if applicable)
- [ ] Upgrade from previous release succeeds
- [ ] Scaling up/down works correctly
- [ ] Configuration changes apply correctly

The installation and functional tests did not run. A test of the waiting room needs a cluster with an nginx Ingress controller.

### Specific to this PR
- [x] `helm unittest` passes: 335 tests in 28 suites, up from 332.
- [x] The new test finds the fault. With `number: 3000` back in place, the test "Ingress defaultBackend targets the fallback Service port, not the container port" fails. The other nine pass.

## Notes for reviewers
- [ ] Verify all applicable tests above pass
- [ ] Validate that the linked issues are no longer reproducible, if applicable
- [ ] Sync up with the author before merging
- [ ] The commit history should be preserved - use rebase-merge or standard merge options when applicable

A named Service port can prevent this class of fault. That changes the rendered Service, so this PR keeps the small numeric fix.
