### PR TITLE
ci: accept the empty annotation form release-please leaves behind

### DIFF
--- a/.github/scripts/artifacthub_changes.py
+++ b/.github/scripts/artifacthub_changes.py
@@ -147,16 +147,25 @@ def splice(chart_text: str, body: str) -> str:
     Line-based on purpose: a YAML round-trip would reflow unrelated keys.
     """
     lines = chart_text.splitlines()
-    key = re.compile(r"^(?P<indent>\s*)artifacthub\.io/changes:\s*\|")
+    # release-please round-trips Chart.yaml through a YAML parser when it bumps
+    # `version:`, and that turns an empty block scalar into `""`. Both forms mean
+    # the same empty annotation, so accept either and always write the block
+    # scalar back. Matching only `|` made every release fail here.
+    key = re.compile(
+        r"^(?P<indent>\s*)artifacthub\.io/changes:\s*(?:\||\"\"|''|)\s*$"
+    )
 
     start = next((i for i, l in enumerate(lines) if key.match(l)), None)
     if start is None:
         raise SystemExit(
             "artifacthub.io/changes annotation not found; add the key with an "
-            "empty block scalar (`artifacthub.io/changes: |`) first"
+            "empty value (`artifacthub.io/changes: |`) first"
         )
 
     indent = key.match(lines[start]).group("indent")
+    # Normalise the key line: the body below it is a block scalar regardless of
+    # which empty form we found.
+    lines[start] = f"{indent}artifacthub.io/changes: |"
     end = start + 1
     while end < len(lines) and (
         not lines[end].strip() or lines[end].startswith(indent + " ")


### PR DESCRIPTION
## Summary
When release-please bumps `version:`, it round-trips `Chart.yaml` and rewrites `artifacthub.io/changes: |` as `""`. The annotation generator matched only the block scalar form, so every release would fail to publish, after the tag and release already existed. It now accepts both forms and writes the block scalar back.

What I changed: the first sentence was carrying two ideas joined by "and", so the round-trip is now its own statement. which fails the publish job became a plain clause with the actor named, and the bolted-on on every release moved into that sentence instead of trailing after a comma. I also cut before splicing, which named an internal step no reviewer needs, and fixed a factual slip in my own draft: the failure happens before packaging, not at it.
