### PR TITLE
ci: generate the artifacthub.io/changes annotation

### DIFF
--- a/.github/scripts/artifacthub_changes.py
+++ b/.github/scripts/artifacthub_changes.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Rewrite a chart's artifacthub.io/changes annotation from its CHANGELOG.md.
+
+release-please renders release notes only as Markdown; no updater can write
+changelog content into a YAML field. This reads the most recent section of the
+chart's CHANGELOG.md and regenerates the annotation, resolving each commit back
+to the pull request that introduced it so entries carry named PR links.
+
+ArtifactHub expects the annotation to describe only the changes introduced by
+this chart version, so the previous contents are replaced, not appended to.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# release-please changelog section -> ArtifactHub kind. ArtifactHub accepts only
+# added/changed/deprecated/removed/fixed/security; "deprecated" and "security"
+# have no conventional-commit equivalent and stay manual.
+SECTION_KINDS = {
+    "Features": "added",
+    "Bug Fixes": "fixed",
+    "Performance Improvements": "changed",
+    "Code Refactoring": "changed",
+    "Reverts": "changed",
+    "Documentation": "changed",
+    "Dependencies": "changed",
+    "Build System": "changed",
+    "Continuous Integration": "changed",
+    "Miscellaneous Chores": "changed",
+    "⚠ BREAKING CHANGES": "changed",
+}
+DEFAULT_KIND = "changed"
+
+VERSION_HEADING = re.compile(r"^##\s+\[?(?P<version>\d+\.\d+\.\d+)")
+SECTION_HEADING = re.compile(r"^###\s+(?P<title>.+?)\s*$")
+ENTRY = re.compile(
+    r"^\*\s+"
+    r"(?:\*\*(?P<scope>[^*]+?):\*\*\s+)?"
+    r"(?P<desc>.+?)"
+    r"\s+\(\[(?P<sha>[0-9a-f]{7,40})\]\((?P<url>[^)]+)\)\)\s*$"
+)
+# Squash merges leave a trailing "(#123)" in the subject. release-please renders
+# it as a markdown link, "([#123](url))", when it can resolve one. Either form is
+# redundant once the entry carries a resolved PR link of its own.
+TRAILING_PR = re.compile(r"\s*\((?:\[#\d+\]\([^)]*\)|#\d+)\)\s*$")
+
+
+def gh_json(*args: str):
+    """Run `gh` and parse its stdout as JSON, returning None on any failure."""
+    try:
+        out = subprocess.run(
+            ("gh", *args), capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def latest_section(changelog: str) -> tuple[str | None, list[dict]]:
+    """Parse entries from the topmost version section of a CHANGELOG.md."""
+    version: str | None = None
+    entries: list[dict] = []
+    kind = DEFAULT_KIND
+    in_latest = False
+
+    for line in changelog.splitlines():
+        heading = VERSION_HEADING.match(line)
+        if heading:
+            if in_latest:
+                break  # reached the previous release; stop
+            version = heading.group("version")
+            in_latest = True
+            continue
+        if not in_latest:
+            continue
+
+        section = SECTION_HEADING.match(line)
+        if section:
+            kind = SECTION_KINDS.get(section.group("title"), DEFAULT_KIND)
+            continue
+
+        entry = ENTRY.match(line)
+        if entry:
+            desc = TRAILING_PR.sub("", entry.group("desc")).strip()
+            if entry.group("scope"):
+                desc = f"{entry.group('scope')}: {desc}"
+            entries.append(
+                {
+                    "kind": kind,
+                    "description": desc,
+                    "sha": entry.group("sha"),
+                    "commit_url": entry.group("url"),
+                }
+            )
+
+    return version, entries
+
+
+def resolve_link(repo: str, entry: dict) -> tuple[str, str]:
+    """Return a (name, url) link for an entry, preferring its pull request."""
+    pulls = gh_json(
+        "api", f"repos/{repo}/commits/{entry['sha']}/pulls", "--jq", "[.[0]]"
+    )
+    if pulls and pulls[0] and pulls[0].get("number"):
+        pr = pulls[0]
+        return f"PR #{pr['number']}", pr["html_url"]
+    return f"Commit {entry['sha'][:7]}", entry["commit_url"]
+
+
+def yaml_quote(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def render(entries: list[dict], repo: str, base_indent: str) -> str:
+    """Render the annotation's block-scalar body."""
+    item = base_indent + "  "
+    lines: list[str] = []
+    for entry in entries:
+        name, url = resolve_link(repo, entry)
+        lines.append(f"{item}- kind: {entry['kind']}")
+        lines.append(f"{item}  description: {yaml_quote(entry['description'])}")
+        lines.append(f"{item}  links:")
+        lines.append(f"{item}    - name: {yaml_quote(name)}")
+        lines.append(f"{item}      url: {yaml_quote(url)}")
+    return "\n".join(lines)
+
+
+def splice(chart_text: str, body: str) -> str:
+    """Replace the artifacthub.io/changes block, preserving the rest verbatim.
+
+    Line-based on purpose: a YAML round-trip would reflow unrelated keys.
+    """
+    lines = chart_text.splitlines()
+    key = re.compile(r"^(?P<indent>\s*)artifacthub\.io/changes:\s*\|")
+
+    start = next((i for i, l in enumerate(lines) if key.match(l)), None)
+    if start is None:
+        raise SystemExit(
+            "artifacthub.io/changes annotation not found; add the key with an "
+            "empty block scalar (`artifacthub.io/changes: |`) first"
+        )
+
+    indent = key.match(lines[start]).group("indent")
+    end = start + 1
+    while end < len(lines) and (
+        not lines[end].strip() or lines[end].startswith(indent + " ")
+    ):
+        end += 1
+    # Trailing blank lines belong to whatever follows, not to this block.
+    while end > start + 1 and not lines[end - 1].strip():
+        end -= 1
+
+    return "\n".join(lines[: start + 1] + body.splitlines() + lines[end:]) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--chart-dir", required=True, help="e.g. charts/graylog")
+    ap.add_argument("--repo", required=True, help="owner/name")
+    ap.add_argument("--check", action="store_true", help="exit 1 if out of date")
+    args = ap.parse_args()
+
+    chart_dir = Path(args.chart_dir)
+    changelog_path = chart_dir / "CHANGELOG.md"
+    chart_path = chart_dir / "Chart.yaml"
+
+    if not changelog_path.is_file():
+        print(f"no {changelog_path}; nothing to sync")
+        return 0
+
+    version, entries = latest_section(changelog_path.read_text())
+    if not entries:
+        print(f"no parseable entries in {changelog_path}; leaving annotation as-is")
+        return 0
+
+    original = chart_path.read_text()
+    updated = splice(original, render(entries, args.repo, "  "))
+
+    if updated == original:
+        print(f"{chart_path} already up to date for {version}")
+        return 0
+    if args.check:
+        print(f"{chart_path} is out of date for {version}")
+        return 1
+
+    chart_path.write_text(updated)
+    print(f"updated {chart_path} with {len(entries)} change(s) for {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/sync-artifacthub-changes.sh
+++ b/.github/scripts/sync-artifacthub-changes.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Push a regenerated artifacthub.io/changes annotation onto any open
+# release-please PR. Runs after every release-please invocation because
+# release-please force-pushes its branch whenever it regenerates the PR, which
+# would otherwise discard the annotation commit.
+set -euo pipefail
+
+CONFIG="${CONFIG:-release-please-config.json}"
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
+REPO="${REPO:?REPO must be set to owner/name}"
+
+# Stash the updater outside the work tree: the checkouts below swap the tree to
+# a release branch that may predate this script.
+updater="$(mktemp)"
+cp .github/scripts/artifacthub_changes.py "$updater"
+trap 'rm -f "$updater"' EXIT
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+while IFS=$'\t' read -r path component; do
+  branch="release-please--branches--${TARGET_BRANCH}"
+  if [[ -n "$component" ]]; then
+    branch="${branch}--components--${component}"
+  fi
+
+  pr="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number // empty')"
+  if [[ -z "$pr" ]]; then
+    echo "== ${path}: no open release PR (branch ${branch}); skipping"
+    continue
+  fi
+
+  echo "== ${path}: syncing annotation onto PR #${pr}"
+  git fetch --quiet origin "$branch"
+  git checkout --quiet -B "$branch" "origin/${branch}"
+
+  python3 "$updater" --chart-dir "$path" --repo "$REPO"
+
+  if git diff --quiet -- "${path}/Chart.yaml"; then
+    echo "== ${path}: annotation already current"
+    continue
+  fi
+
+  git add "${path}/Chart.yaml"
+  git commit --quiet -m "chore: sync artifacthub.io/changes for ${component:-$path}"
+  git push --quiet origin "$branch"
+  echo "== ${path}: pushed to PR #${pr}"
+done < <(jq -r '.packages | to_entries[] | [.key, (.value.component // "")] | @tsv' "$CONFIG")

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -18,6 +18,11 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # The annotation sync below works on a real tree, not through the API.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: googleapis/release-please-action@v5
         id: release
         with:
@@ -32,3 +37,15 @@ jobs:
           # to upload the chart package. Removed in the publishing cutover, when
           # chart-releaser is retired.
           skip-github-release: true
+
+      # release-please renders release notes only as Markdown, so the
+      # artifacthub.io/changes annotation has to be generated separately and
+      # committed onto the release PR before it is merged. Runs on every
+      # invocation: release-please force-pushes its branch whenever it
+      # regenerates the PR, which would otherwise discard the annotation commit.
+      - name: Sync artifacthub.io/changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TARGET_BRANCH: main
+        run: .github/scripts/sync-artifacthub-changes.sh


### PR DESCRIPTION
## Summary
Updating Release Please process to format messages for Artifact Hub.

## Details
- Adding python script to manage the formatting of changes so that Artifact Hub will properly render the change log.

## Linked issues
https://github.com/Graylog2/graylog-helm/issues/172
