### PR TITLE
ci: Implementing release please for the Graylog Helm repository

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -12,7 +12,14 @@ validate-maintainers: false
 
 # Defaults below are made explicit to document the chart's CI policy
 # rather than relying on ct's built-in defaults.
-check-version-increment: true
+
+# release-please owns `version:` in Chart.yaml, so contributors no longer bump
+# it: an ordinary chart PR deliberately leaves the version at the last release.
+# An increment check would fail every such PR, or invite hand-edits to a field
+# release-please manages. (`ct lint --all` already overrides this and logs
+# "Version increment checking disabled." — false states the intent instead of
+# relying on that override.)
+check-version-increment: false
 validate-chart-schema: true
 validate-yaml: true
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,34 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v5
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          target-branch: main
+          # PR-only mode: chart-releaser (release.yaml) still owns the tag, the
+          # release and the index entry. Both use the name graylog-X.Y.Z, so if
+          # release-please created the release first, chart-releaser would find
+          # it present and — running with skip_existing: true — silently decline
+          # to upload the chart package. Removed in the publishing cutover, when
+          # chart-releaser is retired.
+          skip-github-release: true

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "charts/graylog": "1.0.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
+  "include-v-in-tag": false,
+  "tag-separator": "-",
+  "packages": {
+    "charts/graylog": {
+      "component": "graylog",
+      "exclude-paths": [
+        ".github",
+        "docs"
+      ],
+      "release-type": "helm",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false
+    }
+  }
+}


### PR DESCRIPTION
Adding Release Please to the Graylog Helm repository.

## Summary
Bringing in [Release Please](https://github.com/googleapis/release-please) to help manage change logs. This setup should support multiple charts when we have multiple to manage.

## Details
- List of meaningful technical changes

## Linked issues
 - https://github.com/Graylog2/graylog-helm/issues/172
